### PR TITLE
Remove duplicate Pillow requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==2.2.13
 Markdown==2.6.8
-Pillow==6.2.0
 Pillow==7.1.2
 pyyaml==4.2b1
 argparse==1.2.1


### PR DESCRIPTION
Having this specified twice causes the following error when installing dependencies:

    ERROR: Double requirement given: Pillow==7.1.2 (from -r requirements.txt (line 4)) (already in Pillow==6.2.0 (from -r requirements.txt (line 3)), name='Pillow')