### PR TITLE
Sending data to templates from hard-coded context dictionaries in the views

### DIFF
--- a/bluetail/views.py
+++ b/bluetail/views.py
@@ -16,14 +16,173 @@ def test_view(request):
     }
     return render(request, "test.html", context)
 
+
 def tenders_view(request):
-    context = {}
+    context = {
+        "tenders": [
+            {
+                "id": "PROC-20-0001",
+                "title": "Tachograph Forensic Services",
+                "publisher": "H M Revenue & Customs",
+                "closed_date": "1st April",
+                "is_closed": True,
+                "received": 5,
+            },
+            {
+                "id": "PROC-20-0002",
+                "title": "Dynamic Purchasing System for the Supply of Protective Equipment",
+                "publisher": "Gateshead Council",
+                "closed_date": "1st April",
+                "is_closed": True,
+                "received": 8,
+            },
+            {
+                "id": "PROC-20-0003",
+                "title": "Radio Communication Services for the Birmingham 2022 Commonwealth Games",
+                "publisher": "The Organising Committee for the 2022 Birmingham Commonwealth Games",
+                "closed_date": "13th April",
+                "is_closed": False,
+                "received": 4,
+            },
+            {
+                "id": "PROC-20-0004",
+                "title": "Town Centre Gift Card Scheme",
+                "publisher": "Knowsley Council",
+                "closed_date": "21st April",
+                "is_closed": False,
+                "received": 0,
+            },
+        ],
+    }
     return render(request, "tenders.html", context)
 
+
 def tender_view(request):
-    context = {}
+    context = {
+        "id": "PROC-20-0001",
+        "title": "Tachograph Forensic Services",
+        "publisher": "H M Revenue & Customs",
+        "published_date": "1st January",
+        "closed_date": "1st April",
+        "is_closed": True,
+        "start_date": "1st June",
+        "value": "£120,000",
+        "received": [
+            {
+                "id": "PROC-20-0001/a",
+                "tenderer": {
+                    "name": "Synomus Technology Services Ltd.",
+                },
+                "total_errors": 1,
+                "total_warnings": 1,
+            },
+            {
+                "id": "PROC-20-0001/b",
+                "tenderer": {
+                    "name": "Frost Group Ltd.",
+                },
+                "total_errors": 0,
+                "total_warnings": 0,
+            },
+            {
+                "id": "PROC-20-0001/c",
+                "tenderer": {
+                    "name": "Mitchell Systems Ltd.",
+                },
+                "total_errors": 0,
+                "total_warnings": 2,
+            },
+            {
+                "id": "PROC-20-0001/d",
+                "tenderer": {
+                    "name": "Gough-Hunt Ltd.",
+                },
+                "total_errors": 0,
+                "total_warnings": 3,
+            },
+            {
+                "id": "PROC-20-0001/e",
+                "tenderer": {
+                    "name": "Future Tech Horizons Ltd.",
+                },
+                "total_errors": 0,
+                "total_warnings": 1,
+            }
+        ]
+    }
     return render(request, "tender.html", context)
 
+
 def tenderer_view(request):
-    context = {}
+    context = {
+        "notice": {
+            "id": "PROC-20-0001",
+        },
+        "id": "PROC-20-0001/a",
+        "total_errors": 1,
+        "total_warnings": 1,
+        "tenderer": {
+            "total_errors": 1,
+            "total_warnings": 0,
+            "name": "Synomus Technology Services Ltd.",
+            "company_id": {
+                "value": "1602647563",
+                "error": "Invalid company ID",
+            },
+            "jurisdiction": {
+                "value": "UK",
+            },
+        },
+        "owners": [
+            {
+                "total_errors": 0,
+                "total_warnings": 0,
+                "name": "Jasmine Wilkins",
+                "national_id": {
+                    "value": "FZDS12383607776793",
+                },
+            },
+            {
+                "total_errors": 0,
+                "total_warnings": 1,
+                "name": "Jasmine Wilkins",
+                "national_id": {
+                    "value": "YDAZ21513405928609",
+                    "warning": "Name and ID match a currently serving cabinet minister.",
+                },
+            },
+            {
+                "total_errors": 0,
+                "total_warnings": 0,
+                "name": "Mr. Joe Jones",
+                "national_id": {
+                    "value": "PFQY03765447964910",
+                },
+            },
+        ],
+        "parents": [
+            {
+                "total_errors": 0,
+                "total_warnings": 0,
+                "name": "Synomus International Ltd.",
+                "company_id": {
+                    "value": "6235874596",
+                },
+                "jurisdiction": {
+                    "value": "UK",
+                },
+            },
+            {
+                "total_errors": 0,
+                "total_warnings": 0,
+                "name": "S C M Holdings LLC.",
+                "company_id": {
+                    "value": "6321254583",
+                },
+                "jurisdiction": {
+                    "value": "UK",
+                },
+            },
+        ],
+    }
     return render(request, "tenderer.html", context)

