### PR TITLE
Improve setup scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,8 @@ Vagrant.configure(2) do |config|
     # Install some of the other things we need that are just for dev
     sudo apt-get install -qq -y ruby-dev libsqlite3-dev build-essential
 
+    # TODO: We should use script/setup here!
+
     # Create a postgresql user
     sudo -u postgres psql -c "CREATE USER bluetail SUPERUSER CREATEDB PASSWORD 'bluetail'"
     # Create a database

--- a/script/console
+++ b/script/console
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"$(dirname "$0")/manage" shell
+"$(dirname "$0")/manage" shell "$@"

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# Move to top level of project.
+cd `dirname $0`/..
+
+find . -name '*.pyc' -delete
+
+# Recreate database.
+sudo -u postgres psql -c "DROP DATABASE IF EXISTS bluetail"
+sudo -u postgres psql -c "CREATE DATABASE bluetail"
+
+# Create database user if not exists.
+sudo -u postgres psql -c "SELECT 'exists' FROM pg_roles WHERE rolname='bluetail'" | grep -q 'exists' || sudo -u postgres psql -c "CREATE USER bluetail SUPERUSER CREATEDB PASSWORD 'bluetail'"
+
+# Set up database.
+script/migrate
+
+# Insert example data.
+script/insert_example_data
+
+# Create superuser.
+script/console -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'admin')"


### PR DESCRIPTION
As @SimKennedy and I discussed earlier, the provisioning / setup process for the project is getting a bit complicated, and now would be a good opportunity to simplify it.

I’ve made a start with a `script/setup` script, that _should_ work whether run inside or outside a Vagrant VM.

A few other things we’ve discussed:

* Do Vagrant VM setup in a `script/bootstrap` script?
* Vagrant currently has setup in three places – `Vagrantfile`, `provision.sh`, and `post_deploy_actions.sh` – can we drop two or all of these?
* Should we take this opportunity to replace the built-in Python `venv` with [`pipenv`](https://pipenv.pypa.io/en/latest/), which would help us manage package versions better?