### PR TITLE
Prevent flag_name from being changed in the admin

### DIFF
--- a/bluetail/admin.py
+++ b/bluetail/admin.py
@@ -2,6 +2,17 @@ from django.contrib import admin
 
 from bluetail.models import Flag, OCDSReleaseJSON, FlagAttachment
 
-admin.site.register(Flag)
+
+class FlagAdmin(admin.ModelAdmin):
+    fields = ('flag_name', 'flag_field', 'flag_text', 'flag_type')
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return ['flag_name']
+        else:
+            return []
+
+
+admin.site.register(Flag, FlagAdmin)
 admin.site.register(FlagAttachment)
 admin.site.register(OCDSReleaseJSON)


### PR DESCRIPTION
The `flag_name` identifier, e.g. `person_id_matches_cabinet_minister`, will likely end up appearing in code. We don't want an
accidental change in the admin to break things in the code.

This change makes the `flag_name` field read-only in the Django admin when updating existing flags. So flag names will need to be changed using Django's shell or in the database directly.

I had to use the dynamic `get_readonly_fields`, rather than the `readonly_fields` attribute because we only want to make the flag name read-only for updates, so the user can still choose a name when creating new flags.