--- a/templates/partials/application-summary-row.html
+++ b/templates/partials/application-summary-row.html
@@ -1,5 +1,5 @@
 <div class="application-summary">
-    <a href="{% url 'example-tenderer' %}">PROC-20-0001/{{ id }}</a>
+    <a href="{% url 'example-tenderer' %}">{{ id }}</a>
     <div class="ml-3">
         {{ name }}
     </div>

--- a/templates/partials/company.html
+++ b/templates/partials/company.html
@@ -1,34 +1,41 @@
 <div class="card bods-scorecard">
     <h5 class="card-header d-flex align-items-center">
-        <span class="mr-auto">{{ name }}</span>
-      {% if errors %}
+        <span class="mr-auto">{{ company.name }}</span>
+      {% if company.total_errors %}
         <span class="ml-2 badge badge-pill badge-danger d-flex">
             {% include "icons/prohibited.html" with classes="icon mr-1" %}
-            {{ errors }}
+            {{ company.total_errors }}
         </span>
       {% endif %}
-      {% if warnings %}
+      {% if company.total_warnings %}
         <span class="ml-2 badge badge-pill badge-warning d-flex">
             {% include "icons/exclamation.html" with classes="icon mr-1" %}
-            {{ warnings }}
+            {{ company.total_warnings }}
         </span>
       {% endif %}
     </h5>
     <ul class="list-group list-group-flush">
         <li class="list-group-item">
             <small class="scorecard-key">Company name</small>
-            <span class="scorecard-value">{{ name }}</span>
+            <span class="scorecard-value">{{ company.name }}</span>
         </li>
-        <li class="list-group-item {% if errors %}list-group-item-danger{% endif %}">
+        <li class="list-group-item {% if company.company_id.error %}list-group-item-danger{% elif company.company_id.warning %}list-group-item-warning{% endif %}">
             <small class="scorecard-key">Company ID</small>
-            <span class="scorecard-value">{{ id }}</span>
-          {% if errors %}
-            <p class="scorecard-warning">Invalid company ID.</p>
+            <span class="scorecard-value">{{ company.company_id.value }}</span>
+          {% if company.company_id.error %}
+            <p class="scorecard-warning">{{ company.company_id.error }}</p>
+          {% elif company.company_id.warning %}
+            <p class="scorecard-warning">{{ company.company_id.warning }}</p>
           {% endif %}
         </li>
-        <li class="list-group-item">
+        <li class="list-group-item {% if company.jurisdiction.error %}list-group-item-danger{% elif company.jurisdiction.warning %}list-group-item-warning{% endif %}">
             <small class="scorecard-key">Country of registration</small>
-            <span class="scorecard-value">{{ jurisdiction }}</span>
+            <span class="scorecard-value">{{ company.jurisdiction.value }}</span>
+          {% if company.jurisdiction.error %}
+            <p class="scorecard-warning">{{ company.jurisdiction.error }}</p>
+          {% elif company.jurisdiction.warning %}
+            <p class="scorecard-warning">{{ company.jurisdiction.warning }}</p>
+          {% endif %}
         </li>
     </ul>
 </div>

--- a/templates/partials/person.html
+++ b/templates/partials/person.html
@@ -1,29 +1,32 @@
 <div class="card bods-scorecard">
     <h5 class="card-header d-flex align-items-center">
-        <span class="mr-auto">{{ name }}</span>
-      {% if errors %}
+        <span class="mr-auto">{{ person.name }}</span>
+      {% if person.total_errors %}
         <span class="ml-2 badge badge-pill badge-danger d-flex">
             {% include "icons/prohibited.html" with classes="icon mr-1" %}
-            {{ errors }}
+            {{ person.total_errors }}
         </span>
       {% endif %}
-      {% if warnings %}
+      {% if person.total_warnings %}
         <span class="ml-2 badge badge-pill badge-warning d-flex">
             {% include "icons/exclamation.html" with classes="icon mr-1" %}
-            {{ warnings }}
+            {{ person.total_warnings }}
         </span>
       {% endif %}
     </h5>
     <ul class="list-group list-group-flush">
         <li class="list-group-item">
             <small class="scorecard-key">Full name</small>
-            <span class="scorecard-value">{{ name }}</span>
+            <span class="scorecard-value">{{ person.name }}</span>
         </li>
