### PR TITLE
Add README instructions for running locally without Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,43 @@ script/manage collectstatic --noinput --clear
 ```
 
 
+## Running this locally (without Vagrant)
+
+You’ll need:
+
+* Python 3.x
+* A local Postgres server
+
+As above, make sure you’ve cloned the repo and checked out its submodules.
+
+Open up a Postgres shell (eg: `psql`) and create a user and database matching the details in `conf/config.py`:
+
+```
+CREATE USER bluetail SUPERUSER CREATEDB PASSWORD 'bluetail'
+CREATE DATABASE bluetail
+```
+
+Create a Python virtual environment at a location of your choosing, activate it, and install the required packages:
+
+```
+python3 -m venv ./venv
+. ./venv/bin/activate
+pip3 install --requirement requirements.txt
+```
+
+With the virtual environment still activated, run the Django migrations, to set up the database:
+
+```
+script/migrate
+```
+
+And run the development server:
+
+```
+script/server
+```
+
+
 ## Running this in production
 
 The site requires:

--- a/script/manage
+++ b/script/manage
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-virtualenv_dir="$(dirname "$0")/../../venv"
-virtualenv_activate="$virtualenv_dir/bin/activate"
-. $virtualenv_activate
-
+default_venv_activate="$(dirname "$0")/../../venv/bin/activate"
 managepy="$(dirname "$0")/../manage.py"
+
+# If we aren’t already in a virtualenv, but there’s a suitable one
+# in ../venv (eg: when we’re running in the Vagrant VM), activate it.
+if [ -z "$VIRTUAL_ENV" ] && [ -e "$default_venv_activate" ]
+then
+    . $default_venv_activate
+fi
 
 python3 "$managepy" "$@"


### PR DESCRIPTION
I got the project running natively on my Mac (ie: outside of Vagrant) so I could test out #4, and I figured I should document how I did it.

For convenience, I’ve amended `/script/manage` to skip the virtualenv activation step if a virtualenv is already active. This makes it easier to store your virtualenv somewhere _other_ than `../venv`, but still be able to benefit from the `/script` scripts, as long as you‘ve activated your virtualenv manually yourself before running the scripts.

@ajparsons It would be interesting—but not critical—to know whether you think these instructions would apply for a Windows environment too?