-        <li class="list-group-item {% if warnings %}list-group-item-warning{% endif %}">
+        <li class="list-group-item {% if person.national_id.error %}list-group-item-danger{% elif person.national_id.warning %}list-group-item-warning{% endif %}">
             <small class="scorecard-key">National ID</small>
-            <span class="scorecard-value">{{ id }}</span>
-          {% if warnings %}
-            <p class="scorecard-warning">Name and ID match a currently serving cabinet minister.</p>
+            <span class="scorecard-value">{{ person.national_id.value }}</span>
+          {% if person.national_id.erorr %}
+            <p class="scorecard-warning">{{ person.national_id.error }}</p>
+          {% endif %}
+          {% if person.national_id.warning %}
+            <p class="scorecard-warning">{{ person.national_id.warning }}</p>
           {% endif %}
         </li>
     </ul>

--- a/templates/partials/tender-card.html
+++ b/templates/partials/tender-card.html
@@ -1,10 +1,10 @@
 <div class="card mt-4" style="max-width: 40em">
     <div class="card-body">
-        <h2 class="h3 card-title"><a {% if view %}href="{% url view %}"{% else %}href="#" class="fake-link"{% endif %}>{{ title }}</a></h5>
-        <p class="card-text">{{ publisher }}</p>
+        <h2 class="h3 card-title"><a {% if view %}href="{% url view %}"{% else %}href="#" class="fake-link"{% endif %}>{{ tender.title }}</a></h5>
+        <p class="card-text">{{ tender.publisher }}</p>
     </div>
     <div class="card-footer text-muted d-flex">
-        <div class="mr-auto">{{ end }}</div>
-        <div>{{ received }}</div>
+        <div class="mr-auto">{% if tender.is_closed %}Closed{% else %}Closes{% endif %} {{ tender.closed_date }}</div>
+        <div>{{ tender.received }} tender{{ tender.received|pluralize }} received</div>
     </div>
 </div>

--- a/templates/tender.html
+++ b/templates/tender.html
@@ -8,32 +8,32 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-4">
             <li class="breadcrumb-item"><a href="{% url 'example-tenders' %}">Tenders in progress</a></li>
-            <li class="breadcrumb-item active" aria-current="page">PROC-20-0001</li>
+            <li class="breadcrumb-item active" aria-current="page">{{ id }}</li>
         </ol>
     </nav>
 
-    <h1 class="mt-4">Tachograph Forensic Services</h1>
-    <p>Procurement notice <code>PROC-20-0001</code></p>
+    <h1 class="mt-4">{{ title }}</h1>
+    <p>Procurement notice <code>{{ id }}</code></p>
 
-    <dl class="row mt-4" style="max-width: 24em">
-        <dt class="col-sm-6">Published date</dt>
-        <dd class="col-sm-6">1st January 2020</dd>
-        <dt class="col-sm-6">Closing date</dt>
-        <dd class="col-sm-6">1st April 2020</dd>
-        <dt class="col-sm-6">Contract start date</dt>
-        <dd class="col-sm-6">1st June 2020</dd>
-        <dt class="col-sm-6">Value of contract</dt>
-        <dd class="col-sm-6">£120,000</dd>
+    <dl class="row mt-4" style="max-width: 32em">
+        <dt class="col-sm-5">Published by</dt>
+        <dd class="col-sm-7">{{ publisher }}</dd>
+        <dt class="col-sm-5">Published date</dt>
+        <dd class="col-sm-7">{{ published_date }}</dd>
+        <dt class="col-sm-5">Closing date</dt>
+        <dd class="col-sm-7">{{ closed_date }}</dd>
+        <dt class="col-sm-5">Contract start date</dt>
+        <dd class="col-sm-7">{{ start_date }}</dd>
+        <dt class="col-sm-5">Value of contract</dt>
+        <dd class="col-sm-7">{{ value }}</dd>
     </dl>
 
     <h2 class="mt-5">Tenders received</h2>
 
     <div class="application-summaries">
-        {% include "partials/application-summary-row.html" with id="a" name="Synomus Technology Services Ltd." errors=1 warnings=1 %}
-        {% include "partials/application-summary-row.html" with id="b" name="Frost Group Ltd." errors=0 warnings=0 %}
-        {% include "partials/application-summary-row.html" with id="c" name="Mitchell Systems Ltd." errors=0 warnings=2 %}
-        {% include "partials/application-summary-row.html" with id="d" name="Gough-Hunt Ltd." errors=0 warnings=3 %}
-        {% include "partials/application-summary-row.html" with id="e" name="Future Tech Horizons Ltd." errors=0 warnings=1 %}
+      {% for r in received %}
+        {% include "partials/application-summary-row.html" with id=r.id name=r.tenderer.name errors=r.total_errors warnings=r.total_warnings %}
+      {% endfor %}
     </div>
 
 </div>

--- a/templates/tenderer.html
+++ b/templates/tenderer.html
@@ -8,37 +8,44 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-4">
             <li class="breadcrumb-item"><a href="{% url 'example-tenders' %}">Tenders in progress</a></li>
-            <li class="breadcrumb-item"><a href="{% url 'example-tender' %}">PROC-20-0001</a></li>
-            <li class="breadcrumb-item active" aria-current="page">PROC-20-0001/a</li>
+            <li class="breadcrumb-item"><a href="{% url 'example-tender' %}">{{ notice.id }}</a></li>
+            <li class="breadcrumb-item active" aria-current="page">{{ id }}</li>
         </ol>
     </nav>
 
     <div class="d-md-flex align-items-center mt-4">
-        <h1 class="mr-auto mb-2">Synomus Technology Services Ltd.</h1>
+        <h1 class="mr-auto mb-2">{{ tenderer.name }}</h1>
+      {% if total_errors or total_warnings %}
         <p class="mb-2 text-md-right" style="font-size: 1.5rem">
-            {% include "partials/application-errors-badge.html" with n=1 classes="mr-3" %}
-            {% include "partials/application-warnings-badge.html" with n=1 classes="mr-3" %}
+            {% include "partials/application-errors-badge.html" with n=total_errors classes="mr-3" %}
+            {% include "partials/application-warnings-badge.html" with n=total_warnings classes="mr-3" %}
         </p>
+      {% endif %}
     </div>
-    <p>Tender application <code>PROC-20-0001/a</code></p>
+    <p>Tender application <code>{{ id }}</code></p>
 
     <h2>Applicant</h2>
     <div class="scorecards">
-        {% include "partials/company.html" with name="Synomus Technology Services Ltd." id="1602647563" jurisdiction="UK" errors=1 %}
+        {% include "partials/company.html" with company=tenderer %}
     </div>
 
+  {% if owners %}
     <h2>Beneficial owners</h2>
     <div class="scorecards">
-        {% include "partials/person.html" with name="Jasmine Wilkins" id="FZDS12383607776793" %}
-        {% include "partials/person.html" with name="Mr. Simon Clark" id="YDAZ21513405928609" warnings=1 %}
-        {% include "partials/person.html" with name="Mr. Joe Jones" id="PFQY03765447964910" %}
+      {% for owner in owners %}
+        {% include "partials/person.html" with person=owner %}
+      {% endfor %}
     </div>
+  {% endif %}
 
+  {% if parents %}
     <h2>Parent companies</h2>
     <div class="scorecards">
-        {% include "partials/company.html" with name="Synomus International Ltd." id="6235874596" jurisdiction="UK" %}
-        {% include "partials/company.html" with name="S C M Holdings LLC." id="6321254583" jurisdiction="USA" %}
+      {% for parent in parents %}
+        {% include "partials/company.html" with company=parent %}
+      {% endfor %}
     </div>
+  {% endif %}
 
 </div>
 

--- a/templates/tenders.html
+++ b/templates/tenders.html
@@ -13,13 +13,9 @@
 
     <h1 class="mt-4">Tenders in progress</h1>
 
-    {% include "partials/tender-card.html" with view="example-tender" title="Tachograph Forensic Services" publisher="H M Revenue &amp; Customs" end="Closed 1st April" received="5 tenders received" %}
-
-    {% include "partials/tender-card.html" with view="example-tender" title="Dynamic Purchasing System for the Supply of Protective Equipment" publisher="Gateshead Council" end="Closed 1st April" received="8 tenders received" %}
-
-    {% include "partials/tender-card.html" with view="example-tender" title="Radio Communication Services for the Birmingham 2022 Commonwealth Games" publisher="The Organising Committee for the 2022 Birmingham Commonwealth Games" end="Closes 13th April" received="4 tenders received" %}
-
-    {% include "partials/tender-card.html" with view="example-tender" title="Town Centre Gift Card Scheme" publisher="Knowsley Council" end="Closes 21st April" received="0 tenders received" %}
+    {% for t in tenders %}
+        {% include "partials/tender-card.html" with view="example-tender" tender=t %}
+    {% endfor %}
 
 </div>
 {% endblock %}


### PR DESCRIPTION
@SimKennedy @ErinClark Here’s a first stab at what we talked about in standup this morning.

Once @SimKennedy has set up the model interface, it _should_ be fairly easy to update the `context = {…}` lines here to construct the context out of data from the models, instead of hard-coded values.

Can merge this commit as it is, now, or wait until the models work is done, and merge _that_ work into this. Up to you @SimKennedy.