### PR TITLE
Include bods data management commands

### DIFF
--- a/.env-template.env
+++ b/.env-template.env
@@ -1,3 +1,6 @@
 DJANGO_SETTINGS_MODULE="proj.settings"
 DATABASE_URL="postgres://bluetail:bluetail@localhost:5432/bluetail"
 SECRET_KEY="changeme"
+
+ELASTICSEARCH_URL="https://43612fa0056b48b38a9e5e9be9202387.europe-west1.gcp.cloud.es.io:9243"
+ELASTICSEARCH_BODS_INDEX="bods-open_ownership_register"

--- a/Pipfile
+++ b/Pipfile
@@ -36,6 +36,7 @@ ocdskit = "*"
 pandas = "*"
 elasticsearch = "<8"
 elasticsearch_dsl = "*"
+smart_open = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ futures = "==3.0.5"
 libsass = "==0.12.3"
 olefile = "==0.44"
 psycopg2 = "==2.8.5"
-six = "==1.10.0"
+six = "*"
 feedparser = "==5.2.1"
 django-import-export = "==2.0.2"
 # Heroku
@@ -30,13 +30,14 @@ dj-database-url = "==0.5.0"
 # Bluetail
 django-pgviews-redux = "==0.6.0"
 
-[dev-packages]
-# Used for scripts to gather and process Contracts Finder data
+# Used for scripts to gather and process Contracts Finder and BODS data
 ocdskit = "*"
 pandas = "*"
 elasticsearch = "<8"
 elasticsearch_dsl = "*"
 smart_open = "*"
+
+[dev-packages]
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aaba46201fa6bec7c7221d7b76f8cd751a2a1a91c8da73b8e2213fae63278feb"
+            "sha256": "f0816f6ac4a1f9cf240c9b7fd74ad3abae5c90e990a153fa6024727dd9316655"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6"
         },
         "sources": [
             {
@@ -31,13 +31,6 @@
             ],
             "version": "==4.9.1"
         },
-        "certifi": {
-            "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
-            ],
-            "version": "==2020.6.20"
-        },
         "csscompressor": {
             "hashes": [
                 "sha256:0e12f125b88379d7b680636d94a3c8fa14bed1de2358f7f9a9e6749e222cff3b"
@@ -50,6 +43,7 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "diff-match-patch": {
@@ -126,22 +120,6 @@
             "git": "https://github.com/mysociety/django-pipeline-csscompressor",
             "ref": "6a88fde5045d68746f1c7ee816deda86615c5581"
         },
-        "elasticsearch": {
-            "hashes": [
-                "sha256:6fb566dd23b91b5871ce12212888674b4cf33374e92b71b1080916c931e44dcb",
-                "sha256:e637d8cf4e27e279b5ff8ca8edc0c086f4b5df4bf2b48e2f950b7833aca3a792"
-            ],
-            "index": "pypi",
-            "version": "==7.8.0"
-        },
-        "elasticsearch-dsl": {
-            "hashes": [
-                "sha256:1e345535164cb684de4b825e1d0daf81b75554b30d3905446584a9e4af0cc3e7",
-                "sha256:593c01822a03e3e84b87753c78edb833f4b2bfafcd52089841bd8f99b7e74ccd"
-            ],
-            "index": "pypi",
-            "version": "==7.2.1"
-        },
         "et-xmlfile": {
             "hashes": [
                 "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
@@ -170,6 +148,7 @@
                 "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
                 "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1"
         },
         "jdcal": {
@@ -216,40 +195,10 @@
             ],
             "version": "==1.14"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:13af0184177469192d80db9bd02619f6fa8b922f9f327e077d6f2a6acb1ce1c0",
-                "sha256:26a45798ca2a4e168d00de75d4a524abf5907949231512f372b217ede3429e98",
-                "sha256:26f509450db547e4dfa3ec739419b31edad646d21fb8d0ed0734188b35ff6b27",
-                "sha256:30a59fb41bb6b8c465ab50d60a1b298d1cd7b85274e71f38af5a75d6c475d2d2",
-                "sha256:33c623ef9ca5e19e05991f127c1be5aeb1ab5cdf30cb1c5cf3960752e58b599b",
-                "sha256:356f96c9fbec59974a592452ab6a036cd6f180822a60b529a975c9467fcd5f23",
-                "sha256:3c40c827d36c6d1c3cf413694d7dc843d50997ebffbc7c87d888a203ed6403a7",
-                "sha256:4d054f013a1983551254e2379385e359884e5af105e3efe00418977d02f634a7",
-                "sha256:63d971bb211ad3ca37b2adecdd5365f40f3b741a455beecba70fd0dde8b2a4cb",
-                "sha256:658624a11f6e1c252b2cd170d94bf28c8f9410acab9f2fd4369e11e1cd4e1aaf",
-                "sha256:76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598",
-                "sha256:7b57f26e5e6ee2f14f960db46bd58ffdca25ca06dd997729b1b179fddd35f5a3",
-                "sha256:7b852817800eb02e109ae4a9cef2beda8dd50d98b76b6cfb7b5c0099d27b52d4",
-                "sha256:8cde829f14bd38f6da7b2954be0f2837043e8b8d7a9110ec5e318ae6bf706610",
-                "sha256:a2e3a39f43f0ce95204beb8fe0831199542ccab1e0c6e486a0b4947256215632",
-                "sha256:a86c962e211f37edd61d6e11bb4df7eddc4a519a38a856e20a6498c319efa6b0",
-                "sha256:a8705c5073fe3fcc297fb8e0b31aa794e05af6a329e81b7ca4ffecab7f2b95ef",
-                "sha256:b6aaeadf1e4866ca0fdf7bb4eed25e521ae21a7947c59f78154b24fc7abbe1dd",
-                "sha256:be62aeff8f2f054eff7725f502f6228298891fd648dc2630e03e44bf63e8cee0",
-                "sha256:c2edbb783c841e36ca0fa159f0ae97a88ce8137fb3a6cd82eae77349ba4b607b",
-                "sha256:cbe326f6d364375a8e5a8ccb7e9cd73f4b2f6dc3b2ed205633a0db8243e2a96a",
-                "sha256:d34fbb98ad0d6b563b95de852a284074514331e6b9da0a9fc894fb1cdae7a79e",
-                "sha256:d97a86937cf9970453c3b62abb55a6475f173347b4cde7f8dcdb48c8e1b9952d",
-                "sha256:dd53d7c4a69e766e4900f29db5872f5824a06827d594427cf1a4aa542818b796",
-                "sha256:df1889701e2dfd8ba4dc9b1a010f0a60950077fb5242bb92c8b5c7f1a6f2668a",
-                "sha256:fa1fe75b4a9e18b66ae7f0b122543c42debcf800aaafa0212aaff3ad273c2596"
-            ],
-            "version": "==1.19.0"
-        },
         "odfpy": {
             "hashes": [
-                "sha256:db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec"
+                "sha256:db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec",
+                "sha256:fc3b8d1bc098eba4a0fda865a76d9d1e577c4ceec771426bcb169a82c5e9dfe0"
             ],
             "version": "==1.4.1"
         },
@@ -262,59 +211,41 @@
         },
         "openpyxl": {
             "hashes": [
-                "sha256:547a9fc6aafcf44abe358b89ed4438d077e9d92e4f182c87e2dc294186dc4b64"
+                "sha256:6e62f058d19b09b95d20ebfbfb04857ad08d0833190516c1660675f699c6186f"
             ],
-            "version": "==3.0.3"
-        },
-        "pandas": {
-            "hashes": [
-                "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096",
-                "sha256:13f75fb18486759da3ff40f5345d9dd20e7d78f2a39c5884d013456cec9876f0",
-                "sha256:35b670b0abcfed7cad76f2834041dcf7ae47fd9b22b63622d67cdc933d79f453",
-                "sha256:4c73f373b0800eb3062ffd13d4a7a2a6d522792fa6eb204d67a4fad0a40f03dc",
-                "sha256:5759edf0b686b6f25a5d4a447ea588983a33afc8a0081a0954184a4a87fd0dd7",
-                "sha256:5a7cf6044467c1356b2b49ef69e50bf4d231e773c3ca0558807cdba56b76820b",
-                "sha256:69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8",
-                "sha256:8778a5cc5a8437a561e3276b85367412e10ae9fff07db1eed986e427d9a674f8",
-                "sha256:9871ef5ee17f388f1cb35f76dc6106d40cb8165c562d573470672f4cdefa59ef",
-                "sha256:9c31d52f1a7dd2bb4681d9f62646c7aa554f19e8e9addc17e8b1b20011d7522d",
-                "sha256:ab8173a8efe5418bbe50e43f321994ac6673afc5c7c4839014cf6401bbdd0705",
-                "sha256:ae961f1f0e270f1e4e2273f6a539b2ea33248e0e3a11ffb479d757918a5e03a9",
-                "sha256:b3c4f93fcb6e97d993bf87cdd917883b7dab7d20c627699f360a8fb49e9e0b91",
-                "sha256:c9410ce8a3dee77653bc0684cfa1535a7f9c291663bd7ad79e39f5ab58f67ab3",
-                "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107",
-                "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"
-            ],
-            "index": "pypi",
-            "version": "==1.0.5"
+            "version": "==3.0.4"
         },
         "pillow": {
             "hashes": [
-                "sha256:04766c4930c174b46fd72d450674612ab44cca977ebbcc2dde722c6933290107",
-                "sha256:0e2a3bceb0fd4e0cb17192ae506d5f082b309ffe5fc370a5667959c9b2f85fa3",
-                "sha256:0f01e63c34f0e1e2580cc0b24e86a5ccbbfa8830909a52ee17624c4193224cd9",
-                "sha256:12e4bad6bddd8546a2f9771485c7e3d2b546b458ae8ff79621214119ac244523",
-                "sha256:1f694e28c169655c50bb89a3fa07f3b854d71eb47f50783621de813979ba87f3",
-                "sha256:3d25dd8d688f7318dca6d8cd4f962a360ee40346c15893ae3b95c061cdbc4079",
-                "sha256:4b02b9c27fad2054932e89f39703646d0c543f21d3cc5b8e05434215121c28cd",
-                "sha256:9744350687459234867cbebfe9df8f35ef9e1538f3e729adbd8fde0761adb705",
-                "sha256:a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd",
-                "sha256:ae2b270f9a0b8822b98655cb3a59cdb1bd54a34807c6c56b76dd2e786c3b7db3",
-                "sha256:b37bb3bd35edf53125b0ff257822afa6962649995cbdfde2791ddb62b239f891",
-                "sha256:b532bcc2f008e96fd9241177ec580829dee817b090532f43e54074ecffdcd97f",
-                "sha256:b67a6c47ed963c709ed24566daa3f95a18f07d3831334da570c71da53d97d088",
-                "sha256:b943e71c2065ade6fef223358e56c167fc6ce31c50bc7a02dd5c17ee4338e8ac",
-                "sha256:ccc9ad2460eb5bee5642eaf75a0438d7f8887d484490d5117b98edd7f33118b7",
-                "sha256:d23e2aa9b969cf9c26edfb4b56307792b8b374202810bd949effd1c6e11ebd6d",
-                "sha256:eaa83729eab9c60884f362ada982d3a06beaa6cc8b084cf9f76cae7739481dfa",
-                "sha256:ee94fce8d003ac9fd206496f2707efe9eadcb278d94c271f129ab36aa7181344",
-                "sha256:f455efb7a98557412dc6f8e463c1faf1f1911ec2432059fa3e582b6000fc90e2",
-                "sha256:f46e0e024346e1474083c729d50de909974237c72daca05393ee32389dabe457",
-                "sha256:f54be399340aa602066adb63a86a6a5d4f395adfdd9da2b9a0162ea808c7b276",
-                "sha256:f784aad988f12c80aacfa5b381ec21fd3f38f851720f652b9f33facc5101cf4d"
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.2.0"
         },
         "psycopg2": {
             "hashes": [
@@ -334,13 +265,6 @@
             ],
             "index": "pypi",
             "version": "==2.8.5"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
-            ],
-            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
@@ -369,6 +293,7 @@
                 "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55",
                 "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.1"
         },
         "sqlparse": {
@@ -376,6 +301,7 @@
                 "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
                 "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.3.1"
         },
         "tablib": {
@@ -390,14 +316,8 @@
                 "sha256:8cc2fa10bc37219ac5e76850eb7fbd50de313c7a1a7895c44af2a8dd206b7be7",
                 "sha256:c5a77c96ad306d5b380def1309d521ad5e98b4f83726f84857ad87e142d13279"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.0"
-        },
-        "urllib3": {
-            "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
-            ],
-            "version": "==1.25.9"
         },
         "waitress": {
             "hashes": [
@@ -437,5 +357,345 @@
             "version": "==1.3.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==19.3.0"
+        },
+        "boto": {
+            "hashes": [
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
+            ],
+            "version": "==2.49.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:77d926c16ab2ab2bfe68811f3bc987e7d79c97f3e2adebf9265c587cdb1fc47b",
+                "sha256:7f558165eaa608a5d0e05227ee820f4b3cc74533a52c9dde7eb488eba091d50d"
+            ],
+            "version": "==1.14.13"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:37b65cc48c99b7dd4d5606e56f76ecd88eb7be392ea8a166df734a6b3035301c",
+                "sha256:5ac9b53a75852fe4282be8741c8136e6948714fef6eff1bd9babb861f8647ba3"
+            ],
+            "version": "==1.17.13"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.15.2"
+        },
+        "elasticsearch": {
+            "hashes": [
+                "sha256:6fb566dd23b91b5871ce12212888674b4cf33374e92b71b1080916c931e44dcb",
+                "sha256:e637d8cf4e27e279b5ff8ca8edc0c086f4b5df4bf2b48e2f950b7833aca3a792"
+            ],
+            "index": "pypi",
+            "version": "==7.8.0"
+        },
+        "elasticsearch-dsl": {
+            "hashes": [
+                "sha256:1e345535164cb684de4b825e1d0daf81b75554b30d3905446584a9e4af0cc3e7",
+                "sha256:593c01822a03e3e84b87753c78edb833f4b2bfafcd52089841bd8f99b7e74ccd"
+            ],
+            "index": "pypi",
+            "version": "==7.2.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "ijson": {
+            "hashes": [
+                "sha256:07cd88c9224392726128673fea7a90276746d3bf56d11635e3457769eda6295a",
+                "sha256:0ae656f3ca3bd833dc548583f13ba205eaee7c15d27496091549de4523931e00",
+                "sha256:13c088aa3d79585aa7c137c0367d5f6c34596a907bff0af3bcfbd18db49edfdb",
+                "sha256:1c7ee9405c6392e44f777ca76e917e729bc86cbb6c608981860b360879e6b991",
+                "sha256:3bff72a69fd54c36b0b74e532e7e0f737e221b84528369aaf53bbd380c935d29",
+                "sha256:4f19911b7b844d0e78f9903387b9984d44e598405d6e5a8a93a269cedf34e01d",
+                "sha256:5a1788225e5074ffb47d5884049ad55ce3ddc7e069ea07f1608a819235894e45",
+                "sha256:663e607af2643c86493fce07c495235c3431d62dae78feaa449feeec6dd10301",
+                "sha256:67188e55800dfd89a9fcd2565d36f148bc51a3b4081da3c82ee1a5a87206bd3b",
+                "sha256:8353709024d85eeb97428c53c74c3ac7473b5959a9f1cbde7fcc41341d1c93f9",
+                "sha256:88a65bbf2d35c882ac6ca50c476f0a914cd47f48292c099b393dd56070c842aa",
+                "sha256:a1d55a1df5654f79d15a890b4bfe35cbd2f9fed71ac8e8034575ec875771fb4d",
+                "sha256:a6109893bf2e51cd4027a1983a46f3300c3c12172151b01e71d340274a9344ed",
+                "sha256:b303e2ff8d1ea326ed426fd5614d89850341cef54fe3010087b9fe8dc2926620",
+                "sha256:b85216d962e083262eb8bd3ea5fc0c285ca3a0ef7d8ea198f60b954ca05fe0e5",
+                "sha256:b8552dce8ca65f29ffe4fac9bb770f8556a7cfa5d4f840611bbc878fe3f54e05",
+                "sha256:deb698069fb38c9300df5fe9eeb4d6abd9011abdb470ca914fdce165b4e99e38",
+                "sha256:e19b7a2d3ff9122aa235b63e61788b7a800ad81f2f2bd91fef0d31a65cb9ceb1",
+                "sha256:e25c4b59eb05ac1d96b4df47205d3f7d18d148e6d375e452a4f37c2db5216aff",
+                "sha256:e96efc3411384070ad3e95645a5e9b5af7c67c348eefa96f71a1e71f0f08119b"
+            ],
+            "version": "==3.1.post0"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.7.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.0"
+        },
+        "json-merge-patch": {
+            "hashes": [
+                "sha256:09898b6d427c08754e2a97c709cf2dfd7e28bd10c5683a538914975eab778d39"
+            ],
+            "version": "==0.2"
+        },
+        "jsonpointer": {
+            "hashes": [
+                "sha256:c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362",
+                "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.0"
+        },
+        "jsonref": {
+            "hashes": [
+                "sha256:b1e82fa0b62e2c2796a13e5401fe51790b248f6d9bf9d7212a3e31a3501b291f",
+                "sha256:f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
+            ],
+            "version": "==0.2"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "version": "==3.2.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:13af0184177469192d80db9bd02619f6fa8b922f9f327e077d6f2a6acb1ce1c0",
+                "sha256:26a45798ca2a4e168d00de75d4a524abf5907949231512f372b217ede3429e98",
+                "sha256:26f509450db547e4dfa3ec739419b31edad646d21fb8d0ed0734188b35ff6b27",
+                "sha256:30a59fb41bb6b8c465ab50d60a1b298d1cd7b85274e71f38af5a75d6c475d2d2",
+                "sha256:33c623ef9ca5e19e05991f127c1be5aeb1ab5cdf30cb1c5cf3960752e58b599b",
+                "sha256:356f96c9fbec59974a592452ab6a036cd6f180822a60b529a975c9467fcd5f23",
+                "sha256:3c40c827d36c6d1c3cf413694d7dc843d50997ebffbc7c87d888a203ed6403a7",
+                "sha256:4d054f013a1983551254e2379385e359884e5af105e3efe00418977d02f634a7",
+                "sha256:63d971bb211ad3ca37b2adecdd5365f40f3b741a455beecba70fd0dde8b2a4cb",
+                "sha256:658624a11f6e1c252b2cd170d94bf28c8f9410acab9f2fd4369e11e1cd4e1aaf",
+                "sha256:76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598",
+                "sha256:7b57f26e5e6ee2f14f960db46bd58ffdca25ca06dd997729b1b179fddd35f5a3",
+                "sha256:7b852817800eb02e109ae4a9cef2beda8dd50d98b76b6cfb7b5c0099d27b52d4",
+                "sha256:8cde829f14bd38f6da7b2954be0f2837043e8b8d7a9110ec5e318ae6bf706610",
+                "sha256:a2e3a39f43f0ce95204beb8fe0831199542ccab1e0c6e486a0b4947256215632",
+                "sha256:a86c962e211f37edd61d6e11bb4df7eddc4a519a38a856e20a6498c319efa6b0",
+                "sha256:a8705c5073fe3fcc297fb8e0b31aa794e05af6a329e81b7ca4ffecab7f2b95ef",
+                "sha256:b6aaeadf1e4866ca0fdf7bb4eed25e521ae21a7947c59f78154b24fc7abbe1dd",
+                "sha256:be62aeff8f2f054eff7725f502f6228298891fd648dc2630e03e44bf63e8cee0",
+                "sha256:c2edbb783c841e36ca0fa159f0ae97a88ce8137fb3a6cd82eae77349ba4b607b",
+                "sha256:cbe326f6d364375a8e5a8ccb7e9cd73f4b2f6dc3b2ed205633a0db8243e2a96a",
+                "sha256:d34fbb98ad0d6b563b95de852a284074514331e6b9da0a9fc894fb1cdae7a79e",
+                "sha256:d97a86937cf9970453c3b62abb55a6475f173347b4cde7f8dcdb48c8e1b9952d",
+                "sha256:dd53d7c4a69e766e4900f29db5872f5824a06827d594427cf1a4aa542818b796",
+                "sha256:df1889701e2dfd8ba4dc9b1a010f0a60950077fb5242bb92c8b5c7f1a6f2668a",
+                "sha256:fa1fe75b4a9e18b66ae7f0b122543c42debcf800aaafa0212aaff3ad273c2596"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.19.0"
+        },
+        "ocdsextensionregistry": {
+            "hashes": [
+                "sha256:3adc8d5cd63c45872951d7f4d34a3b601ea9a768777fdeb603effca443d1f0bf"
+            ],
+            "version": "==0.0.19"
+        },
+        "ocdskit": {
+            "hashes": [
+                "sha256:1155857a0227c0cc1e700c2bf41e5d36c2361c775789cce9180221de47c3de2c"
+            ],
+            "index": "pypi",
+            "version": "==0.2.8"
+        },
+        "ocdsmerge": {
+            "hashes": [
+                "sha256:e48fc35752748321d595b2aeb3da41a37c7d2e5d79bff89a26b05cbb1684e8ef"
+            ],
+            "version": "==0.6.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096",
+                "sha256:13f75fb18486759da3ff40f5345d9dd20e7d78f2a39c5884d013456cec9876f0",
+                "sha256:35b670b0abcfed7cad76f2834041dcf7ae47fd9b22b63622d67cdc933d79f453",
+                "sha256:4c73f373b0800eb3062ffd13d4a7a2a6d522792fa6eb204d67a4fad0a40f03dc",
+                "sha256:5759edf0b686b6f25a5d4a447ea588983a33afc8a0081a0954184a4a87fd0dd7",
+                "sha256:5a7cf6044467c1356b2b49ef69e50bf4d231e773c3ca0558807cdba56b76820b",
+                "sha256:69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8",
+                "sha256:8778a5cc5a8437a561e3276b85367412e10ae9fff07db1eed986e427d9a674f8",
+                "sha256:9871ef5ee17f388f1cb35f76dc6106d40cb8165c562d573470672f4cdefa59ef",
+                "sha256:9c31d52f1a7dd2bb4681d9f62646c7aa554f19e8e9addc17e8b1b20011d7522d",
+                "sha256:ab8173a8efe5418bbe50e43f321994ac6673afc5c7c4839014cf6401bbdd0705",
+                "sha256:ae961f1f0e270f1e4e2273f6a539b2ea33248e0e3a11ffb479d757918a5e03a9",
+                "sha256:b3c4f93fcb6e97d993bf87cdd917883b7dab7d20c627699f360a8fb49e9e0b91",
+                "sha256:c9410ce8a3dee77653bc0684cfa1535a7f9c291663bd7ad79e39f5ab58f67ab3",
+                "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107",
+                "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"
+            ],
+            "index": "pypi",
+            "version": "==1.0.5"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
+            ],
+            "version": "==0.16.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+            ],
+            "version": "==2020.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.24.0"
+        },
+        "requests-cache": {
+            "hashes": [
+                "sha256:813023269686045f8e01e2289cc1e7e9ae5ab22ddd1e2849a9093ab3ab7270eb",
+                "sha256:81e13559baee64677a7d73b85498a5a8f0639e204517b5d05ff378e44a57831a"
+            ],
+            "version": "==0.5.2"
+        },
+        "rfc3987": {
+            "hashes": [
+                "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53",
+                "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            ],
+            "version": "==1.3.8"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
+                "sha256:105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+            ],
+            "index": "pypi",
+            "version": "==1.10.0"
+        },
+        "smart-open": {
+            "hashes": [
+                "sha256:555962abf982faff8a8aeb65e0695474e3091f604826055782beffa8400e4e4e"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:0942a3a0df3f6131580eddd26d99071b48cfe5aaf3eab2783076fbc5a1c1882e",
+                "sha256:0ec575db1b54909750332c2e335c2bb11257883914a03bc5a3306a4488ecc772",
+                "sha256:109581ccc8915001e8037b73c29590e78ce74be49ca0a3630a23831f9e3ed6c7",
+                "sha256:16593fd748944726540cd20f7e83afec816c2ac96b082e26ae226e8f7e9688cf",
+                "sha256:427273b08efc16a85aa2b39892817e78e3ed074fcb89b2a51c4979bae7e7ba98",
+                "sha256:50c4ee32f0e1581828843267d8de35c3298e86ceecd5e9017dc45788be70a864",
+                "sha256:512a85c3c8c3995cc91af3e90f38f460da5d3cade8dc3a229c8e0879037547c9",
+                "sha256:57aa843b783179ab72e863512e14bdcba186641daf69e4e3a5761d705dcc35b1",
+                "sha256:621f58cd921cd71ba6215c42954ffaa8a918eecd8c535d97befa1a8acad986dd",
+                "sha256:6ac2558631a81b85e7fb7a44e5035347938b0a73f5fdc27a8566777d0792a6a4",
+                "sha256:716754d0b5490bdcf68e1e4925edc02ac07209883314ad01a137642ddb2056f1",
+                "sha256:736d41cfebedecc6f159fc4ac0769dc89528a989471dc1d378ba07d29a60ba1c",
+                "sha256:8619b86cb68b185a778635be5b3e6018623c0761dde4df2f112896424aa27bd8",
+                "sha256:87fad64529cde4f1914a5b9c383628e1a8f9e3930304c09cf22c2ae118a1280e",
+                "sha256:89494df7f93b1836cae210c42864b292f9b31eeabca4810193761990dc689cce",
+                "sha256:8cac7bb373a5f1423e28de3fd5fc8063b9c8ffe8957dc1b1a59cb90453db6da1",
+                "sha256:8fd452dc3d49b3cc54483e033de6c006c304432e6f84b74d7b2c68afa2569ae5",
+                "sha256:adad60eea2c4c2a1875eb6305a0b6e61a83163f8e233586a4d6a55221ef984fe",
+                "sha256:c26f95e7609b821b5f08a72dab929baa0d685406b953efd7c89423a511d5c413",
+                "sha256:cbe1324ef52ff26ccde2cb84b8593c8bf930069dfc06c1e616f1bfd4e47f48a3",
+                "sha256:d05c4adae06bd0c7f696ae3ec8d993ed8ffcc4e11a76b1b35a5af8a099bd2284",
+                "sha256:d98bc827a1293ae767c8f2f18be3bb5151fd37ddcd7da2a5f9581baeeb7a3fa1",
+                "sha256:da2fb75f64792c1fc64c82313a00c728a7c301efe6a60b7a9fe35b16b4368ce7",
+                "sha256:e4624d7edb2576cd72bb83636cd71c8ce544d8e272f308bd80885056972ca299",
+                "sha256:e89e0d9e106f8a9180a4ca92a6adde60c58b1b0299e1b43bd5e0312f535fbf33",
+                "sha256:f11c2437fb5f812d020932119ba02d9e2bc29a6eca01a055233a8b449e3e1e7d",
+                "sha256:f57be5673e12763dd400fea568608700a63ce1c6bd5bdbc3cc3a2c5fdb045274",
+                "sha256:fc728ece3d5c772c196fd338a99798e7efac7a04f9cb6416299a3638ee9a94cd"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.3.18"
+        },
+        "strict-rfc3339": {
+            "hashes": [
+                "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
+            ],
+            "version": "==0.7"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.25.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.0"
+        }
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f0816f6ac4a1f9cf240c9b7fd74ad3abae5c90e990a153fa6024727dd9316655"
+            "sha256": "b4b7e7340f0845d33d703b209cf0ad6d41e4d0ec14061fe103c463469f3c1329"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             "index": "pypi",
             "version": "==1.2.1"
         },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==19.3.0"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7",
@@ -30,6 +38,41 @@
                 "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"
             ],
             "version": "==4.9.1"
+        },
+        "boto": {
+            "hashes": [
+                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
+                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
+            ],
+            "version": "==2.49.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:77d926c16ab2ab2bfe68811f3bc987e7d79c97f3e2adebf9265c587cdb1fc47b",
+                "sha256:7f558165eaa608a5d0e05227ee820f4b3cc74533a52c9dde7eb488eba091d50d"
+            ],
+            "version": "==1.14.13"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:37b65cc48c99b7dd4d5606e56f76ecd88eb7be392ea8a166df734a6b3035301c",
+                "sha256:5ac9b53a75852fe4282be8741c8136e6948714fef6eff1bd9babb861f8647ba3"
+            ],
+            "version": "==1.17.13"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "csscompressor": {
             "hashes": [
@@ -120,6 +163,31 @@
             "git": "https://github.com/mysociety/django-pipeline-csscompressor",
             "ref": "6a88fde5045d68746f1c7ee816deda86615c5581"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.15.2"
+        },
+        "elasticsearch": {
+            "hashes": [
+                "sha256:6fb566dd23b91b5871ce12212888674b4cf33374e92b71b1080916c931e44dcb",
+                "sha256:e637d8cf4e27e279b5ff8ca8edc0c086f4b5df4bf2b48e2f950b7833aca3a792"
+            ],
+            "index": "pypi",
+            "version": "==7.8.0"
+        },
+        "elasticsearch-dsl": {
+            "hashes": [
+                "sha256:1e345535164cb684de4b825e1d0daf81b75554b30d3905446584a9e4af0cc3e7",
+                "sha256:593c01822a03e3e84b87753c78edb833f4b2bfafcd52089841bd8f99b7e74ccd"
+            ],
+            "index": "pypi",
+            "version": "==7.2.1"
+        },
         "et-xmlfile": {
             "hashes": [
                 "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
@@ -150,281 +218,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1"
-        },
-        "jdcal": {
-            "hashes": [
-                "sha256:1abf1305fce18b4e8aa248cf8fe0c56ce2032392bc64bbd61b5dff2a19ec8bba",
-                "sha256:472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8"
-            ],
-            "version": "==1.4.1"
-        },
-        "libsass": {
-            "hashes": [
-                "sha256:236762af9c693bb72ed92d65ff4a5a77d27af9494b6174fbec7e6308416673b0",
-                "sha256:28a490f350d38fa3a16da8a52e5ae685e71c8938a7b87cf2d58aee892f30c756",
-                "sha256:2fb999d978e9cc8f7459f8f07a8acf9fc03d6e9fa95fcf98169bf0a5ede81eb6",
-                "sha256:38e9b9b08d299793fffa7b5003d473a6c537e495117f2c44787e3437a5e38f90",
-                "sha256:55cb32142f8c5f449edcb4baf040b553d59a604c8957aa177d26782a06d0eb6f",
-                "sha256:64414697e65da4bfb47f0e11471bf5c79e1dd81e10e2e4b1a70f8ed1cdc33f5b",
-                "sha256:815d60626b329db2943c5d331a5b74d36eb2e441047ae2bd6ad8d1b2c14cfc5d",
-                "sha256:a1e3f19ef392badcc87ad75d8988b1720a4d4f5a506f2f52ebb781300c57136d",
-                "sha256:b064ccedb51b874c725a40f03fc952afd85bd6f5369d41aa74f393ff3388b9e1",
-                "sha256:b8f8cf7c5ee16d217541e6b34def3f45286545077301adc4f54e94977fc69c9f",
-                "sha256:c3ea0cbb36745b6cc10278539e0bf93a426f2f497306181fc6214193f493b8d5",
-                "sha256:cd20479d80cdb49ba7007611d8a9a7004579d54552e010277764c19d82233a51",
-                "sha256:cf43ea1a69bab2836fc953e3d73f32d15efdcbf44c6082df36dd12c76ff59322",
-                "sha256:d2b77e43726cd658b1bc13f1a2df543dc34c9f945a9144faecc88ca03fe581ff",
-                "sha256:ebf413799057a4dd59d85ceb533935f171117565053341e3714e4cb05253bbbf",
-                "sha256:ec659d4d2f60d95160e60f7f52d569bf1b29318018b6f07f8706ff6d4bc04de7",
-                "sha256:edb366b784c58c635ace69ef392e5ad3a42690aeac80d43521c64e0ee7706331",
-                "sha256:ff07c2c55f9d73d9f57cded30138ff99dfbb9fe7fbc71a4bbb43aa067ad2beed"
-            ],
-            "index": "pypi",
-            "version": "==0.12.3"
-        },
-        "markdown": {
-            "hashes": [
-                "sha256:0ac8a81e658167da95d063a9279c9c1b2699f37c7c4153256a458b3a43860e33"
-            ],
-            "index": "pypi",
-            "version": "==2.6.8"
-        },
-        "markuppy": {
-            "hashes": [
-                "sha256:1adee2c0a542af378fe84548ff6f6b0168f3cb7f426b46961038a2bcfaad0d5f"
-            ],
-            "version": "==1.14"
-        },
-        "odfpy": {
-            "hashes": [
-                "sha256:db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec",
-                "sha256:fc3b8d1bc098eba4a0fda865a76d9d1e577c4ceec771426bcb169a82c5e9dfe0"
-            ],
-            "version": "==1.4.1"
-        },
-        "olefile": {
-            "hashes": [
-                "sha256:61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad"
-            ],
-            "index": "pypi",
-            "version": "==0.44"
-        },
-        "openpyxl": {
-            "hashes": [
-                "sha256:6e62f058d19b09b95d20ebfbfb04857ad08d0833190516c1660675f699c6186f"
-            ],
-            "version": "==3.0.4"
-        },
-        "pillow": {
-            "hashes": [
-                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
-                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
-                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
-                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
-                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
-                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
-                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
-                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
-                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
-                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
-                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
-                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
-                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
-                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
-                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
-                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
-                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
-                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
-                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
-                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
-                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
-                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
-                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
-                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
-                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
-                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
-            ],
-            "index": "pypi",
-            "version": "==7.2.0"
-        },
-        "psycopg2": {
-            "hashes": [
-                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
-                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
-                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
-                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
-                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
-                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
-                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
-                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
-                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
-                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
-                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
-                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
-                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
-            ],
-            "index": "pypi",
-            "version": "==2.8.5"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
-                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
-            ],
-            "version": "==2020.1"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:ef3a0d5a5e950747f4a39ed7b204e036b37f9bddc7551c1a813b8727515a832e"
-            ],
-            "index": "pypi",
-            "version": "==4.2b1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
-                "sha256:105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
-            ],
-            "index": "pypi",
-            "version": "==1.10.0"
-        },
-        "soupsieve": {
-            "hashes": [
-                "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55",
-                "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.0.1"
-        },
-        "sqlparse": {
-            "hashes": [
-                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
-                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.3.1"
-        },
-        "tablib": {
-            "extras": [
-                "html",
-                "ods",
-                "xls",
-                "xlsx",
-                "yaml"
-            ],
-            "hashes": [
-                "sha256:8cc2fa10bc37219ac5e76850eb7fbd50de313c7a1a7895c44af2a8dd206b7be7",
-                "sha256:c5a77c96ad306d5b380def1309d521ad5e98b4f83726f84857ad87e142d13279"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.0.0"
-        },
-        "waitress": {
-            "hashes": [
-                "sha256:045b3efc3d97c93362173ab1dfc159b52cfa22b46c3334ffc805dbdbf0e4309e",
-                "sha256:77ff3f3226931a1d7d8624c5371de07c8e90c7e5d80c5cc660d72659aaf23f38"
-            ],
-            "index": "pypi",
-            "version": "==1.4.3"
-        },
-        "webencodings": {
-            "hashes": [
-                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
-                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
-            ],
-            "version": "==0.5.1"
-        },
-        "whitenoise": {
-            "hashes": [
-                "sha256:0f9137f74bd95fa54329ace88d8dc695fbe895369a632e35f7a136e003e41d73",
-                "sha256:62556265ec1011bd87113fb81b7516f52688887b7a010ee899ff1fd18fd22700"
-            ],
-            "index": "pypi",
-            "version": "==5.0.1"
-        },
-        "xlrd": {
-            "hashes": [
-                "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2",
-                "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"
-            ],
-            "version": "==1.2.0"
-        },
-        "xlwt": {
-            "hashes": [
-                "sha256:a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e",
-                "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88"
-            ],
-            "version": "==1.3.0"
-        }
-    },
-    "develop": {
-        "attrs": {
-            "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==19.3.0"
-        },
-        "boto": {
-            "hashes": [
-                "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8",
-                "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"
-            ],
-            "version": "==2.49.0"
-        },
-        "boto3": {
-            "hashes": [
-                "sha256:77d926c16ab2ab2bfe68811f3bc987e7d79c97f3e2adebf9265c587cdb1fc47b",
-                "sha256:7f558165eaa608a5d0e05227ee820f4b3cc74533a52c9dde7eb488eba091d50d"
-            ],
-            "version": "==1.14.13"
-        },
-        "botocore": {
-            "hashes": [
-                "sha256:37b65cc48c99b7dd4d5606e56f76ecd88eb7be392ea8a166df734a6b3035301c",
-                "sha256:5ac9b53a75852fe4282be8741c8136e6948714fef6eff1bd9babb861f8647ba3"
-            ],
-            "version": "==1.17.13"
-        },
-        "certifi": {
-            "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
-            ],
-            "version": "==2020.6.20"
-        },
-        "chardet": {
-            "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
-            ],
-            "version": "==3.0.4"
-        },
-        "docutils": {
-            "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.15.2"
-        },
-        "elasticsearch": {
-            "hashes": [
-                "sha256:6fb566dd23b91b5871ce12212888674b4cf33374e92b71b1080916c931e44dcb",
-                "sha256:e637d8cf4e27e279b5ff8ca8edc0c086f4b5df4bf2b48e2f950b7833aca3a792"
-            ],
-            "index": "pypi",
-            "version": "==7.8.0"
-        },
-        "elasticsearch-dsl": {
-            "hashes": [
-                "sha256:1e345535164cb684de4b825e1d0daf81b75554b30d3905446584a9e4af0cc3e7",
-                "sha256:593c01822a03e3e84b87753c78edb833f4b2bfafcd52089841bd8f99b7e74ccd"
-            ],
-            "index": "pypi",
-            "version": "==7.2.1"
         },
         "idna": {
             "hashes": [
@@ -467,6 +260,13 @@
             "markers": "python_version < '3.8'",
             "version": "==1.7.0"
         },
+        "jdcal": {
+            "hashes": [
+                "sha256:1abf1305fce18b4e8aa248cf8fe0c56ce2032392bc64bbd61b5dff2a19ec8bba",
+                "sha256:472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8"
+            ],
+            "version": "==1.4.1"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
@@ -502,6 +302,43 @@
                 "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
             ],
             "version": "==3.2.0"
+        },
+        "libsass": {
+            "hashes": [
+                "sha256:236762af9c693bb72ed92d65ff4a5a77d27af9494b6174fbec7e6308416673b0",
+                "sha256:28a490f350d38fa3a16da8a52e5ae685e71c8938a7b87cf2d58aee892f30c756",
+                "sha256:2fb999d978e9cc8f7459f8f07a8acf9fc03d6e9fa95fcf98169bf0a5ede81eb6",
+                "sha256:38e9b9b08d299793fffa7b5003d473a6c537e495117f2c44787e3437a5e38f90",
+                "sha256:55cb32142f8c5f449edcb4baf040b553d59a604c8957aa177d26782a06d0eb6f",
+                "sha256:64414697e65da4bfb47f0e11471bf5c79e1dd81e10e2e4b1a70f8ed1cdc33f5b",
+                "sha256:815d60626b329db2943c5d331a5b74d36eb2e441047ae2bd6ad8d1b2c14cfc5d",
+                "sha256:a1e3f19ef392badcc87ad75d8988b1720a4d4f5a506f2f52ebb781300c57136d",
+                "sha256:b064ccedb51b874c725a40f03fc952afd85bd6f5369d41aa74f393ff3388b9e1",
+                "sha256:b8f8cf7c5ee16d217541e6b34def3f45286545077301adc4f54e94977fc69c9f",
+                "sha256:c3ea0cbb36745b6cc10278539e0bf93a426f2f497306181fc6214193f493b8d5",
+                "sha256:cd20479d80cdb49ba7007611d8a9a7004579d54552e010277764c19d82233a51",
+                "sha256:cf43ea1a69bab2836fc953e3d73f32d15efdcbf44c6082df36dd12c76ff59322",
+                "sha256:d2b77e43726cd658b1bc13f1a2df543dc34c9f945a9144faecc88ca03fe581ff",
+                "sha256:ebf413799057a4dd59d85ceb533935f171117565053341e3714e4cb05253bbbf",
+                "sha256:ec659d4d2f60d95160e60f7f52d569bf1b29318018b6f07f8706ff6d4bc04de7",
+                "sha256:edb366b784c58c635ace69ef392e5ad3a42690aeac80d43521c64e0ee7706331",
+                "sha256:ff07c2c55f9d73d9f57cded30138ff99dfbb9fe7fbc71a4bbb43aa067ad2beed"
+            ],
+            "index": "pypi",
+            "version": "==0.12.3"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:0ac8a81e658167da95d063a9279c9c1b2699f37c7c4153256a458b3a43860e33"
+            ],
+            "index": "pypi",
+            "version": "==2.6.8"
+        },
+        "markuppy": {
+            "hashes": [
+                "sha256:1adee2c0a542af378fe84548ff6f6b0168f3cb7f426b46961038a2bcfaad0d5f"
+            ],
+            "version": "==1.14"
         },
         "numpy": {
             "hashes": [
@@ -554,6 +391,26 @@
             ],
             "version": "==0.6.4"
         },
+        "odfpy": {
+            "hashes": [
+                "sha256:db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec",
+                "sha256:fc3b8d1bc098eba4a0fda865a76d9d1e577c4ceec771426bcb169a82c5e9dfe0"
+            ],
+            "version": "==1.4.1"
+        },
+        "olefile": {
+            "hashes": [
+                "sha256:61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad"
+            ],
+            "index": "pypi",
+            "version": "==0.44"
+        },
+        "openpyxl": {
+            "hashes": [
+                "sha256:6e62f058d19b09b95d20ebfbfb04857ad08d0833190516c1660675f699c6186f"
+            ],
+            "version": "==3.0.4"
+        },
         "pandas": {
             "hashes": [
                 "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096",
@@ -576,6 +433,57 @@
             "index": "pypi",
             "version": "==1.0.5"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
+            ],
+            "index": "pypi",
+            "version": "==7.2.0"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
+                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
+                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
+                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
+                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
+                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
+                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
+                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
+                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
+                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
+                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
+                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
+                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
+            ],
+            "index": "pypi",
+            "version": "==2.8.5"
+        },
         "pyrsistent": {
             "hashes": [
                 "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
@@ -596,6 +504,13 @@
                 "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
             "version": "==2020.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:ef3a0d5a5e950747f4a39ed7b204e036b37f9bddc7551c1a813b8727515a832e"
+            ],
+            "index": "pypi",
+            "version": "==4.2b1"
         },
         "requests": {
             "hashes": [
@@ -628,11 +543,11 @@
         },
         "six": {
             "hashes": [
-                "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1",
-                "sha256:105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
             "index": "pypi",
-            "version": "==1.10.0"
+            "version": "==1.15.0"
         },
         "smart-open": {
             "hashes": [
@@ -640,6 +555,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55",
+                "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.1"
         },
         "sqlalchemy": {
             "hashes": [
@@ -675,11 +598,34 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.3.18"
         },
+        "sqlparse": {
+            "hashes": [
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.3.1"
+        },
         "strict-rfc3339": {
             "hashes": [
                 "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
             ],
             "version": "==0.7"
+        },
+        "tablib": {
+            "extras": [
+                "html",
+                "ods",
+                "xls",
+                "xlsx",
+                "yaml"
+            ],
+            "hashes": [
+                "sha256:8cc2fa10bc37219ac5e76850eb7fbd50de313c7a1a7895c44af2a8dd206b7be7",
+                "sha256:c5a77c96ad306d5b380def1309d521ad5e98b4f83726f84857ad87e142d13279"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.0"
         },
         "urllib3": {
             "hashes": [
@@ -689,6 +635,43 @@
             "markers": "python_version != '3.4'",
             "version": "==1.25.9"
         },
+        "waitress": {
+            "hashes": [
+                "sha256:045b3efc3d97c93362173ab1dfc159b52cfa22b46c3334ffc805dbdbf0e4309e",
+                "sha256:77ff3f3226931a1d7d8624c5371de07c8e90c7e5d80c5cc660d72659aaf23f38"
+            ],
+            "index": "pypi",
+            "version": "==1.4.3"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "whitenoise": {
+            "hashes": [
+                "sha256:0f9137f74bd95fa54329ace88d8dc695fbe895369a632e35f7a136e003e41d73",
+                "sha256:62556265ec1011bd87113fb81b7516f52688887b7a010ee899ff1fd18fd22700"
+            ],
+            "index": "pypi",
+            "version": "==5.0.1"
+        },
+        "xlrd": {
+            "hashes": [
+                "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2",
+                "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"
+            ],
+            "version": "==1.2.0"
+        },
+        "xlwt": {
+            "hashes": [
+                "sha256:a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e",
+                "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88"
+            ],
+            "version": "==1.3.0"
+        },
         "zipp": {
             "hashes": [
                 "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
@@ -697,5 +680,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.1.0"
         }
-    }
+    },
+    "develop": {}
 }

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Contracts Finder data with suppliers linked to Companies House and an ID include
 
 ## Flags
 
-Flags are warnings/errors about the data, attached to an individual or company.
+Flags are warnings/errors about the data, attached to an individual or company and/or a contracting process.
 
 Flag
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For example:
 
     http://127.0.0.1:8000/ocds/?ocid_prefix=ocds-b5fd17
     
-####Prefixes used in the sample data:
+#### Prefixes used in the sample data:
 
 Prototype data:
 
@@ -176,6 +176,45 @@ If you don't have a superuser, create one manually like this
 or without prompt (username: admin, password: admin)
 
     echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'admin')" | python manage.py shell
+
+### Updating the BODS data
+
+There are Django management commands included for looking up BODS data from the Open Ownership register
+
+- bluetail/management/commands/create_openownership_elasticsearch_index.py
+
+    This is a script to build an Elasticsearch index for querying the Open Ownership register.
+    
+    This requires this variable to be set
+    
+        ELASTICSEARCH_URL="https://..."
+
+    To change the index name from the default `bods-open_ownership_register`, also set this var
+
+        ELASTICSEARCH_BODS_INDEX="bods-open_ownership_register"
+    
+    Run command using:
+    
+        script/manage create_openownership_elasticsearch_index
+    
+
+- bluetail/management/commands/get_bods_statements_from_ocds.py
+
+    This script will lookup any Companies House IDs present in the OCDS data to gather any related BODS data from the elasticsearch index created above and store in the Bluetail database.
+    
+    NB. Note this only does 1 depth of lookup currently. ie.
+     
+    - This will get all BODS statements for the Beneficial owners of a company
+    - This does NOT lookup these immediate beneficial owners or parent companies to get further companies/persons related to those
+ 
+    This command requires this variable to be set
+    
+        ELASTICSEARCH_URL="https://..."
+
+    Run command using:
+    
+        script/manage get_bods_statements_from_ocds
+    
 
 
 ### Deployment to Heroku 

--- a/bluetail/helpers.py
+++ b/bluetail/helpers.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 from bluetail import models
 from bluetail.models import FlagAttachment, Flag, BODSEntityStatement, BODSOwnershipStatement, BODSPersonStatement, OCDSReleaseJSON
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('django')
 
 
 class FlagHelperFunctions():

--- a/bluetail/management/commands/create_openownership_elasticsearch_index.py
+++ b/bluetail/management/commands/create_openownership_elasticsearch_index.py
@@ -1,0 +1,83 @@
+"""
+Command to create an elasticsearch index from the Open Ownership register
+"""
+import logging
+import json
+import uuid
+import os
+
+from django.core.management import BaseCommand
+from elasticsearch import Elasticsearch, helpers
+from smart_open import open
+
+logger = logging.getLogger('django')
+
+ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL")
+ELASTICSEARCH_BODS_INDEX = os.getenv("ELASTICSEARCH_BODS_INDEX", "bods-open_ownership_register")
+
+
+class Command(BaseCommand):
+    help = "Create an Elasticsearch index from the Open Ownership register bulk download for Bluetail to lookup BODS data"
+
+    def handle(self, *args, **kwargs):
+        logger.info("Creating Elasticsearch index of Open Ownership register: %s", ELASTICSEARCH_BODS_INDEX)
+
+        elastic_conn = Elasticsearch(ELASTICSEARCH_URL)
+        latest_oo_register_url = "https://oo-register-production.s3-eu-west-1.amazonaws.com/public/exports/statements.latest.jsonl.gz"
+        id_jsonpath = "statementID"
+
+        iterator = elasticsearch_bulk_index_json_iterator(latest_oo_register_url, ELASTICSEARCH_BODS_INDEX, id_jsonpath=id_jsonpath)
+
+        elasticsearch_bulk_wrapper(elastic_conn, iterator)
+
+
+def elasticsearch_bulk_index_json_iterator(json_file, target_index, op_type='index', id_jsonpath=None, json_file_encoding="utf-8"):
+    """
+    Uses `smart_open` to stream line-delimited JSON from any supported source or file.
+    Returns generator to use in elasticsearch.helpers.bulk index
+
+    :param json_file: Line-delimeted JSON file
+    :param target_index:
+    :param op_type:
+    :param id_jsonpath: json path to the field containing a unique value to use as _id eg. "data.links.self"
+    :return: generator to use in elasticsearch.helpers.bulk index
+    """
+    with open(json_file, encoding=json_file_encoding) as reader:
+        for json_line in reader:
+            if id_jsonpath:
+                j = json.loads(json_line)
+                id = j
+                for nestedKey in id_jsonpath.split('.'):
+                    id = id.get(nestedKey, id)
+            else:
+                id = uuid.uuid4()
+
+            # filter objects if needed
+            # json_line
+
+            yield {
+                "_op_type": op_type,
+                "_index": target_index,
+                "_type": "_doc",  # Mapping types removed in ES6+. Must be _doc
+                "_id": id,
+                "_source": json_line
+            }
+
+
+def elasticsearch_bulk_wrapper(elastic_conn, source_iterator):
+    """
+    Simple wrapper around the elasticsearch.helpers.bulk command for common configuration
+
+    :param elastic_conn:
+    :param source_iterator:
+    :return:
+    """
+    response = helpers.bulk(
+        elastic_conn,
+        source_iterator,
+        chunk_size=1000,
+        max_retries=10,
+        request_timeout=60,
+    )
+    logger.info("\nbulk_json_data() RESPONSE:", response)
+    return response

--- a/bluetail/management/commands/get_bods_statements_from_ocds.py
+++ b/bluetail/management/commands/get_bods_statements_from_ocds.py
@@ -1,115 +1,117 @@
 """
 Acquire BODS data for any Companies House IDs we have in the OCDS data
-
-This script uses Spend Networks Elasticsearch index of OpenOwnership register for lookups
-
-This requires multiple steps
-
-- Get entity statement for the company scheme/ID
-    - store the statementID (s)
-- Get ownership statements that have this statementID as subject
-
+This uses an Elasticsearch index of OpenOwnership register for looking up BODS statements
+Use the command "create_openownership_elasticsearch_index" to create the index
+The BODS statements are stored in a local directory
+To insert to database use the insert_example_data command
 """
 import json
 import shutil
-import sys
-from urllib.parse import urlparse
 import logging
 import os
 
 import pandas as pd
-import psycopg2
 from sqlalchemy import create_engine
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import Term, Q
 from django.conf import settings
+from django.core.management import BaseCommand
 
-logger = logging.getLogger(__name__)
+from bluetail.models import OCDSParty
 
-ELASTICSEARCH_7_TEST = os.getenv("ELASTICSEARCH_7_TEST")
+logger = logging.getLogger('django')
+
+ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL")
+ELASTICSEARCH_BODS_INDEX = os.getenv("ELASTICSEARCH_BODS_INDEX", "bods-open_ownership_register")
 DATABASE_URL = os.environ.get('DATABASE_URL')
-SQL_DIR = os.path.join(settings.BASE_DIR, "data", "contracts_finder", "processing", "sql")
 BODS_OUTPUT_DIR = os.path.join(settings.BASE_DIR, "data", "contracts_finder", "bods")
 ELASTICSEARCH_CONN = None
+
+
+class Command(BaseCommand):
+    help = "Download BODS JSON relating to Companies House IDs from the OCDS Party scheme/id in the database"
+
+    def handle(self, *args, **kwargs):
+        lookup_ch_ids()
 
 
 def get_entity_statements(
         company_id,
         scheme='GB-COH',
-        elastic_conn=ELASTICSEARCH_CONN,
+        elasticsearch_conn=ELASTICSEARCH_CONN,
 ):
     """
     Get entity statements about this Company
     """
-    s = Search(using=elastic_conn, index="bods") \
+    s = Search(using=elasticsearch_conn, index="bods") \
         .filter("term", identifiers__scheme__keyword=scheme) \
         .filter("term", identifiers__id__keyword=company_id)
     res = s.execute()
     statements = [h["_source"] for h in res.hits.hits]
-    # Convert AttrDict to Dict
-    # statements = [s.to_dict() for s in statements]
     return statements
 
 
 def get_ownership_statements_with_subject_as(
         statementID,
-        elastic_conn=ELASTICSEARCH_CONN,
+        elasticsearch_conn=ELASTICSEARCH_CONN,
 ):
     """
     Get ownership statements about subject
     """
-    s = Search(using=elastic_conn, index="bods") \
+    s = Search(using=elasticsearch_conn, index="bods") \
         .filter("term", subject__describedByEntityStatement__keyword=statementID)
     res = s.execute()
     statements = [h["_source"] for h in res.hits.hits]
-    # Convert AttrDict to Dict
-    # statements = [s.to_dict() for s in statements]
     return statements
 
 
 def get_interested_party(
         statementID,
-        elastic_conn=ELASTICSEARCH_CONN,
+        elasticsearch_conn=ELASTICSEARCH_CONN,
 ):
     """
     Get statementID for interested party
     """
-    s = Search(using=elastic_conn, index="bods") \
+    s = Search(using=elasticsearch_conn, index="bods") \
         .filter("term", subject__describedByEntityStatement__keyword=statementID)
     res = s.execute()
     statements = [h["_source"] for h in res.hits.hits]
-    # Convert AttrDict to Dict
-    # statements = [s.to_dict() for s in statements]
     return statements
 
 
 def get_statements_by_statementIDs(
         list_of_ids,
-        elastic_conn=ELASTICSEARCH_CONN,
+        elasticsearch_conn=ELASTICSEARCH_CONN,
 ):
     """
     Get statements from list of statementIDs
     """
-    s = Search(using=elastic_conn, index="bods") \
+    s = Search(using=elasticsearch_conn, index="bods") \
         .filter('ids', values=list_of_ids)
     res = s.execute()
     statements = [h["_source"] for h in res.hits.hits]
-    # Convert AttrDict to Dict
-    # statements = [s.to_dict() for s in statements]
     return statements
 
 
 
-def get_company_statements(
+def get_bods_statements_for_company(
         company_id,
         scheme='GB-COH',
-        elastic_conn=ELASTICSEARCH_CONN,
+        elasticsearch_conn=ELASTICSEARCH_CONN,
 ):
+    """
+    This requires multiple steps
+
+    - Get entity statement referencing the company scheme/ID
+    - Get all ownership statements that have this statementID as subject
+    - Get interestedParty statementIDs from the ownership statements
+    - Get entity/person statements from these interestedParty statementIDs
+    """
     statements = []
 
     # Get entity statements
-    entity_statements = get_entity_statements(company_id, scheme, ELASTICSEARCH_CONN)
+    entity_statements = get_entity_statements(company_id, scheme, elasticsearch_conn)
     if len(entity_statements) > 1:
         logger.info("more than 1 entity statement: %s", company_id)
     statements.extend(entity_statements)
@@ -117,7 +119,7 @@ def get_company_statements(
     # Get interested party statements
     for e in entity_statements:
         entity_statementID = e["statementID"]
-        ownership_statements = get_ownership_statements_with_subject_as(entity_statementID, elastic_conn)
+        ownership_statements = get_ownership_statements_with_subject_as(entity_statementID, elasticsearch_conn)
         if ownership_statements:
             interested_party_statementIDs = []
             for o in ownership_statements:
@@ -130,61 +132,46 @@ def get_company_statements(
                 if hasattr(interested_party, "describedByEntityStatement"):
                     interested_party_statementIDs.append(interested_party.describedByEntityStatement)
             if interested_party_statementIDs:
-                interested_party_statements = get_statements_by_statementIDs(interested_party_statementIDs, ELASTICSEARCH_CONN)
+                interested_party_statements = get_statements_by_statementIDs(interested_party_statementIDs, elasticsearch_conn)
                 statements.extend(interested_party_statements)
 
     return statements
 
 
-def connect_from_url(url):
-    result = urlparse(url)
-    # TODO add common exceptions
-    connection = psycopg2.connect(user=result.username,
-                                  password=result.password,
-                                  host=result.hostname,
-                                  port=result.port,
-                                  database=result.path[1:])
-    return connection
-
-
 def lookup_ch_ids():
-    sql_filename = "distinct_GB-COH_ids_from_bluetail.sql"
-    sql = os.path.join(SQL_DIR, sql_filename)
+    # Get list of Company Numbers from the OCDS Parties
+    logger.info("Getting OCDS Party scheme/id queryset")
 
-    engine = create_engine(DATABASE_URL)
-    elastic_conn = Elasticsearch(ELASTICSEARCH_7_TEST, verify_certs=True)
-    sql = open(sql).read()
-    df = pd.read_sql(sql, engine)
+    ids = OCDSParty.objects.filter(party_identifier_scheme="GB-COH")
 
+    elasticsearch_conn = Elasticsearch(ELASTICSEARCH_URL, verify_certs=True)
     OUTPUT_DIR = os.path.join(BODS_OUTPUT_DIR, "ch_id_openownership_bods")
 
     if os.path.exists(OUTPUT_DIR):
         shutil.rmtree(OUTPUT_DIR)
     os.makedirs(OUTPUT_DIR)
 
-    for i, item in df.iterrows():
-        scheme = item.get("party_identifier_scheme")
-        id = item.get("party_identifier_id")
+    logger.info("Downloading BODS statements to %s", BODS_OUTPUT_DIR)
+
+    for item in ids:
+        scheme = item.party_identifier_scheme
+        id = item.party_identifier_id
 
         # Ignore bad CH IDs
         if len(id) != 8:
             continue
 
-        logger.info("Looking up %s, %s", scheme, id)
-        statements = get_company_statements(company_id=id, scheme=scheme, elastic_conn=elastic_conn)
+        logger.debug("Looking up %s, %s", scheme, id)
+        statements = get_bods_statements_for_company(company_id=id, scheme=scheme, elasticsearch_conn=elasticsearch_conn)
         statements = [s.to_dict() for s in statements]
 
-        # for s in statements:
+        # recursive lookups?
+        # for statement in statements:
+        #     scheme = item.get("party_identifier_scheme")
+        #     id = item.get("party_identifier_id")
+        #     new_statements = get_bods_statements_for_company(company_id=id, scheme=scheme, elasticsearch_conn=elasticsearch_conn)
+        #     statements.extend(new_statements)
+
         save_path = os.path.join(OUTPUT_DIR, "{0}_{1}_bods.json".format(scheme, id))
         with open(save_path, "w") as writer:
-            json.dump(statements, writer)
-
-
-if __name__ == '__main__':
-    logging.basicConfig(stream=sys.stdout,
-                        level=logging.INFO,
-                        format='%(asctime)s:%(name)s:%(levelname)s:%(message)s',
-                        datefmt="%Y-%m-%dT%H:%M:%S")
-
-    ELASTICSEARCH_CONN = Elasticsearch(ELASTICSEARCH_7_TEST, verify_certs=True)
-    lookup_ch_ids()
+            json.dump(statements, writer, indent=4)

--- a/bluetail/management/commands/insert_example_data.py
+++ b/bluetail/management/commands/insert_example_data.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from bluetail.helpers import UpsertDataHelpers
 from bluetail.tests.fixtures import insert_flags, insert_flag_attachments
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('django')
 
 DATA_DIR = os.path.join(settings.BASE_DIR, "data")
 

--- a/bluetail/tests/test_scripts.py
+++ b/bluetail/tests/test_scripts.py
@@ -1,8 +1,10 @@
 import os
 import subprocess
-from unittest import TestCase
+from unittest import skip
+
 from django.conf import settings
 from django.core.management import call_command
+from django.test import TestCase
 
 SCRIPTS_DIR = os.path.join(settings.BASE_DIR, "script")
 
@@ -12,6 +14,7 @@ class TestFlagHelperFunctions(TestCase):
     def setUp(self):
         pass
 
+    @skip("Only for local testing")
     def test_script_setup(self):
         db = settings.DATABASES["default"]
         test_db_url = "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00088456_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00088456_bods.json
@@ -1,105 +1,105 @@
 [
-  {
-    "statementID": "openownership-register-4501624486344343879",
-    "statementType": "entityStatement",
-    "entityType": "registeredEntity",
-    "name": "INTERSERVE PLC",
-    "incorporatedInJurisdiction": {
-      "name": "United Kingdom of Great Britain and Northern Ireland",
-      "code": "GB"
+    {
+        "statementID": "openownership-register-4501624486344343879",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INTERSERVE PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00088456"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00088456",
+                "uri": "https://opencorporates.com/companies/gb/00088456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "88456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9436667e4ebf3408741e8",
+                "uri": "http://register.openownership.org/entities/59b9436667e4ebf3408741e8"
+            }
+        ],
+        "foundingDate": "1906-04-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ernst & Young Llp 1, More London Place, London, SE1 2AF",
+                "country": "GB"
+            }
+        ]
     },
-    "identifiers": [
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "00088456"
-      },
-      {
-        "schemeName": "OpenCorporates",
-        "id": "https://opencorporates.com/companies/gb/00088456",
-        "uri": "https://opencorporates.com/companies/gb/00088456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "88456"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/59b9436667e4ebf3408741e8",
-        "uri": "http://register.openownership.org/entities/59b9436667e4ebf3408741e8"
-      }
-    ],
-    "foundingDate": "1906-04-19",
-    "addresses": [
-      {
-        "type": "registered",
-        "address": "Ernst & Young Llp 1, More London Place, London, SE1 2AF",
-        "country": "GB"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-14198099548844766685",
-    "statementType": "ownershipOrControlStatement",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-4501624486344343879"
-    },
-    "interestedParty": {
-      "unspecified": {
-        "reason": "unknown",
-        "description": "Unknown person(s)"
-      }
-    },
-    "interests": []
-  }
+    {
+        "statementID": "openownership-register-14198099548844766685",
+        "statementType": "ownershipOrControlStatement",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4501624486344343879"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": []
+    }
 ]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00178605_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00178605_bods.json
@@ -1,1 +1,196 @@
-[{"statementID": "openownership-register-13177754584531939992", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WILDGOOSE CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00178605"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00178605"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00178605", "uri": "https://opencorporates.com/companies/gb/00178605"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9971867e4ebf340008b1b", "uri": "http://register.openownership.org/entities/59b9971867e4ebf340008b1b"}], "foundingDate": "1921-12-22", "addresses": [{"type": "registered", "address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY", "country": "GB"}]}, {"statementID": "openownership-register-5717634819109132889", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13177754584531939992"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14420371617873287496"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13797014115900814753", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13177754584531939992"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10578146277919432431"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10578146277919432431", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Laura Rebecca Harcourt"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09770235/persons-with-significant-control/individual/V3rxmjUdY1x6x4te0GQdcyvTOpk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93de667e4ebf3406fba19", "uri": "http://register.openownership.org/entities/59b93de667e4ebf3406fba19"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-12-01", "addresses": [{"address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY"}]}, {"statementID": "openownership-register-14420371617873287496", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jonathan Nigel Wildgoose"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09770235/persons-with-significant-control/individual/eRwDV7iv_mr-Ezyix-zizeLDsFg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93de667e4ebf3406fba02", "uri": "http://register.openownership.org/entities/59b93de667e4ebf3406fba02"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-10-01", "addresses": [{"address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY"}]}]
+[
+    {
+        "statementID": "openownership-register-13177754584531939992",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WILDGOOSE CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00178605"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00178605"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00178605",
+                "uri": "https://opencorporates.com/companies/gb/00178605"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9971867e4ebf340008b1b",
+                "uri": "http://register.openownership.org/entities/59b9971867e4ebf340008b1b"
+            }
+        ],
+        "foundingDate": "1921-12-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5717634819109132889",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13177754584531939992"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14420371617873287496"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13797014115900814753",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13177754584531939992"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10578146277919432431"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10578146277919432431",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Laura Rebecca Harcourt"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09770235/persons-with-significant-control/individual/V3rxmjUdY1x6x4te0GQdcyvTOpk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93de667e4ebf3406fba19",
+                "uri": "http://register.openownership.org/entities/59b93de667e4ebf3406fba19"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-12-01",
+        "addresses": [
+            {
+                "address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14420371617873287496",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jonathan Nigel Wildgoose"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09770235/persons-with-significant-control/individual/eRwDV7iv_mr-Ezyix-zizeLDsFg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93de667e4ebf3406fba02",
+                "uri": "http://register.openownership.org/entities/59b93de667e4ebf3406fba02"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-10-01",
+        "addresses": [
+            {
+                "address": "Horsefair House, 35 King Street, Alfreton, Derbyshire, DE55 7BY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00191408_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00191408_bods.json
@@ -1,1 +1,344 @@
-[{"statementID": "openownership-register-6905764423547145952", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SKANSKA CONSTRUCTION UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00191408", "uri": "https://opencorporates.com/companies/gb/00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4", "uri": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4"}], "foundingDate": "1923-07-19", "addresses": [{"type": "registered", "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW", "country": "GB"}]}, {"statementID": "openownership-register-15700314617915960068", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-6905764423547145952"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6465406336178337658"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6465406336178337658", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SKANSKA UK PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00784752"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00784752", "uri": "https://opencorporates.com/companies/gb/00784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "784752"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9927867e4ebf340f088c0", "uri": "http://register.openownership.org/entities/59b9927867e4ebf340f088c0"}], "foundingDate": "1963-12-16", "addresses": [{"type": "registered", "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6905764423547145952",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SKANSKA CONSTRUCTION UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00191408",
+                "uri": "https://opencorporates.com/companies/gb/00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4",
+                "uri": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4"
+            }
+        ],
+        "foundingDate": "1923-07-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15700314617915960068",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6905764423547145952"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6465406336178337658"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6465406336178337658",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SKANSKA UK PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00784752"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00784752",
+                "uri": "https://opencorporates.com/companies/gb/00784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "784752"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9927867e4ebf340f088c0",
+                "uri": "http://register.openownership.org/entities/59b9927867e4ebf340f088c0"
+            }
+        ],
+        "foundingDate": "1963-12-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00198823_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00198823_bods.json
@@ -1,1 +1,175 @@
-[{"statementID": "openownership-register-4515342307752257319", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GAP GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00198823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00198823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00198823"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00198823", "uri": "https://opencorporates.com/companies/gb/00198823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00198823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00198823"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9691667e4ebf340368e61", "uri": "http://register.openownership.org/entities/59b9691667e4ebf340368e61"}], "foundingDate": "1924-06-24", "addresses": [{"type": "registered", "address": "Gap Group Blenheim Place, Dunston Industrial Estate, Gateshead, Tyne And Wear, NE11 9HF", "country": "GB"}]}, {"statementID": "openownership-register-11769143142079209312", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4515342307752257319"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12459904278939394776"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12459904278939394776", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GAP HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC143099"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC143099", "uri": "https://opencorporates.com/companies/gb/SC143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc143099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc 143099"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9691767e4ebf3403692bd", "uri": "http://register.openownership.org/entities/59b9691767e4ebf3403692bd"}], "foundingDate": "1993-03-08", "addresses": [{"type": "registered", "address": "Carrick House, Carrick Street, Glasgow, G2 8JP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4515342307752257319",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GAP GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00198823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00198823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00198823"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00198823",
+                "uri": "https://opencorporates.com/companies/gb/00198823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00198823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00198823"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9691667e4ebf340368e61",
+                "uri": "http://register.openownership.org/entities/59b9691667e4ebf340368e61"
+            }
+        ],
+        "foundingDate": "1924-06-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Gap Group Blenheim Place, Dunston Industrial Estate, Gateshead, Tyne And Wear, NE11 9HF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11769143142079209312",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4515342307752257319"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12459904278939394776"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12459904278939394776",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GAP HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC143099"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC143099",
+                "uri": "https://opencorporates.com/companies/gb/SC143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc143099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc 143099"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9691767e4ebf3403692bd",
+                "uri": "http://register.openownership.org/entities/59b9691767e4ebf3403692bd"
+            }
+        ],
+        "foundingDate": "1993-03-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Carrick House, Carrick Street, Glasgow, G2 8JP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00203583_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00203583_bods.json
@@ -1,1 +1,642 @@
-[{"statementID": "openownership-register-9132352691681765504", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NACRO", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00203583"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00203583", "uri": "https://opencorporates.com/companies/gb/00203583"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa748", "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa748"}], "foundingDate": "1925-02-04", "addresses": [{"type": "registered", "address": "Walkden House, 16-17 Devonshire Square, London, EC2M 4SQ", "country": "GB"}]}, {"statementID": "openownership-register-6829865011584895917", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3588483754869042513"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13327132818942734015", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-23", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15625451875026851109"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-09-23", "endDate": "2017-12-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17252904561107975525", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4065654391179884746"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-06-11"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16067610461762341421", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1780158758730984654"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17692248439367484668", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-375963952582567103"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14443856005661448794", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10838337612927960841"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-03-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-18028431598411964668", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4898416329392647330"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-03-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13701902858304304927", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6516324242392286423"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-06T11:44:23Z"}}, {"statementID": "openownership-register-9027744570119580897", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4849406385200254899"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10165181319906888994", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9132352691681765504"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3553109941648674766"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-12-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-3588483754869042513", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert William Booker"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/CmVZFilh78UYSwK3K4lKT2xwAZY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa74e", "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa74e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1955-11-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH", "country": "GB"}]}, {"statementID": "openownership-register-15625451875026851109", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Sarah Nelson-Smith"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/RwsttEqdn8SbVuKzKdIBdBiFtvE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa07", "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa07"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1979-10-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-4065654391179884746", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Kerry Patrick Pollard"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/TNvRzn600RcywYC1U5frxVY7fLM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa02", "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa02"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1994-04-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-1780158758730984654", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Darren Hughes"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/TviJzar8Ipa4j2mhb2lgzmo0vp0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa998", "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa998"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-02-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-375963952582567103", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ronald Morton Crank"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/XyhGvZGStCEnpQVrwFRTtHauVuw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa979", "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa979"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1948-08-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-10838337612927960841", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Waheed Saleem"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/aRk33MYdovYLsoUBdh5dnnXgP5c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa7f5", "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa7f5"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1980-01-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-4898416329392647330", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Charles Darley"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/eoWFsUZCteduBUTnyHt-Jx_t0MA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa78e", "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa78e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1948-05-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-6516324242392286423", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Dominic Harold David Mcgonigal"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/iNuDET9MmKhj4jPkNZKTQ3LR8rU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa773", "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa773"}], "birthDate": "1962-10-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-3553109941648674766", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew Leslie Billany"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00203583/persons-with-significant-control/individual/q-cT1W9BI-8x03QCCqrqnhAi9Zk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa9a5", "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa9a5"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-10-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}, {"statementID": "openownership-register-4849406385200254899", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Nigel Conrad Chapman"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01052098/persons-with-significant-control/individual/XnrQFedIMCBmTmpmo0VVST3sSVI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9639267e4ebf3401bc739", "uri": "http://register.openownership.org/entities/59b9639267e4ebf3401bc739"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1955-12-01", "addresses": [{"address": "46, Loman Street, London, SE1 0EH"}]}]
+[
+    {
+        "statementID": "openownership-register-9132352691681765504",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NACRO",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00203583"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00203583",
+                "uri": "https://opencorporates.com/companies/gb/00203583"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa748",
+                "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa748"
+            }
+        ],
+        "foundingDate": "1925-02-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Walkden House, 16-17 Devonshire Square, London, EC2M 4SQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6829865011584895917",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3588483754869042513"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13327132818942734015",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15625451875026851109"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-09-23",
+                "endDate": "2017-12-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17252904561107975525",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4065654391179884746"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-06-11"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16067610461762341421",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1780158758730984654"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17692248439367484668",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-375963952582567103"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14443856005661448794",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10838337612927960841"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-03-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-18028431598411964668",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4898416329392647330"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-03-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13701902858304304927",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6516324242392286423"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-06T11:44:23Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9027744570119580897",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4849406385200254899"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10165181319906888994",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9132352691681765504"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3553109941648674766"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3588483754869042513",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert William Booker"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/CmVZFilh78UYSwK3K4lKT2xwAZY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa74e",
+                "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa74e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-11-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15625451875026851109",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Sarah Nelson-Smith"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/RwsttEqdn8SbVuKzKdIBdBiFtvE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa07",
+                "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa07"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1979-10-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4065654391179884746",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Kerry Patrick Pollard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/TNvRzn600RcywYC1U5frxVY7fLM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa02",
+                "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aaa02"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1994-04-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1780158758730984654",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Darren Hughes"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/TviJzar8Ipa4j2mhb2lgzmo0vp0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa998",
+                "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa998"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-02-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-375963952582567103",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ronald Morton Crank"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/XyhGvZGStCEnpQVrwFRTtHauVuw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa979",
+                "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa979"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1948-08-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10838337612927960841",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Waheed Saleem"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/aRk33MYdovYLsoUBdh5dnnXgP5c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa7f5",
+                "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa7f5"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1980-01-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4898416329392647330",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Charles Darley"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/eoWFsUZCteduBUTnyHt-Jx_t0MA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa78e",
+                "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa78e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1948-05-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6516324242392286423",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Dominic Harold David Mcgonigal"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/iNuDET9MmKhj4jPkNZKTQ3LR8rU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa773",
+                "uri": "http://register.openownership.org/entities/59b9704c67e4ebf3405aa773"
+            }
+        ],
+        "birthDate": "1962-10-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3553109941648674766",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew Leslie Billany"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00203583/persons-with-significant-control/individual/q-cT1W9BI-8x03QCCqrqnhAi9Zk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa9a5",
+                "uri": "http://register.openownership.org/entities/59b9704d67e4ebf3405aa9a5"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-10-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4849406385200254899",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Nigel Conrad Chapman"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01052098/persons-with-significant-control/individual/XnrQFedIMCBmTmpmo0VVST3sSVI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9639267e4ebf3401bc739",
+                "uri": "http://register.openownership.org/entities/59b9639267e4ebf3401bc739"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-12-01",
+        "addresses": [
+            {
+                "address": "46, Loman Street, London, SE1 0EH"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00215496_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00215496_bods.json
@@ -1,1 +1,137 @@
-[{"statementID": "openownership-register-10834749062685699121", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HENKEL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00215496"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00215496"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00215496"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00215496"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00215496"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00215496", "uri": "https://opencorporates.com/companies/gb/00215496"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b90967e4ebf3407fa668", "uri": "http://register.openownership.org/entities/59b9b90967e4ebf3407fa668"}], "foundingDate": "1926-08-05", "addresses": [{"type": "registered", "address": "Henkel Limited, Wood Lane End, Hemel Hempstead, Hertfordshire, HP2 4RQ", "country": "GB"}]}, {"statementID": "openownership-register-9510888797722862683", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10834749062685699121"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10448180238416384568"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10448180238416384568", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Henkel Ag & Co. Kgaa", "incorporatedInJurisdiction": {"name": "Germany", "code": "DE"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00215496/persons-with-significant-control/corporate-entity/rGxa0Ku41JqoeNeldJNDUXfjc7c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c81c67e4ebf340b894a0", "uri": "http://register.openownership.org/entities/59b9c81c67e4ebf340b894a0"}], "addresses": [{"type": "registered", "address": "Henkelstrasse 67, Dusseldorf", "country": "DE"}]}]
+[
+    {
+        "statementID": "openownership-register-10834749062685699121",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HENKEL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00215496"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00215496"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00215496"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00215496"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00215496"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00215496",
+                "uri": "https://opencorporates.com/companies/gb/00215496"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b90967e4ebf3407fa668",
+                "uri": "http://register.openownership.org/entities/59b9b90967e4ebf3407fa668"
+            }
+        ],
+        "foundingDate": "1926-08-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Henkel Limited, Wood Lane End, Hemel Hempstead, Hertfordshire, HP2 4RQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9510888797722862683",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10834749062685699121"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10448180238416384568"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10448180238416384568",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Henkel Ag & Co. Kgaa",
+        "incorporatedInJurisdiction": {
+            "name": "Germany",
+            "code": "DE"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00215496/persons-with-significant-control/corporate-entity/rGxa0Ku41JqoeNeldJNDUXfjc7c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c81c67e4ebf340b894a0",
+                "uri": "http://register.openownership.org/entities/59b9c81c67e4ebf340b894a0"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Henkelstrasse 67, Dusseldorf",
+                "country": "DE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00216628_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00216628_bods.json
@@ -1,1 +1,487 @@
-[{"statementID": "openownership-register-3717730522155112761", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EAST YORKSHIRE MOTOR SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00216628"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00216628", "uri": "https://opencorporates.com/companies/gb/00216628"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c8b667e4ebf340bad557", "uri": "http://register.openownership.org/entities/59b9c8b667e4ebf340bad557"}], "foundingDate": "1926-10-05", "addresses": [{"type": "registered", "address": "The Go-Ahead Group 3rd Floor, 41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE", "country": "GB"}]}, {"statementID": "openownership-register-415641687180117273", "statementType": "ownershipOrControlStatement", "statementDate": "2018-11-29", "subject": {"describedByEntityStatement": "openownership-register-3717730522155112761"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5679610090984822817"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-11-29", "endDate": "2018-11-29"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-11-29", "endDate": "2018-11-29"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-11-29", "endDate": "2018-11-29"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-27T19:27:34Z"}}, {"statementID": "openownership-register-14671845151317193727", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3717730522155112761"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5679610090984822817"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-27T19:27:34Z"}}, {"statementID": "openownership-register-3169410158568554409", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3717730522155112761"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8521585160273500986"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-11-29"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-27T19:27:34Z"}}, {"statementID": "openownership-register-8521585160273500986", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter John Sidney Shipp"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02123369/persons-with-significant-control/individual/EdhJ_lyp8ZqHGMA1IkI0e1rEOOI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c88067e4ebf340ba0010", "uri": "http://register.openownership.org/entities/59b9c88067e4ebf340ba0010"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1943-10-01", "addresses": [{"address": "The Go-Ahead Group, 3rd Floor, 41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE"}]}, {"statementID": "openownership-register-5679610090984822817", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EYMS GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02065145", "uri": "https://opencorporates.com/companies/gb/02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02065145"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96a2c67e4ebf3403c3d15", "uri": "http://register.openownership.org/entities/59b96a2c67e4ebf3403c3d15"}], "foundingDate": "1986-10-17", "addresses": [{"type": "registered", "address": "41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3717730522155112761",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EAST YORKSHIRE MOTOR SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00216628"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00216628",
+                "uri": "https://opencorporates.com/companies/gb/00216628"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c8b667e4ebf340bad557",
+                "uri": "http://register.openownership.org/entities/59b9c8b667e4ebf340bad557"
+            }
+        ],
+        "foundingDate": "1926-10-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Go-Ahead Group 3rd Floor, 41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-415641687180117273",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-11-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3717730522155112761"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5679610090984822817"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-11-29",
+                "endDate": "2018-11-29"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-11-29",
+                "endDate": "2018-11-29"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-11-29",
+                "endDate": "2018-11-29"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-27T19:27:34Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14671845151317193727",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3717730522155112761"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5679610090984822817"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-27T19:27:34Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3169410158568554409",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3717730522155112761"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8521585160273500986"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-11-29"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-27T19:27:34Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8521585160273500986",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter John Sidney Shipp"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02123369/persons-with-significant-control/individual/EdhJ_lyp8ZqHGMA1IkI0e1rEOOI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c88067e4ebf340ba0010",
+                "uri": "http://register.openownership.org/entities/59b9c88067e4ebf340ba0010"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1943-10-01",
+        "addresses": [
+            {
+                "address": "The Go-Ahead Group, 3rd Floor, 41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5679610090984822817",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EYMS GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02065145",
+                "uri": "https://opencorporates.com/companies/gb/02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02065145"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96a2c67e4ebf3403c3d15",
+                "uri": "http://register.openownership.org/entities/59b96a2c67e4ebf3403c3d15"
+            }
+        ],
+        "foundingDate": "1986-10-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "41-51 Grey Street, Newcastle Upon Tyne, NE1 6EE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00262456_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00262456_bods.json
@@ -1,1 +1,197 @@
-[{"statementID": "openownership-register-13926997676151675609", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "THORNES INDEPENDENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00262456"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00262456", "uri": "https://opencorporates.com/companies/gb/00262456"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9637d67e4ebf3401b68f3", "uri": "http://register.openownership.org/entities/59b9637d67e4ebf3401b68f3"}], "foundingDate": "1932-02-04", "addresses": [{"type": "registered", "address": "Coach Station, Hull Road  Hemingbrough, Selby, North Yorkshire, YO8 6QG", "country": "GB"}]}, {"statementID": "openownership-register-10484106646362052689", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-13926997676151675609"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16892636312372195225"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9222207703521955799", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-13926997676151675609"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11771093770413204291"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11771093770413204291", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Christine Thornes"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02123276/persons-with-significant-control/individual/96gT0PCnE11-9I3pnmr1JsipSyk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9637767e4ebf3401b4723", "uri": "http://register.openownership.org/entities/59b9637767e4ebf3401b4723"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1958-04-01", "addresses": [{"address": "Fir Tree House, Hull Road, Hemingbrough, Selby, YO8 6QG", "country": "GB"}]}, {"statementID": "openownership-register-16892636312372195225", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip Thornes"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02123276/persons-with-significant-control/individual/mMPh7p_UEaoyn4ICEdUMnf_DGwk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9637767e4ebf3401b4730", "uri": "http://register.openownership.org/entities/59b9637767e4ebf3401b4730"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1949-08-01", "addresses": [{"address": "Fir Tree House, Hull Road, Hemingbrough, Selby, YO8 6QG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13926997676151675609",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "THORNES INDEPENDENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00262456"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00262456",
+                "uri": "https://opencorporates.com/companies/gb/00262456"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9637d67e4ebf3401b68f3",
+                "uri": "http://register.openownership.org/entities/59b9637d67e4ebf3401b68f3"
+            }
+        ],
+        "foundingDate": "1932-02-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Coach Station, Hull Road  Hemingbrough, Selby, North Yorkshire, YO8 6QG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10484106646362052689",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13926997676151675609"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16892636312372195225"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9222207703521955799",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13926997676151675609"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11771093770413204291"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11771093770413204291",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Christine Thornes"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02123276/persons-with-significant-control/individual/96gT0PCnE11-9I3pnmr1JsipSyk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9637767e4ebf3401b4723",
+                "uri": "http://register.openownership.org/entities/59b9637767e4ebf3401b4723"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1958-04-01",
+        "addresses": [
+            {
+                "address": "Fir Tree House, Hull Road, Hemingbrough, Selby, YO8 6QG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16892636312372195225",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip Thornes"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02123276/persons-with-significant-control/individual/mMPh7p_UEaoyn4ICEdUMnf_DGwk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9637767e4ebf3401b4730",
+                "uri": "http://register.openownership.org/entities/59b9637767e4ebf3401b4730"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1949-08-01",
+        "addresses": [
+            {
+                "address": "Fir Tree House, Hull Road, Hemingbrough, Selby, YO8 6QG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00367257_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00367257_bods.json
@@ -1,1 +1,182 @@
-[{"statementID": "openownership-register-3375051905989865291", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Bennett Safetywear Limited", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00367257"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00367257", "uri": "https://opencorporates.com/companies/gb/00367257"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a740b", "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a740b"}], "foundingDate": "1941-05-22", "addresses": [{"type": "registered", "address": "7-11, Mersey Road, Crosby, Liverpool, L23 3AF", "country": "GB"}]}, {"statementID": "openownership-register-459006591560010324", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3375051905989865291"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10822494983529091332"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-18023416647212250884", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3375051905989865291"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5703680221179367053"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10822494983529091332", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Christopher Bennett"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00367257/persons-with-significant-control/individual/kC8zvq3A9fq1YjwUVRPQXoHqMJ0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a741a", "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a741a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-05-01", "addresses": [{"address": "11 Mersey Road, Crosby, Liverpool, L23 3AF", "country": "GB"}]}, {"statementID": "openownership-register-5703680221179367053", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Brian Garner Bennett"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00367257/persons-with-significant-control/individual/ms3ZP1QLFUMVHqEVgu9pOlNYVMY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a74f9", "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a74f9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1944-02-01", "addresses": [{"address": "11 Mersey Road, Crosby, Liverpool, L23 3AF"}]}]
+[
+    {
+        "statementID": "openownership-register-3375051905989865291",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Bennett Safetywear Limited",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00367257"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00367257",
+                "uri": "https://opencorporates.com/companies/gb/00367257"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a740b",
+                "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a740b"
+            }
+        ],
+        "foundingDate": "1941-05-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "7-11, Mersey Road, Crosby, Liverpool, L23 3AF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-459006591560010324",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3375051905989865291"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10822494983529091332"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-18023416647212250884",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3375051905989865291"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5703680221179367053"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10822494983529091332",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Christopher Bennett"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00367257/persons-with-significant-control/individual/kC8zvq3A9fq1YjwUVRPQXoHqMJ0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a741a",
+                "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a741a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-05-01",
+        "addresses": [
+            {
+                "address": "11 Mersey Road, Crosby, Liverpool, L23 3AF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5703680221179367053",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Brian Garner Bennett"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00367257/persons-with-significant-control/individual/ms3ZP1QLFUMVHqEVgu9pOlNYVMY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95ff067e4ebf3400a74f9",
+                "uri": "http://register.openownership.org/entities/59b95ff067e4ebf3400a74f9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1944-02-01",
+        "addresses": [
+            {
+                "address": "11 Mersey Road, Crosby, Liverpool, L23 3AF"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00442696_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00442696_bods.json
@@ -1,1 +1,109 @@
-[{"statementID": "openownership-register-16264003161779340777", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LYRECO UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00442696"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00442696", "uri": "https://opencorporates.com/companies/gb/00442696"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9488467e4ebf3409efcc7", "uri": "http://register.openownership.org/entities/59b9488467e4ebf3409efcc7"}], "foundingDate": "1947-09-25", "addresses": [{"type": "registered", "address": "Deer Park Court, Donnington Wood, Telford, Shropshire, TF2 7NB", "country": "GB"}]}, {"statementID": "openownership-register-11717973030390832207", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-03", "subject": {"describedByEntityStatement": "openownership-register-16264003161779340777"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2637895348761929469"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-10-03"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-10-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2637895348761929469", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Georges Andres Daniel Gaspard"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00442696/persons-with-significant-control/individual/5cWhEQpAS5ZYGFFBFYFy7wgfG2w"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9488467e4ebf3409efcdd", "uri": "http://register.openownership.org/entities/59b9488467e4ebf3409efcdd"}], "birthDate": "1951-01-01", "addresses": [{"address": "Lyreco Sas, Rue Du 19 Mars, Marly, 59770", "country": "FR"}]}]
+[
+    {
+        "statementID": "openownership-register-16264003161779340777",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LYRECO UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00442696"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00442696",
+                "uri": "https://opencorporates.com/companies/gb/00442696"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9488467e4ebf3409efcc7",
+                "uri": "http://register.openownership.org/entities/59b9488467e4ebf3409efcc7"
+            }
+        ],
+        "foundingDate": "1947-09-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Deer Park Court, Donnington Wood, Telford, Shropshire, TF2 7NB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11717973030390832207",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16264003161779340777"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2637895348761929469"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-03"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2637895348761929469",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Georges Andres Daniel Gaspard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00442696/persons-with-significant-control/individual/5cWhEQpAS5ZYGFFBFYFy7wgfG2w"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9488467e4ebf3409efcdd",
+                "uri": "http://register.openownership.org/entities/59b9488467e4ebf3409efcdd"
+            }
+        ],
+        "birthDate": "1951-01-01",
+        "addresses": [
+            {
+                "address": "Lyreco Sas, Rue Du 19 Mars, Marly, 59770",
+                "country": "FR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00444569_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00444569_bods.json
@@ -1,1 +1,217 @@
-[{"statementID": "openownership-register-3527013625081828965", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASHTEAD PLANT HIRE COMPANY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00444569", "uri": "https://opencorporates.com/companies/gb/00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00444569"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92bd967e4ebf34019c9b5", "uri": "http://register.openownership.org/entities/59b92bd967e4ebf34019c9b5"}], "foundingDate": "1947-11-01", "addresses": [{"type": "registered", "address": "100 Cheapside, London, EC2V 6DT", "country": "GB"}]}, {"statementID": "openownership-register-2141764266828142371", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3527013625081828965"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3071776247760778193"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3071776247760778193", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASHTEAD HOLDINGS PUBLIC LIMITED COMPANY", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04895881"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04895881"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04895881"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04895881", "uri": "https://opencorporates.com/companies/gb/04895881"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4895881"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4895881"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b940c767e4ebf3407cec5f", "uri": "http://register.openownership.org/entities/59b940c767e4ebf3407cec5f"}], "foundingDate": "2003-09-11", "addresses": [{"type": "registered", "address": "100 Cheapside, London, EC2V 6DT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3527013625081828965",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASHTEAD PLANT HIRE COMPANY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00444569",
+                "uri": "https://opencorporates.com/companies/gb/00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00444569"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92bd967e4ebf34019c9b5",
+                "uri": "http://register.openownership.org/entities/59b92bd967e4ebf34019c9b5"
+            }
+        ],
+        "foundingDate": "1947-11-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 Cheapside, London, EC2V 6DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2141764266828142371",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3527013625081828965"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3071776247760778193"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3071776247760778193",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASHTEAD HOLDINGS PUBLIC LIMITED COMPANY",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04895881"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04895881"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04895881"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04895881",
+                "uri": "https://opencorporates.com/companies/gb/04895881"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4895881"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4895881"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b940c767e4ebf3407cec5f",
+                "uri": "http://register.openownership.org/entities/59b940c767e4ebf3407cec5f"
+            }
+        ],
+        "foundingDate": "2003-09-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 Cheapside, London, EC2V 6DT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00450103_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00450103_bods.json
@@ -1,1 +1,160 @@
-[{"statementID": "openownership-register-7388938866634342443", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ISG CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00450103"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00450103", "uri": "https://opencorporates.com/companies/gb/00450103"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0450103"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95c8667e4ebf340fa9284", "uri": "http://register.openownership.org/entities/59b95c8667e4ebf340fa9284"}], "foundingDate": "1948-02-26", "addresses": [{"type": "registered", "address": "Aldgate House, 33 Aldgate High Street, London, EC3N 1AG", "country": "GB"}]}, {"statementID": "openownership-register-10294999051712988495", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7388938866634342443"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9702520130919981786"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9702520130919981786", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ISG CONSTRUCTION HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07272660"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07272660"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07272660", "uri": "https://opencorporates.com/companies/gb/07272660"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07272660"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97c0967e4ebf340954137", "uri": "http://register.openownership.org/entities/59b97c0967e4ebf340954137"}], "foundingDate": "2010-06-03", "addresses": [{"type": "registered", "address": "Aldgate House, 33 Aldgate High Street, London, EC3N 1AG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7388938866634342443",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ISG CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00450103"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00450103",
+                "uri": "https://opencorporates.com/companies/gb/00450103"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0450103"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95c8667e4ebf340fa9284",
+                "uri": "http://register.openownership.org/entities/59b95c8667e4ebf340fa9284"
+            }
+        ],
+        "foundingDate": "1948-02-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate House, 33 Aldgate High Street, London, EC3N 1AG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10294999051712988495",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7388938866634342443"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9702520130919981786"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9702520130919981786",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ISG CONSTRUCTION HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07272660"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07272660"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07272660",
+                "uri": "https://opencorporates.com/companies/gb/07272660"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07272660"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97c0967e4ebf340954137",
+                "uri": "http://register.openownership.org/entities/59b97c0967e4ebf340954137"
+            }
+        ],
+        "foundingDate": "2010-06-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate House, 33 Aldgate High Street, London, EC3N 1AG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00453791_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00453791_bods.json
@@ -1,1 +1,1058 @@
-[{"statementID": "openownership-register-9185330481728819988", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TARMAC TRADING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00453791", "uri": "https://opencorporates.com/companies/gb/00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00453791"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "453791"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b942f767e4ebf340859acf", "uri": "http://register.openownership.org/entities/59b942f767e4ebf340859acf"}], "foundingDate": "1948-05-07", "addresses": [{"type": "registered", "address": "Portland House Bickenhill Lane, Solihull, Birmingham, B37 7BQ", "country": "GB"}]}, {"statementID": "openownership-register-14946478004005975067", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9185330481728819988"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4344339031287253246"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4344339031287253246", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TARMAC HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07533961", "uri": "https://opencorporates.com/companies/gb/07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb", "uri": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb"}], "foundingDate": "2011-02-17", "addresses": [{"type": "registered", "address": "Portland House, Bickenhill Lane, Solihull, Birmingham, B37 7BQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9185330481728819988",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TARMAC TRADING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00453791",
+                "uri": "https://opencorporates.com/companies/gb/00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00453791"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "453791"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b942f767e4ebf340859acf",
+                "uri": "http://register.openownership.org/entities/59b942f767e4ebf340859acf"
+            }
+        ],
+        "foundingDate": "1948-05-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Portland House Bickenhill Lane, Solihull, Birmingham, B37 7BQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14946478004005975067",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9185330481728819988"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4344339031287253246"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4344339031287253246",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TARMAC HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07533961",
+                "uri": "https://opencorporates.com/companies/gb/07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb",
+                "uri": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb"
+            }
+        ],
+        "foundingDate": "2011-02-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Portland House, Bickenhill Lane, Solihull, Birmingham, B37 7BQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00469608_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00469608_bods.json
@@ -1,1 +1,154 @@
-[{"statementID": "openownership-register-1293003134940353731", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CARWOOD MOTOR UNITS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00469608", "uri": "https://opencorporates.com/companies/gb/00469608"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00469608"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9326967e4ebf34039d503", "uri": "http://register.openownership.org/entities/59b9326967e4ebf34039d503"}], "foundingDate": "1949-06-14", "addresses": [{"type": "registered", "address": "Herald Way, Binley, Coventry, CV3 2RQ", "country": "GB"}]}, {"statementID": "openownership-register-2532455738218116853", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1293003134940353731"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11648179442499704507"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11648179442499704507", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CARWOOD LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05068076"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05068076"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05068076", "uri": "https://opencorporates.com/companies/gb/05068076"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99c6167e4ebf340131d05", "uri": "http://register.openownership.org/entities/59b99c6167e4ebf340131d05"}], "foundingDate": "2004-03-09", "addresses": [{"type": "registered", "address": "Herald Way, Binley, Coventry, West Midlands, CV3 2RQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1293003134940353731",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CARWOOD MOTOR UNITS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00469608",
+                "uri": "https://opencorporates.com/companies/gb/00469608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00469608"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9326967e4ebf34039d503",
+                "uri": "http://register.openownership.org/entities/59b9326967e4ebf34039d503"
+            }
+        ],
+        "foundingDate": "1949-06-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Herald Way, Binley, Coventry, CV3 2RQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2532455738218116853",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1293003134940353731"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11648179442499704507"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11648179442499704507",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CARWOOD LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05068076"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05068076"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05068076",
+                "uri": "https://opencorporates.com/companies/gb/05068076"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99c6167e4ebf340131d05",
+                "uri": "http://register.openownership.org/entities/59b99c6167e4ebf340131d05"
+            }
+        ],
+        "foundingDate": "2004-03-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Herald Way, Binley, Coventry, West Midlands, CV3 2RQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00472058_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00472058_bods.json
@@ -1,1 +1,229 @@
-[{"statementID": "openownership-register-8962050435087112010", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DARCY PRODUCTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00472058"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00472058", "uri": "https://opencorporates.com/companies/gb/00472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0472058"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0472058"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92a7e67e4ebf340137c46", "uri": "http://register.openownership.org/entities/59b92a7e67e4ebf340137c46"}], "foundingDate": "1949-08-20", "addresses": [{"type": "registered", "address": "Brook House Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN", "country": "GB"}]}, {"statementID": "openownership-register-11719740718425143147", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8962050435087112010"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7764970257696952580"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14546553695120513948", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8962050435087112010"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10682909628075847362"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7764970257696952580", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Richard William George Proctor"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00472058/persons-with-significant-control/individual/dpokCRv3lz2HeBje-UHRh3ZvXn4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bbe6", "uri": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bbe6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-03-01", "addresses": [{"address": "Brook House, Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN"}]}, {"statementID": "openownership-register-10682909628075847362", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Edith Mary Proctor"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00472058/persons-with-significant-control/individual/mpwvGJmmSdJwoDITipUM1IVq-ow"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bc27", "uri": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bc27"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1940-12-01", "addresses": [{"address": "Brook House, Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN"}]}]
+[
+    {
+        "statementID": "openownership-register-8962050435087112010",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DARCY PRODUCTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00472058"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00472058",
+                "uri": "https://opencorporates.com/companies/gb/00472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0472058"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0472058"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92a7e67e4ebf340137c46",
+                "uri": "http://register.openownership.org/entities/59b92a7e67e4ebf340137c46"
+            }
+        ],
+        "foundingDate": "1949-08-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Brook House Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11719740718425143147",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8962050435087112010"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7764970257696952580"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14546553695120513948",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8962050435087112010"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10682909628075847362"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7764970257696952580",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Richard William George Proctor"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00472058/persons-with-significant-control/individual/dpokCRv3lz2HeBje-UHRh3ZvXn4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bbe6",
+                "uri": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bbe6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-03-01",
+        "addresses": [
+            {
+                "address": "Brook House, Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10682909628075847362",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Edith Mary Proctor"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00472058/persons-with-significant-control/individual/mpwvGJmmSdJwoDITipUM1IVq-ow"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bc27",
+                "uri": "http://register.openownership.org/entities/59b9b6fd67e4ebf34077bc27"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1940-12-01",
+        "addresses": [
+            {
+                "address": "Brook House, Larkfield Trading Estate, New Hythe Lane, Larkfield, Kent, ME20 6GN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00557725_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00557725_bods.json
@@ -1,1 +1,97 @@
-[{"statementID": "openownership-register-15541304840918599873", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AEBI SCHMIDT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00557725"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00557725", "uri": "https://opencorporates.com/companies/gb/00557725"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95a9867e4ebf340f0d4d1", "uri": "http://register.openownership.org/entities/59b95a9867e4ebf340f0d4d1"}], "foundingDate": "1955-11-24", "addresses": [{"type": "registered", "address": "Southgate Way, Orton Southgate, Peterborough, PE2 6GP", "country": "GB"}]}, {"statementID": "openownership-register-16759577979979536594", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15541304840918599873"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13757605638991714099"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13757605638991714099", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Aebi Schmidt Holding Ag", "incorporatedInJurisdiction": {"name": "Switzerland", "code": "CH"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00557725/persons-with-significant-control/corporate-entity/zj4QGDoSTW3LF8RMMkccHE21pMc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95a9867e4ebf340f0da6c", "uri": "http://register.openownership.org/entities/59b95a9867e4ebf340f0da6c"}], "addresses": [{"type": "registered", "address": "310, Zurcherstrasse, Frauenfeld 8500", "country": "CH"}]}]
+[
+    {
+        "statementID": "openownership-register-15541304840918599873",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AEBI SCHMIDT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00557725"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00557725",
+                "uri": "https://opencorporates.com/companies/gb/00557725"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95a9867e4ebf340f0d4d1",
+                "uri": "http://register.openownership.org/entities/59b95a9867e4ebf340f0d4d1"
+            }
+        ],
+        "foundingDate": "1955-11-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Southgate Way, Orton Southgate, Peterborough, PE2 6GP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16759577979979536594",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15541304840918599873"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13757605638991714099"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13757605638991714099",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Aebi Schmidt Holding Ag",
+        "incorporatedInJurisdiction": {
+            "name": "Switzerland",
+            "code": "CH"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00557725/persons-with-significant-control/corporate-entity/zj4QGDoSTW3LF8RMMkccHE21pMc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95a9867e4ebf340f0da6c",
+                "uri": "http://register.openownership.org/entities/59b95a9867e4ebf340f0da6c"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "310, Zurcherstrasse, Frauenfeld 8500",
+                "country": "CH"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00566823_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00566823_bods.json
@@ -1,1 +1,218 @@
-[{"statementID": "openownership-register-15704408405754918020", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SIR ROBERT MCALPINE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00566823"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00566823", "uri": "https://opencorporates.com/companies/gb/00566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "566823"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9852367e4ebf340c164eb", "uri": "http://register.openownership.org/entities/59b9852367e4ebf340c164eb"}], "foundingDate": "1956-05-31", "addresses": [{"type": "registered", "address": "Eaton Court, Maylands Avenue, Hemel Hempstead, Herts, HP2 7TR", "country": "GB"}]}, {"statementID": "openownership-register-12858359851325606107", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15704408405754918020"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4160496151879650082"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4160496151879650082", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SIR ROBERT MCALPINE (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754943"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02754943", "uri": "https://opencorporates.com/companies/gb/02754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2754943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2754943"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94d0f67e4ebf340b34bd7", "uri": "http://register.openownership.org/entities/59b94d0f67e4ebf340b34bd7"}], "foundingDate": "1992-10-12", "addresses": [{"type": "registered", "address": "Eaton Court, Maylands Avenue, Hemel Hempstead, Hertfordshire, HP2 7TR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15704408405754918020",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SIR ROBERT MCALPINE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00566823"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00566823",
+                "uri": "https://opencorporates.com/companies/gb/00566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "566823"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9852367e4ebf340c164eb",
+                "uri": "http://register.openownership.org/entities/59b9852367e4ebf340c164eb"
+            }
+        ],
+        "foundingDate": "1956-05-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Eaton Court, Maylands Avenue, Hemel Hempstead, Herts, HP2 7TR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12858359851325606107",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15704408405754918020"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4160496151879650082"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4160496151879650082",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SIR ROBERT MCALPINE (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754943"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02754943",
+                "uri": "https://opencorporates.com/companies/gb/02754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2754943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94d0f67e4ebf340b34bd7",
+                "uri": "http://register.openownership.org/entities/59b94d0f67e4ebf340b34bd7"
+            }
+        ],
+        "foundingDate": "1992-10-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Eaton Court, Maylands Avenue, Hemel Hempstead, Hertfordshire, HP2 7TR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00604574_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00604574_bods.json
@@ -1,1 +1,236 @@
-[{"statementID": "openownership-register-145406707108562933", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BARRATT DEVELOPMENTS P L C", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00604574"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00604574", "uri": "https://opencorporates.com/companies/gb/00604574"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92f5467e4ebf3402bca4a", "uri": "http://register.openownership.org/entities/59b92f5467e4ebf3402bca4a"}], "foundingDate": "1958-05-14", "addresses": [{"type": "registered", "address": "Barratt House Cartwright Way, Forest Business Park, Bardon Hill, Coalville, Leicestershire, LE67 1UF", "country": "GB"}]}, {"statementID": "openownership-register-6348458138201858108", "statementType": "ownershipOrControlStatement", "subject": {"describedByEntityStatement": "openownership-register-145406707108562933"}, "interestedParty": {"unspecified": {"reason": "unknown", "description": "Unknown person(s)"}}, "interests": []}]
+[
+    {
+        "statementID": "openownership-register-145406707108562933",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BARRATT DEVELOPMENTS P L C",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00604574"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00604574",
+                "uri": "https://opencorporates.com/companies/gb/00604574"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92f5467e4ebf3402bca4a",
+                "uri": "http://register.openownership.org/entities/59b92f5467e4ebf3402bca4a"
+            }
+        ],
+        "foundingDate": "1958-05-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Barratt House Cartwright Way, Forest Business Park, Bardon Hill, Coalville, Leicestershire, LE67 1UF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6348458138201858108",
+        "statementType": "ownershipOrControlStatement",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-145406707108562933"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": []
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00627605_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00627605_bods.json
@@ -1,1 +1,264 @@
-[{"statementID": "openownership-register-8172833218445561112", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Repaircraft Plc", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00627605"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00627605", "uri": "https://opencorporates.com/companies/gb/00627605"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9e05567e4ebf340123672", "uri": "http://register.openownership.org/entities/59b9e05567e4ebf340123672"}], "foundingDate": "1959-05-06", "addresses": [{"type": "registered", "address": "The Old Mill, The Common, Cranleigh, Surrey, GU6 8LU", "country": "GB"}]}, {"statementID": "openownership-register-5609871565575484412", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8172833218445561112"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13745433098852492050"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12359245183564960155", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-01", "subject": {"describedByEntityStatement": "openownership-register-8172833218445561112"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12422549136732558085"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-12-01", "endDate": "2016-12-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10631017445708899983", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8172833218445561112"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17583635745494700010"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13745433098852492050", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REPAIRCRAFT (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06251084"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06251084", "uri": "https://opencorporates.com/companies/gb/06251084"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a71467e4ebf3403b0fa4", "uri": "http://register.openownership.org/entities/59b9a71467e4ebf3403b0fa4"}], "foundingDate": "2007-05-17", "addresses": [{"type": "registered", "address": "The Old Mill, The Common, Cranleigh, Surrey, GU6 8LU", "country": "GB"}]}, {"statementID": "openownership-register-12422549136732558085", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Charles Nicholas Tallon"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00627605/persons-with-significant-control/individual/VweqCay7wgFzG45wN1Gf0afkB2A"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba31369dfc3fae18af7fc3", "uri": "http://register.openownership.org/entities/5aba31369dfc3fae18af7fc3"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-01-01", "addresses": [{"address": "The Common, Cranleigh, Surrey, GU6 8LU", "country": "GB"}]}, {"statementID": "openownership-register-17583635745494700010", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Adrian Noel Stainton"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00627605/persons-with-significant-control/individual/qb4-KN-0JDWx2fxpddqbXwXyKho"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9b3eb9dfc3fae1872e32c", "uri": "http://register.openownership.org/entities/5ab9b3eb9dfc3fae1872e32c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-01-01", "addresses": [{"address": "The Common, Cranleigh, Surrey, GU6 8LU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8172833218445561112",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Repaircraft Plc",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00627605"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00627605",
+                "uri": "https://opencorporates.com/companies/gb/00627605"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9e05567e4ebf340123672",
+                "uri": "http://register.openownership.org/entities/59b9e05567e4ebf340123672"
+            }
+        ],
+        "foundingDate": "1959-05-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Old Mill, The Common, Cranleigh, Surrey, GU6 8LU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5609871565575484412",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8172833218445561112"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13745433098852492050"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12359245183564960155",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8172833218445561112"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12422549136732558085"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-12-01",
+                "endDate": "2016-12-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10631017445708899983",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8172833218445561112"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17583635745494700010"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13745433098852492050",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REPAIRCRAFT (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06251084"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06251084",
+                "uri": "https://opencorporates.com/companies/gb/06251084"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a71467e4ebf3403b0fa4",
+                "uri": "http://register.openownership.org/entities/59b9a71467e4ebf3403b0fa4"
+            }
+        ],
+        "foundingDate": "2007-05-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Old Mill, The Common, Cranleigh, Surrey, GU6 8LU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12422549136732558085",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Charles Nicholas Tallon"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00627605/persons-with-significant-control/individual/VweqCay7wgFzG45wN1Gf0afkB2A"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba31369dfc3fae18af7fc3",
+                "uri": "http://register.openownership.org/entities/5aba31369dfc3fae18af7fc3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-01-01",
+        "addresses": [
+            {
+                "address": "The Common, Cranleigh, Surrey, GU6 8LU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17583635745494700010",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Adrian Noel Stainton"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00627605/persons-with-significant-control/individual/qb4-KN-0JDWx2fxpddqbXwXyKho"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9b3eb9dfc3fae1872e32c",
+                "uri": "http://register.openownership.org/entities/5ab9b3eb9dfc3fae1872e32c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-01-01",
+        "addresses": [
+            {
+                "address": "The Common, Cranleigh, Surrey, GU6 8LU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00633778_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00633778_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-8224872859961677181", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WERNICK HIRE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00633778"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00633778", "uri": "https://opencorporates.com/companies/gb/00633778"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c508d167e4ebf3406ed68e", "uri": "http://register.openownership.org/entities/59c508d167e4ebf3406ed68e"}], "foundingDate": "1959-07-29", "addresses": [{"type": "registered", "address": "Molineux House, Russell Gardens, Wickford Essex, SS11 8BL", "country": "GB"}]}, {"statementID": "openownership-register-151286144113032257", "statementType": "ownershipOrControlStatement", "statementDate": "2018-03-27", "subject": {"describedByEntityStatement": "openownership-register-8224872859961677181"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16443919114189807740"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent-as-firm", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2018-03-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-16443919114189807740", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Mark Wernick"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03671447/persons-with-significant-control/individual/1b36qAcRWvgMrD75fy_YapH71j8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b175efa9dfc3fae18d1addc", "uri": "http://register.openownership.org/entities/5b175efa9dfc3fae18d1addc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-04-01", "addresses": [{"address": "Molineux House, Russell Gardens, Wickford, Essex, SS11 8QG"}]}]
+[
+    {
+        "statementID": "openownership-register-8224872859961677181",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WERNICK HIRE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00633778"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00633778",
+                "uri": "https://opencorporates.com/companies/gb/00633778"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c508d167e4ebf3406ed68e",
+                "uri": "http://register.openownership.org/entities/59c508d167e4ebf3406ed68e"
+            }
+        ],
+        "foundingDate": "1959-07-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Molineux House, Russell Gardens, Wickford Essex, SS11 8BL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-151286144113032257",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-03-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8224872859961677181"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16443919114189807740"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent-as-firm",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2018-03-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16443919114189807740",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Mark Wernick"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03671447/persons-with-significant-control/individual/1b36qAcRWvgMrD75fy_YapH71j8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b175efa9dfc3fae18d1addc",
+                "uri": "http://register.openownership.org/entities/5b175efa9dfc3fae18d1addc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-04-01",
+        "addresses": [
+            {
+                "address": "Molineux House, Russell Gardens, Wickford, Essex, SS11 8QG"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00658390_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00658390_bods.json
@@ -1,1 +1,984 @@
-[{"statementID": "openownership-register-7419779813161337786", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CEMEX UK OPERATIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00658390"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00658390", "uri": "https://opencorporates.com/companies/gb/00658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "658390"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9197967e4ebf340d33484", "uri": "http://register.openownership.org/entities/59b9197967e4ebf340d33484"}], "foundingDate": "1960-05-06", "addresses": [{"type": "registered", "address": "Cemex House, Evreux Way, Rugby, Warwickshire, CV21 2DT", "country": "GB"}]}, {"statementID": "openownership-register-1316054489962377573", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7419779813161337786"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14676941000048399337"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14676941000048399337", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CEMEX INVESTMENTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00249776"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00249776", "uri": "https://opencorporates.com/companies/gb/00249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "249776"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9365367e4ebf3404cf1bf", "uri": "http://register.openownership.org/entities/59b9365367e4ebf3404cf1bf"}], "foundingDate": "1930-07-26", "addresses": [{"type": "registered", "address": "Cemex House, Evreux Way, Rugby, Warwickshire, CV21 2DT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7419779813161337786",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CEMEX UK OPERATIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00658390"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00658390",
+                "uri": "https://opencorporates.com/companies/gb/00658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "658390"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9197967e4ebf340d33484",
+                "uri": "http://register.openownership.org/entities/59b9197967e4ebf340d33484"
+            }
+        ],
+        "foundingDate": "1960-05-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cemex House, Evreux Way, Rugby, Warwickshire, CV21 2DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1316054489962377573",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7419779813161337786"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14676941000048399337"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14676941000048399337",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CEMEX INVESTMENTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00249776"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00249776",
+                "uri": "https://opencorporates.com/companies/gb/00249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "249776"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9365367e4ebf3404cf1bf",
+                "uri": "http://register.openownership.org/entities/59b9365367e4ebf3404cf1bf"
+            }
+        ],
+        "foundingDate": "1930-07-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cemex House, Evreux Way, Rugby, Warwickshire, CV21 2DT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00670176_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00670176_bods.json
@@ -1,1 +1,1910 @@
-[{"statementID": "openownership-register-6945576424069124638", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BELLWAY HOMES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00670176", "uri": "https://opencorporates.com/companies/gb/00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176)"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176)"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00670176"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91bc567e4ebf340da8fc8", "uri": "http://register.openownership.org/entities/59b91bc567e4ebf340da8fc8"}], "foundingDate": "1960-09-16", "addresses": [{"type": "registered", "address": "Seaton Burn House, Dudley Lane, Seaton Burn, Newcastle Upon Tyne, NE13 6BE", "country": "GB"}]}, {"statementID": "openownership-register-12206081044159524071", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-6945576424069124638"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10187528658781832900"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10187528658781832900", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BELLWAY P L C", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01372603", "uri": "https://opencorporates.com/companies/gb/01372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1372603"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01372603"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b948d167e4ebf340a0a233", "uri": "http://register.openownership.org/entities/59b948d167e4ebf340a0a233"}], "foundingDate": "1978-06-09", "addresses": [{"type": "registered", "address": "Seaton Burn House, Dudley Lane, Seaton Burn, Newcastle Upon Tyne, NE13 6BE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6945576424069124638",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BELLWAY HOMES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00670176",
+                "uri": "https://opencorporates.com/companies/gb/00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176)"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176)"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00670176"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91bc567e4ebf340da8fc8",
+                "uri": "http://register.openownership.org/entities/59b91bc567e4ebf340da8fc8"
+            }
+        ],
+        "foundingDate": "1960-09-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Seaton Burn House, Dudley Lane, Seaton Burn, Newcastle Upon Tyne, NE13 6BE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12206081044159524071",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6945576424069124638"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10187528658781832900"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10187528658781832900",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BELLWAY P L C",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01372603",
+                "uri": "https://opencorporates.com/companies/gb/01372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1372603"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01372603"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b948d167e4ebf340a0a233",
+                "uri": "http://register.openownership.org/entities/59b948d167e4ebf340a0a233"
+            }
+        ],
+        "foundingDate": "1978-06-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Seaton Burn House, Dudley Lane, Seaton Burn, Newcastle Upon Tyne, NE13 6BE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00688424_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00688424_bods.json
@@ -1,1 +1,305 @@
-[{"statementID": "openownership-register-5867724539491802071", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ATKINS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00688424"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00688424", "uri": "https://opencorporates.com/companies/gb/00688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "688424"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91ffc67e4ebf340e802be", "uri": "http://register.openownership.org/entities/59b91ffc67e4ebf340e802be"}], "foundingDate": "1961-03-30", "addresses": [{"type": "registered", "address": "Woodcote Grove, Ashley Road, Epsom, Surrey, KT18 5BW", "country": "GB"}]}, {"statementID": "openownership-register-7549265530227762322", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5867724539491802071"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16221963963991934835"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16221963963991934835", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ATKINS INVESTMENTS UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05313134"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05313134"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05313134", "uri": "https://opencorporates.com/companies/gb/05313134"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5313134"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b946fd67e4ebf34097224a", "uri": "http://register.openownership.org/entities/59b946fd67e4ebf34097224a"}], "foundingDate": "2004-12-14", "addresses": [{"type": "registered", "address": "Woodcote Grove, Ashley Road, Epsom, Surrey, KT18 5BW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5867724539491802071",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ATKINS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00688424"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00688424",
+                "uri": "https://opencorporates.com/companies/gb/00688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "688424"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91ffc67e4ebf340e802be",
+                "uri": "http://register.openownership.org/entities/59b91ffc67e4ebf340e802be"
+            }
+        ],
+        "foundingDate": "1961-03-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Woodcote Grove, Ashley Road, Epsom, Surrey, KT18 5BW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7549265530227762322",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5867724539491802071"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16221963963991934835"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16221963963991934835",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ATKINS INVESTMENTS UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05313134"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05313134"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05313134",
+                "uri": "https://opencorporates.com/companies/gb/05313134"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5313134"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b946fd67e4ebf34097224a",
+                "uri": "http://register.openownership.org/entities/59b946fd67e4ebf34097224a"
+            }
+        ],
+        "foundingDate": "2004-12-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Woodcote Grove, Ashley Road, Epsom, Surrey, KT18 5BW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00708997_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00708997_bods.json
@@ -1,1 +1,139 @@
-[{"statementID": "openownership-register-3248641417456231726", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CONLON CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00708997"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00708997"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00708997", "uri": "https://opencorporates.com/companies/gb/00708997"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9930f67e4ebf340f2b935", "uri": "http://register.openownership.org/entities/59b9930f67e4ebf340f2b935"}], "foundingDate": "1961-11-24", "addresses": [{"type": "registered", "address": "Charnley Fold Lane, Bamber Bridge, Preston, Lancashire, PR5 6BE", "country": "GB"}]}, {"statementID": "openownership-register-2643216607430595174", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3248641417456231726"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10965829434730161234"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10965829434730161234", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CONLON HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06060110", "uri": "https://opencorporates.com/companies/gb/06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06060110"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b958ed67e4ebf340e903af", "uri": "http://register.openownership.org/entities/59b958ed67e4ebf340e903af"}], "foundingDate": "2007-01-22", "addresses": [{"type": "registered", "address": "Charnley Fold Lane, Bamber Bridge, Preston, Lancashire, PR5 6BE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3248641417456231726",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CONLON CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00708997"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00708997"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00708997",
+                "uri": "https://opencorporates.com/companies/gb/00708997"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9930f67e4ebf340f2b935",
+                "uri": "http://register.openownership.org/entities/59b9930f67e4ebf340f2b935"
+            }
+        ],
+        "foundingDate": "1961-11-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Charnley Fold Lane, Bamber Bridge, Preston, Lancashire, PR5 6BE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2643216607430595174",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3248641417456231726"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10965829434730161234"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10965829434730161234",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CONLON HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06060110",
+                "uri": "https://opencorporates.com/companies/gb/06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06060110"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b958ed67e4ebf340e903af",
+                "uri": "http://register.openownership.org/entities/59b958ed67e4ebf340e903af"
+            }
+        ],
+        "foundingDate": "2007-01-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Charnley Fold Lane, Bamber Bridge, Preston, Lancashire, PR5 6BE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00729746_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00729746_bods.json
@@ -1,1 +1,64 @@
-[{"statementID": "openownership-register-5953784362493984425", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Shropshire Wildlife Trust", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00729746"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00729746", "uri": "https://opencorporates.com/companies/gb/00729746"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5083b67e4ebf3406d8693", "uri": "http://register.openownership.org/entities/59c5083b67e4ebf3406d8693"}], "foundingDate": "1962-07-12", "addresses": [{"type": "registered", "address": "193, Abbey Foregate, Shrewsbury, SY2 6AH", "country": "GB"}]}, {"statementID": "openownership-register-6344954589345300413", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-23", "subject": {"describedByEntityStatement": "openownership-register-5953784362493984425"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-5953784362493984425",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Shropshire Wildlife Trust",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00729746"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00729746",
+                "uri": "https://opencorporates.com/companies/gb/00729746"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5083b67e4ebf3406d8693",
+                "uri": "http://register.openownership.org/entities/59c5083b67e4ebf3406d8693"
+            }
+        ],
+        "foundingDate": "1962-07-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "193, Abbey Foregate, Shrewsbury, SY2 6AH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6344954589345300413",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5953784362493984425"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00768173_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00768173_bods.json
@@ -1,1 +1,160 @@
-[{"statementID": "openownership-register-7828447431109806772", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WILLMOTT DIXON CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00768173"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00768173", "uri": "https://opencorporates.com/companies/gb/00768173"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ec667e4ebf340bb14d2", "uri": "http://register.openownership.org/entities/59b94ec667e4ebf340bb14d2"}], "foundingDate": "1963-07-19", "addresses": [{"type": "registered", "address": "Spirella 2 Icknield Way, Letchworth Garden City, Hertfordshire, SG6 4GY", "country": "GB"}]}, {"statementID": "openownership-register-13722592448660111453", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7828447431109806772"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5376390986405697103"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-5376390986405697103", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WILLMOTT DIXON LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05922246", "uri": "https://opencorporates.com/companies/gb/05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05922246"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab95bb49dfc3fae189b35ce", "uri": "http://register.openownership.org/entities/5ab95bb49dfc3fae189b35ce"}], "foundingDate": "2006-09-01", "addresses": [{"type": "registered", "address": "Spirella 2 Icknield Way, Letchworth Garden City, Hertfordshire, SG6 4GY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7828447431109806772",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WILLMOTT DIXON CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00768173"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00768173",
+                "uri": "https://opencorporates.com/companies/gb/00768173"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ec667e4ebf340bb14d2",
+                "uri": "http://register.openownership.org/entities/59b94ec667e4ebf340bb14d2"
+            }
+        ],
+        "foundingDate": "1963-07-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spirella 2 Icknield Way, Letchworth Garden City, Hertfordshire, SG6 4GY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13722592448660111453",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7828447431109806772"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5376390986405697103"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5376390986405697103",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WILLMOTT DIXON LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05922246",
+                "uri": "https://opencorporates.com/companies/gb/05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05922246"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab95bb49dfc3fae189b35ce",
+                "uri": "http://register.openownership.org/entities/5ab95bb49dfc3fae189b35ce"
+            }
+        ],
+        "foundingDate": "2006-09-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spirella 2 Icknield Way, Letchworth Garden City, Hertfordshire, SG6 4GY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00798550_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00798550_bods.json
@@ -1,1 +1,184 @@
-[{"statementID": "openownership-register-12435009316561752641", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SKANSKA RASHLEIGH WEATHERFOIL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00798550"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00798550", "uri": "https://opencorporates.com/companies/gb/00798550"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b992e367e4ebf340f20e0e", "uri": "http://register.openownership.org/entities/59b992e367e4ebf340f20e0e"}], "foundingDate": "1964-03-26", "addresses": [{"type": "registered", "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW", "country": "GB"}]}, {"statementID": "openownership-register-6024915320804307200", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12435009316561752641"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6905764423547145952"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6905764423547145952", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SKANSKA CONSTRUCTION UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00191408"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00191408", "uri": "https://opencorporates.com/companies/gb/00191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "191408"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4", "uri": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4"}], "foundingDate": "1923-07-19", "addresses": [{"type": "registered", "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12435009316561752641",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SKANSKA RASHLEIGH WEATHERFOIL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00798550"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00798550",
+                "uri": "https://opencorporates.com/companies/gb/00798550"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b992e367e4ebf340f20e0e",
+                "uri": "http://register.openownership.org/entities/59b992e367e4ebf340f20e0e"
+            }
+        ],
+        "foundingDate": "1964-03-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6024915320804307200",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12435009316561752641"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6905764423547145952"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6905764423547145952",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SKANSKA CONSTRUCTION UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00191408"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00191408",
+                "uri": "https://opencorporates.com/companies/gb/00191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "191408"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4",
+                "uri": "http://register.openownership.org/entities/59b992e267e4ebf340f20af4"
+            }
+        ],
+        "foundingDate": "1923-07-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Maple Cross House, Denham Way Maple Cross, Rickmansworth, Hertfordshire, WD3 9SW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00839629_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00839629_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-1230997587996336356", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLEE HILL PLANT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00839629"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00839629", "uri": "https://opencorporates.com/companies/gb/00839629"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e7967e4ebf340274c91", "uri": "http://register.openownership.org/entities/59b92e7967e4ebf340274c91"}], "foundingDate": "1965-03-03", "addresses": [{"type": "registered", "address": "Mansfield Road, Hasland, Chesterfield, Derbyshire, S41 0JW", "country": "GB"}]}, {"statementID": "openownership-register-12216090179071663229", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1230997587996336356"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4934518077778343529"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-08-16T09:24:39Z"}}, {"statementID": "openownership-register-4934518077778343529", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Anthony Hargreaves"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00839629/persons-with-significant-control/individual/jq4tW9u8spWOdwd1PSDkW5ErqxU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e7967e4ebf340274cba", "uri": "http://register.openownership.org/entities/59b92e7967e4ebf340274cba"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-06-01", "addresses": [{"address": "Mansfield Road, Hasland, Chesterfield, Derbyshire, S41 0JW"}]}]
+[
+    {
+        "statementID": "openownership-register-1230997587996336356",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLEE HILL PLANT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00839629"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00839629",
+                "uri": "https://opencorporates.com/companies/gb/00839629"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e7967e4ebf340274c91",
+                "uri": "http://register.openownership.org/entities/59b92e7967e4ebf340274c91"
+            }
+        ],
+        "foundingDate": "1965-03-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Mansfield Road, Hasland, Chesterfield, Derbyshire, S41 0JW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12216090179071663229",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1230997587996336356"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4934518077778343529"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-08-16T09:24:39Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4934518077778343529",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Anthony Hargreaves"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00839629/persons-with-significant-control/individual/jq4tW9u8spWOdwd1PSDkW5ErqxU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e7967e4ebf340274cba",
+                "uri": "http://register.openownership.org/entities/59b92e7967e4ebf340274cba"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-06-01",
+        "addresses": [
+            {
+                "address": "Mansfield Road, Hasland, Chesterfield, Derbyshire, S41 0JW"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00851645_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00851645_bods.json
@@ -1,1 +1,144 @@
-[{"statementID": "openownership-register-5827228347417887945", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REED IN PARTNERSHIP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00851645"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00851645"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00851645"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00851645", "uri": "https://opencorporates.com/companies/gb/00851645"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "851645"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9434167e4ebf34086a37c", "uri": "http://register.openownership.org/entities/59b9434167e4ebf34086a37c"}], "foundingDate": "1965-06-14", "addresses": [{"type": "registered", "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT", "country": "GB"}]}, {"statementID": "openownership-register-13070108674669367888", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5827228347417887945"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3642049359273931717"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3642049359273931717", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Andrew Reed"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06317279/persons-with-significant-control/individual/A2bRR3cQO9-imdlmXoMtvgA53tI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0", "uri": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-04-01", "addresses": [{"address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT"}]}]
+[
+    {
+        "statementID": "openownership-register-5827228347417887945",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REED IN PARTNERSHIP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00851645"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00851645"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00851645"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00851645",
+                "uri": "https://opencorporates.com/companies/gb/00851645"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "851645"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9434167e4ebf34086a37c",
+                "uri": "http://register.openownership.org/entities/59b9434167e4ebf34086a37c"
+            }
+        ],
+        "foundingDate": "1965-06-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13070108674669367888",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5827228347417887945"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3642049359273931717"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3642049359273931717",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Andrew Reed"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06317279/persons-with-significant-control/individual/A2bRR3cQO9-imdlmXoMtvgA53tI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0",
+                "uri": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-04-01",
+        "addresses": [
+            {
+                "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00913830_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00913830_bods.json
@@ -1,1 +1,329 @@
-[{"statementID": "openownership-register-3905852155653131307", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "P.F.BURRIDGE & SONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00913830"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00913830", "uri": "https://opencorporates.com/companies/gb/00913830"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d9f267e4ebf340f9ffef", "uri": "http://register.openownership.org/entities/59b9d9f267e4ebf340f9ffef"}], "foundingDate": "1967-08-23", "addresses": [{"type": "registered", "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear, NE12 9TA", "country": "GB"}]}, {"statementID": "openownership-register-9188624602011332330", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3905852155653131307"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3427508153899135833"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-07-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14231464664835712337", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3905852155653131307"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8402932855854364428"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-07-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14317507273490644829", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3905852155653131307"}, "interestedParty": {"describedByPersonStatement": "openownership-register-643796203916818528"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-07-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1698099466216455358", "statementType": "ownershipOrControlStatement", "statementDate": "2017-07-06", "subject": {"describedByEntityStatement": "openownership-register-3905852155653131307"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10515758667820228932"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-07-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-07-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-07-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3427508153899135833", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark Burridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00913830/persons-with-significant-control/individual/0C1GBAqybnHWEjeS8x62xgWASAU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cec9", "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cec9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-04-01", "addresses": [{"address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA", "country": "GB"}]}, {"statementID": "openownership-register-8402932855854364428", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip John Burridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00913830/persons-with-significant-control/individual/R_lEzokxgSimkW-enl08CmzC-l0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cfc8", "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cfc8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-06-01", "addresses": [{"address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA", "country": "GB"}]}, {"statementID": "openownership-register-643796203916818528", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter David Burridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00913830/persons-with-significant-control/individual/sclqIKwDM2b7A5I3n5uwcOMiYuM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cf67", "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cf67"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-10-01", "addresses": [{"address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA", "country": "GB"}]}, {"statementID": "openownership-register-10515758667820228932", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "P.F. BURRIDGE HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10755927"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10755927"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10755927", "uri": "https://opencorporates.com/companies/gb/10755927"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b99867e4ebf34081bc0f", "uri": "http://register.openownership.org/entities/59b9b99867e4ebf34081bc0f"}], "foundingDate": "2017-05-05", "addresses": [{"type": "registered", "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, NE12 9TA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3905852155653131307",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "P.F.BURRIDGE & SONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00913830"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00913830",
+                "uri": "https://opencorporates.com/companies/gb/00913830"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d9f267e4ebf340f9ffef",
+                "uri": "http://register.openownership.org/entities/59b9d9f267e4ebf340f9ffef"
+            }
+        ],
+        "foundingDate": "1967-08-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear, NE12 9TA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9188624602011332330",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3905852155653131307"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3427508153899135833"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-07-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14231464664835712337",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3905852155653131307"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8402932855854364428"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-07-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14317507273490644829",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3905852155653131307"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-643796203916818528"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-07-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1698099466216455358",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-07-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3905852155653131307"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10515758667820228932"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-07-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-07-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-07-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3427508153899135833",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark Burridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00913830/persons-with-significant-control/individual/0C1GBAqybnHWEjeS8x62xgWASAU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cec9",
+                "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cec9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-04-01",
+        "addresses": [
+            {
+                "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8402932855854364428",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip John Burridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00913830/persons-with-significant-control/individual/R_lEzokxgSimkW-enl08CmzC-l0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cfc8",
+                "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cfc8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-06-01",
+        "addresses": [
+            {
+                "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-643796203916818528",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter David Burridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00913830/persons-with-significant-control/individual/sclqIKwDM2b7A5I3n5uwcOMiYuM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cf67",
+                "uri": "http://register.openownership.org/entities/5ab929f29dfc3fae1825cf67"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-10-01",
+        "addresses": [
+            {
+                "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, Tyne & Wear , NE12 9TA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10515758667820228932",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "P.F. BURRIDGE HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10755927"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10755927"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10755927",
+                "uri": "https://opencorporates.com/companies/gb/10755927"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b99867e4ebf34081bc0f",
+                "uri": "http://register.openownership.org/entities/59b9b99867e4ebf34081bc0f"
+            }
+        ],
+        "foundingDate": "2017-05-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Units 8 & 9 Wesley Way, Benton Square Industrial Estate, Newcastle Upon Tyne, NE12 9TA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00939400_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00939400_bods.json
@@ -1,1 +1,134 @@
-[{"statementID": "openownership-register-5120835574899106288", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MEL AVIATION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00939400"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00939400"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00939400"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00939400"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00939400", "uri": "https://opencorporates.com/companies/gb/00939400"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9910067e4ebf340eb8ab6", "uri": "http://register.openownership.org/entities/59b9910067e4ebf340eb8ab6"}], "foundingDate": "1968-09-25", "addresses": [{"type": "registered", "address": "Laurence Walter House, 32 Addison Road, Sudbury, Suffolk, CO10 2YW", "country": "GB"}]}, {"statementID": "openownership-register-9916877913898620396", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5120835574899106288"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6143460990798286310"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6143460990798286310", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Nicholas Francis Smith"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00939400/persons-with-significant-control/individual/PbkAOqslA4h2g9WFpthKKfN5pao"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9910067e4ebf340eb8abd", "uri": "http://register.openownership.org/entities/59b9910067e4ebf340eb8abd"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1958-12-01", "addresses": [{"address": "Laurence Walter House, 32 Addison Road, Sudbury, Suffolk, CO10 2YW"}]}]
+[
+    {
+        "statementID": "openownership-register-5120835574899106288",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MEL AVIATION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00939400"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00939400"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00939400"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00939400"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00939400",
+                "uri": "https://opencorporates.com/companies/gb/00939400"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9910067e4ebf340eb8ab6",
+                "uri": "http://register.openownership.org/entities/59b9910067e4ebf340eb8ab6"
+            }
+        ],
+        "foundingDate": "1968-09-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Laurence Walter House, 32 Addison Road, Sudbury, Suffolk, CO10 2YW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9916877913898620396",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5120835574899106288"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6143460990798286310"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6143460990798286310",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Nicholas Francis Smith"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00939400/persons-with-significant-control/individual/PbkAOqslA4h2g9WFpthKKfN5pao"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9910067e4ebf340eb8abd",
+                "uri": "http://register.openownership.org/entities/59b9910067e4ebf340eb8abd"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1958-12-01",
+        "addresses": [
+            {
+                "address": "Laurence Walter House, 32 Addison Road, Sudbury, Suffolk, CO10 2YW"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00947968_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00947968_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-10872155231543085547", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CGI IT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00947968"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00947968"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00947968", "uri": "https://opencorporates.com/companies/gb/00947968"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9562e67e4ebf340dcbe6d", "uri": "http://register.openownership.org/entities/59b9562e67e4ebf340dcbe6d"}], "foundingDate": "1969-02-13", "addresses": [{"type": "registered", "address": "20 Fenchurch Street, 14th Floor, London, EC3M 3BY", "country": "GB"}]}, {"statementID": "openownership-register-15742741870451627537", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10872155231543085547"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13291261723353738002"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13291261723353738002", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CGI GROUP HOLDINGS EUROPE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03290026"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03290026"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03290026"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03290026"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03290026"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03290026", "uri": "https://opencorporates.com/companies/gb/03290026"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93ec167e4ebf34073be71", "uri": "http://register.openownership.org/entities/59b93ec167e4ebf34073be71"}], "foundingDate": "1996-12-10", "addresses": [{"type": "registered", "address": "20 Fenchurch Street, 14th Floor, London, EC3M 3BY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-10872155231543085547",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CGI IT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00947968"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00947968"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00947968",
+                "uri": "https://opencorporates.com/companies/gb/00947968"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9562e67e4ebf340dcbe6d",
+                "uri": "http://register.openownership.org/entities/59b9562e67e4ebf340dcbe6d"
+            }
+        ],
+        "foundingDate": "1969-02-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20 Fenchurch Street, 14th Floor, London, EC3M 3BY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15742741870451627537",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10872155231543085547"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13291261723353738002"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13291261723353738002",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CGI GROUP HOLDINGS EUROPE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03290026"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03290026"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03290026"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03290026"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03290026"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03290026",
+                "uri": "https://opencorporates.com/companies/gb/03290026"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93ec167e4ebf34073be71",
+                "uri": "http://register.openownership.org/entities/59b93ec167e4ebf34073be71"
+            }
+        ],
+        "foundingDate": "1996-12-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20 Fenchurch Street, 14th Floor, London, EC3M 3BY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00974438_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_00974438_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-6576235278628845718", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LONDON METROPOLITAN UNIVERSITY", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00974438"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00974438", "uri": "https://opencorporates.com/companies/gb/00974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "0974438"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94f5867e4ebf340bde1fa", "uri": "http://register.openownership.org/entities/59b94f5867e4ebf340bde1fa"}], "foundingDate": "1970-03-11", "addresses": [{"type": "registered", "address": "London Metropolitan University, 166-220 Holloway Road, London, N7 8DB", "country": "GB"}]}, {"statementID": "openownership-register-15071774738509001762", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-31", "subject": {"describedByEntityStatement": "openownership-register-6576235278628845718"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-6576235278628845718",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LONDON METROPOLITAN UNIVERSITY",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00974438"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00974438",
+                "uri": "https://opencorporates.com/companies/gb/00974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0974438"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94f5867e4ebf340bde1fa",
+                "uri": "http://register.openownership.org/entities/59b94f5867e4ebf340bde1fa"
+            }
+        ],
+        "foundingDate": "1970-03-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "London Metropolitan University, 166-220 Holloway Road, London, N7 8DB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15071774738509001762",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6576235278628845718"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01027457_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01027457_bods.json
@@ -1,1 +1,271 @@
-[{"statementID": "openownership-register-15926873380658601082", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "T.S.S. FACILITIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01027457"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01027457", "uri": "https://opencorporates.com/companies/gb/01027457"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a41167e4ebf340302570", "uri": "http://register.openownership.org/entities/59b9a41167e4ebf340302570"}], "foundingDate": "1971-10-15", "addresses": [{"type": "registered", "address": "60 Lansdowne Place, Hove, East Sussex, BN3 1FG", "country": "GB"}]}, {"statementID": "openownership-register-1829628672139040958", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15926873380658601082"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3440849303149346938"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11695349067193170182", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15926873380658601082"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7771108181297329504"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7501085084121035092", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15926873380658601082"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14701816971356160800"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7771108181297329504", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Stephen Dennis Tugwell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05221703/persons-with-significant-control/individual/ZRdw6nLu893pozau_Zy1tTp2KJ4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9385267e4ebf340565cbb", "uri": "http://register.openownership.org/entities/59b9385267e4ebf340565cbb"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-07-01", "addresses": [{"address": "4, Elms Lea Avenue, Brighton, BN1 6UG", "country": "GB"}]}, {"statementID": "openownership-register-3440849303149346938", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew James Tugwell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01027457/persons-with-significant-control/individual/7op9ORsW_1g-RcUb_fycvHP1G4g"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a41167e4ebf340302576", "uri": "http://register.openownership.org/entities/59b9a41167e4ebf340302576"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-08-01", "addresses": [{"address": "31, Croft Avenue, Southwick, Brighton, West Sussex, BN42 4AA", "country": "GB"}]}, {"statementID": "openownership-register-14701816971356160800", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Christopher Robin Tugwell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01027457/persons-with-significant-control/individual/raQDL-qlBSxENjIpMMbo87uw13Q"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a41167e4ebf3403025de", "uri": "http://register.openownership.org/entities/59b9a41167e4ebf3403025de"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-07-01", "addresses": [{"address": "8, Bevendean Avenue, Saltdean, Brighton, East Sussex, BN2 8LR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15926873380658601082",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "T.S.S. FACILITIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01027457"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01027457",
+                "uri": "https://opencorporates.com/companies/gb/01027457"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a41167e4ebf340302570",
+                "uri": "http://register.openownership.org/entities/59b9a41167e4ebf340302570"
+            }
+        ],
+        "foundingDate": "1971-10-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "60 Lansdowne Place, Hove, East Sussex, BN3 1FG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1829628672139040958",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15926873380658601082"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3440849303149346938"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11695349067193170182",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15926873380658601082"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7771108181297329504"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7501085084121035092",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15926873380658601082"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14701816971356160800"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7771108181297329504",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Stephen Dennis Tugwell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05221703/persons-with-significant-control/individual/ZRdw6nLu893pozau_Zy1tTp2KJ4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9385267e4ebf340565cbb",
+                "uri": "http://register.openownership.org/entities/59b9385267e4ebf340565cbb"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-07-01",
+        "addresses": [
+            {
+                "address": "4, Elms Lea Avenue, Brighton, BN1 6UG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3440849303149346938",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew James Tugwell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01027457/persons-with-significant-control/individual/7op9ORsW_1g-RcUb_fycvHP1G4g"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a41167e4ebf340302576",
+                "uri": "http://register.openownership.org/entities/59b9a41167e4ebf340302576"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-08-01",
+        "addresses": [
+            {
+                "address": "31, Croft Avenue, Southwick, Brighton, West Sussex, BN42 4AA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14701816971356160800",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Christopher Robin Tugwell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01027457/persons-with-significant-control/individual/raQDL-qlBSxENjIpMMbo87uw13Q"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a41167e4ebf3403025de",
+                "uri": "http://register.openownership.org/entities/59b9a41167e4ebf3403025de"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-07-01",
+        "addresses": [
+            {
+                "address": "8, Bevendean Avenue, Saltdean, Brighton, East Sussex, BN2 8LR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01048653_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01048653_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-12947129026426139536", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLARES OFFICE SUPPLIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01048653"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01048653", "uri": "https://opencorporates.com/companies/gb/01048653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01048653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01048653"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c93f67e4ebf340bc9d2f", "uri": "http://register.openownership.org/entities/59b9c93f67e4ebf340bc9d2f"}], "foundingDate": "1972-04-06", "addresses": [{"type": "registered", "address": "Unit D1 Voyager Park, Portfield Road, Portsmouth, Hampshire, PO3 5FN", "country": "GB"}]}, {"statementID": "openownership-register-18390203170227921960", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12947129026426139536"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9200436755985810936"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9200436755985810936", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLARES BUSINESS SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06430836"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06430836"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06430836"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06430836", "uri": "https://opencorporates.com/companies/gb/06430836"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9520c67e4ebf340c99420", "uri": "http://register.openownership.org/entities/59b9520c67e4ebf340c99420"}], "foundingDate": "2007-11-19", "addresses": [{"type": "registered", "address": "Unit D1 Voyager Park, Portfield Road, Portsmouth, Hampshire, PO3 5FN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12947129026426139536",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLARES OFFICE SUPPLIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01048653"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01048653",
+                "uri": "https://opencorporates.com/companies/gb/01048653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01048653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01048653"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c93f67e4ebf340bc9d2f",
+                "uri": "http://register.openownership.org/entities/59b9c93f67e4ebf340bc9d2f"
+            }
+        ],
+        "foundingDate": "1972-04-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit D1 Voyager Park, Portfield Road, Portsmouth, Hampshire, PO3 5FN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18390203170227921960",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12947129026426139536"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9200436755985810936"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9200436755985810936",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLARES BUSINESS SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06430836"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06430836"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06430836"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06430836",
+                "uri": "https://opencorporates.com/companies/gb/06430836"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9520c67e4ebf340c99420",
+                "uri": "http://register.openownership.org/entities/59b9520c67e4ebf340c99420"
+            }
+        ],
+        "foundingDate": "2007-11-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit D1 Voyager Park, Portfield Road, Portsmouth, Hampshire, PO3 5FN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01051852_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01051852_bods.json
@@ -1,1 +1,492 @@
-[{"statementID": "openownership-register-17451191899070673869", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PETER DUFFY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01051852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01051852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01051852"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01051852", "uri": "https://opencorporates.com/companies/gb/01051852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1051852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1051852"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7a2", "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7a2"}], "foundingDate": "1972-04-27", "addresses": [{"type": "registered", "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA", "country": "GB"}]}, {"statementID": "openownership-register-17299614360494563921", "statementType": "ownershipOrControlStatement", "statementDate": "2017-10-24", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8093037978180966878"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-10-24"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-10-24"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-10-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9052156061459224329", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-09", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18207229910993773249"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent-as-trust", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-05-09", "endDate": "2017-10-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11740975999242208698", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-09", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5454590994031020572"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent-as-trust", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-05-09", "endDate": "2017-10-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1882134624092357330", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10745308358871983326"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-10-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13180128068785292768", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8026652452718017245"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent-as-trust", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-03-20"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8054673643181477340", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-20", "subject": {"describedByEntityStatement": "openownership-register-17451191899070673869"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3671837998348347595"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent-as-trust", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-03-20", "endDate": "2017-10-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8093037978180966878", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PETER DUFFY HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10810186"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10810186"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10810186"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10810186"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10810186", "uri": "https://opencorporates.com/companies/gb/10810186"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab922159dfc3fae1816c81d", "uri": "http://register.openownership.org/entities/5ab922159dfc3fae1816c81d"}], "foundingDate": "2017-06-08", "addresses": [{"type": "registered", "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA", "country": "GB"}]}, {"statementID": "openownership-register-18207229910993773249", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Kevin Joseph Duffy"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10810214/persons-with-significant-control/individual/7WzZGN-BBlBPPGdMO2PZBllXGsE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab921dd9dfc3fae18164c6a", "uri": "http://register.openownership.org/entities/5ab921dd9dfc3fae18164c6a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1969-03-01", "addresses": [{"address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA"}]}, {"statementID": "openownership-register-10745308358871983326", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mary Carmel Duffy"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01051852/persons-with-significant-control/individual/tQ7J4fj5ggkuDHU7XK3JK_hLJF4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7b8", "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7b8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1940-04-01", "addresses": [{"address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA", "country": "IE"}]}, {"statementID": "openownership-register-5454590994031020572", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Helen Elizabeth Webb"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10810186/persons-with-significant-control/individual/_CtCNvlAfe961TxQTf6WM5Rkzxc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9220e9dfc3fae1816b98c", "uri": "http://register.openownership.org/entities/5ab9220e9dfc3fae1816b98c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-06-01", "addresses": [{"address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA", "country": "IE"}]}, {"statementID": "openownership-register-3671837998348347595", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Paul Mervyn Clarke"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10810214/persons-with-significant-control/individual/pdYOOzFFKKZcqsgmdtaB85aNkoc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab921dc9dfc3fae181649cf", "uri": "http://register.openownership.org/entities/5ab921dc9dfc3fae181649cf"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-09-01", "addresses": [{"address": "Brown Butler, Leigh House, 28-32 St. Pauls Street, Leeds, LS1 2JT"}]}, {"statementID": "openownership-register-8026652452718017245", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Katherine Ann Jordan"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01051852/persons-with-significant-control/individual/u3uak5o1BmggAyoIMOowuvlF7Uc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7cc", "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7cc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-04-01", "addresses": [{"address": "Blacks Solicitors, Hanover House, 22 Clarendon Road, Leeds, LS2 9NZ"}]}]
+[
+    {
+        "statementID": "openownership-register-17451191899070673869",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PETER DUFFY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01051852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01051852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01051852"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01051852",
+                "uri": "https://opencorporates.com/companies/gb/01051852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1051852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1051852"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7a2",
+                "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7a2"
+            }
+        ],
+        "foundingDate": "1972-04-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17299614360494563921",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-10-24",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8093037978180966878"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-10-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-10-24"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-10-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9052156061459224329",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-09",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18207229910993773249"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent-as-trust",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-05-09",
+                "endDate": "2017-10-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11740975999242208698",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-09",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5454590994031020572"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent-as-trust",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-05-09",
+                "endDate": "2017-10-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1882134624092357330",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10745308358871983326"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-10-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13180128068785292768",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8026652452718017245"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent-as-trust",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-03-20"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8054673643181477340",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-20",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17451191899070673869"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3671837998348347595"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent-as-trust",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-03-20",
+                "endDate": "2017-10-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8093037978180966878",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PETER DUFFY HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10810186"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10810186"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10810186"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10810186"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10810186",
+                "uri": "https://opencorporates.com/companies/gb/10810186"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab922159dfc3fae1816c81d",
+                "uri": "http://register.openownership.org/entities/5ab922159dfc3fae1816c81d"
+            }
+        ],
+        "foundingDate": "2017-06-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18207229910993773249",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Kevin Joseph Duffy"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10810214/persons-with-significant-control/individual/7WzZGN-BBlBPPGdMO2PZBllXGsE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab921dd9dfc3fae18164c6a",
+                "uri": "http://register.openownership.org/entities/5ab921dd9dfc3fae18164c6a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1969-03-01",
+        "addresses": [
+            {
+                "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10745308358871983326",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mary Carmel Duffy"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01051852/persons-with-significant-control/individual/tQ7J4fj5ggkuDHU7XK3JK_hLJF4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7b8",
+                "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7b8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1940-04-01",
+        "addresses": [
+            {
+                "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA",
+                "country": "IE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5454590994031020572",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Helen Elizabeth Webb"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10810186/persons-with-significant-control/individual/_CtCNvlAfe961TxQTf6WM5Rkzxc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9220e9dfc3fae1816b98c",
+                "uri": "http://register.openownership.org/entities/5ab9220e9dfc3fae1816b98c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-06-01",
+        "addresses": [
+            {
+                "address": "Connaught House, Park View, Lofthouse Gate, Wakefield, West Yorkshire, WF3 3HA",
+                "country": "IE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3671837998348347595",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Paul Mervyn Clarke"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10810214/persons-with-significant-control/individual/pdYOOzFFKKZcqsgmdtaB85aNkoc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab921dc9dfc3fae181649cf",
+                "uri": "http://register.openownership.org/entities/5ab921dc9dfc3fae181649cf"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-09-01",
+        "addresses": [
+            {
+                "address": "Brown Butler, Leigh House, 28-32 St. Pauls Street, Leeds, LS1 2JT"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8026652452718017245",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Katherine Ann Jordan"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01051852/persons-with-significant-control/individual/u3uak5o1BmggAyoIMOowuvlF7Uc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7cc",
+                "uri": "http://register.openownership.org/entities/59b93e5c67e4ebf34071f7cc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-04-01",
+        "addresses": [
+            {
+                "address": "Blacks Solicitors, Hanover House, 22 Clarendon Road, Leeds, LS2 9NZ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01070807_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01070807_bods.json
@@ -1,1 +1,168 @@
-[{"statementID": "openownership-register-12499612705305061226", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MEDTRONIC LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01070807"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01070807"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01070807", "uri": "https://opencorporates.com/companies/gb/01070807"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba55799dfc3fae18e787b1", "uri": "http://register.openownership.org/entities/5aba55799dfc3fae18e787b1"}], "foundingDate": "1972-09-08", "addresses": [{"type": "registered", "address": "Building 9 Croxley Park, Hatters Lane, Watford, Hertfordshire, WD18 8WW", "country": "GB"}]}, {"statementID": "openownership-register-2664949553127466268", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12499612705305061226"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17704602379944595011"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17704602379944595011", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MEDTRONIC PUBLIC LIMITED COMPANY", "incorporatedInJurisdiction": {"name": "Ireland", "code": "IE"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03122084/persons-with-significant-control/corporate-entity/8f3hPj4Mnlf7NFDdBXSq2te_1po"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03141707/persons-with-significant-control/corporate-entity/kzBf5MZ7R8_3FTMUmqMRgGkfXSQ"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02285007/persons-with-significant-control/corporate-entity/3Illp_pxHX7h1dfGHKleb-pyy-E"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01409596/persons-with-significant-control/corporate-entity/HnN6oWJlMwAhL6QkacFXdr_x9Bw"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02672650/persons-with-significant-control/corporate-entity/AaDS0ILdVh-NNdhG7pD1E4xeFsw"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06524642/persons-with-significant-control/corporate-entity/p-unPc3HMQMZWb3hZ_eUDU4Ze1I"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07162873/persons-with-significant-control/corporate-entity/10W8iQvJ7_4NY1Q1PTdkLyXRnxA"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03970512/persons-with-significant-control/corporate-entity/LY1DYZy-Toz3MdXuKzRuvpU6WhM"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01070807/persons-with-significant-control/corporate-entity/orStYcXT2gcnnZBZDmFNNieRhwE"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08698024/persons-with-significant-control/corporate-entity/Kx-xcWHRhp2amxBNrJNRO1us0XA"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/SC220767/persons-with-significant-control/corporate-entity/ccdw2kbNdtgtJBeLO1wTuev6DLU"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/ie/545333", "uri": "https://opencorporates.com/companies/ie/545333"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07546735/persons-with-significant-control/corporate-entity/1dNTl5IUTmc_0DNXMhBnm_ULomE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95d4a67e4ebf340fe527b", "uri": "http://register.openownership.org/entities/59b95d4a67e4ebf340fe527b"}], "foundingDate": "2014-06-12", "addresses": [{"type": "registered", "address": "20, LOWER HATCH STREET, DUBLIN 2., D02XH02", "country": "IE"}]}]
+[
+    {
+        "statementID": "openownership-register-12499612705305061226",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MEDTRONIC LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01070807"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01070807"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01070807",
+                "uri": "https://opencorporates.com/companies/gb/01070807"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba55799dfc3fae18e787b1",
+                "uri": "http://register.openownership.org/entities/5aba55799dfc3fae18e787b1"
+            }
+        ],
+        "foundingDate": "1972-09-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Building 9 Croxley Park, Hatters Lane, Watford, Hertfordshire, WD18 8WW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2664949553127466268",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12499612705305061226"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17704602379944595011"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17704602379944595011",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MEDTRONIC PUBLIC LIMITED COMPANY",
+        "incorporatedInJurisdiction": {
+            "name": "Ireland",
+            "code": "IE"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03122084/persons-with-significant-control/corporate-entity/8f3hPj4Mnlf7NFDdBXSq2te_1po"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03141707/persons-with-significant-control/corporate-entity/kzBf5MZ7R8_3FTMUmqMRgGkfXSQ"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02285007/persons-with-significant-control/corporate-entity/3Illp_pxHX7h1dfGHKleb-pyy-E"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01409596/persons-with-significant-control/corporate-entity/HnN6oWJlMwAhL6QkacFXdr_x9Bw"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02672650/persons-with-significant-control/corporate-entity/AaDS0ILdVh-NNdhG7pD1E4xeFsw"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06524642/persons-with-significant-control/corporate-entity/p-unPc3HMQMZWb3hZ_eUDU4Ze1I"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07162873/persons-with-significant-control/corporate-entity/10W8iQvJ7_4NY1Q1PTdkLyXRnxA"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03970512/persons-with-significant-control/corporate-entity/LY1DYZy-Toz3MdXuKzRuvpU6WhM"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01070807/persons-with-significant-control/corporate-entity/orStYcXT2gcnnZBZDmFNNieRhwE"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08698024/persons-with-significant-control/corporate-entity/Kx-xcWHRhp2amxBNrJNRO1us0XA"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/SC220767/persons-with-significant-control/corporate-entity/ccdw2kbNdtgtJBeLO1wTuev6DLU"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/ie/545333",
+                "uri": "https://opencorporates.com/companies/ie/545333"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07546735/persons-with-significant-control/corporate-entity/1dNTl5IUTmc_0DNXMhBnm_ULomE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95d4a67e4ebf340fe527b",
+                "uri": "http://register.openownership.org/entities/59b95d4a67e4ebf340fe527b"
+            }
+        ],
+        "foundingDate": "2014-06-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20, LOWER HATCH STREET, DUBLIN 2., D02XH02",
+                "country": "IE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01084535_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01084535_bods.json
@@ -1,1 +1,311 @@
-[{"statementID": "openownership-register-16807468737470862813", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SIGNPOST SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01084535"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01084535", "uri": "https://opencorporates.com/companies/gb/01084535"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9960b67e4ebf340fcfa98", "uri": "http://register.openownership.org/entities/59b9960b67e4ebf340fcfa98"}], "foundingDate": "1972-11-30", "addresses": [{"type": "registered", "address": "Westhaven House Arleston Way, Shirley, Solihull, West Midlands, B90 4LH", "country": "GB"}]}, {"statementID": "openownership-register-12880623680097925540", "statementType": "ownershipOrControlStatement", "statementDate": "2019-12-03", "subject": {"describedByEntityStatement": "openownership-register-16807468737470862813"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13500353556890485664"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-03"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-03"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-12-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-12-10T10:45:26Z"}}, {"statementID": "openownership-register-6353567795617818382", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16807468737470862813"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13443814005295362056"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-10-13"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-10-13"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2016-10-13"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06", "endDate": "2016-10-13"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3852027757332293914", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-13", "subject": {"describedByEntityStatement": "openownership-register-16807468737470862813"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17345000122087306643"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-10-13", "endDate": "2019-12-03"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-10-13", "endDate": "2019-12-03"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-10-13", "endDate": "2019-12-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-12-10T10:45:26Z"}}, {"statementID": "openownership-register-13500353556890485664", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Mallatite Limited", "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01084535/persons-with-significant-control/corporate-entity/jpP6Zr-8dgD_tP32_wE9vqFjA0M"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5def86729dfc3fae18efce30", "uri": "http://register.openownership.org/entities/5def86729dfc3fae18efce30"}], "addresses": [{"type": "registered", "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH"}]}, {"statementID": "openownership-register-17345000122087306643", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SWARCO UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754698"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754698"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754698"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02754698"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02754698", "uri": "https://opencorporates.com/companies/gb/02754698"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9313067e4ebf34033b1fb", "uri": "http://register.openownership.org/entities/59b9313067e4ebf34033b1fb"}], "foundingDate": "1992-10-09", "addresses": [{"type": "registered", "address": "1 Maxted Corner, Maxted Road, Hemel Hempstead Industrial Estate, Hemel Hempstead, HP2 7RA", "country": "GB"}]}, {"statementID": "openownership-register-13443814005295362056", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SIGNPOST SOLUTIONS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04594308"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04594308"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04594308", "uri": "https://opencorporates.com/companies/gb/04594308"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba0a2a9dfc3fae18528676", "uri": "http://register.openownership.org/entities/5aba0a2a9dfc3fae18528676"}], "foundingDate": "2002-11-19", "dissolutionDate": "2017-01-31", "addresses": [{"type": "registered", "address": "Unit 5 Clarendon Drive, The Parkway, Tipton, West Midlands, DY4 0QA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16807468737470862813",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SIGNPOST SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01084535"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01084535",
+                "uri": "https://opencorporates.com/companies/gb/01084535"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9960b67e4ebf340fcfa98",
+                "uri": "http://register.openownership.org/entities/59b9960b67e4ebf340fcfa98"
+            }
+        ],
+        "foundingDate": "1972-11-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Westhaven House Arleston Way, Shirley, Solihull, West Midlands, B90 4LH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12880623680097925540",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-12-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16807468737470862813"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13500353556890485664"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-03"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-03"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-12-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-12-10T10:45:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6353567795617818382",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16807468737470862813"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13443814005295362056"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-10-13"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-10-13"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2016-10-13"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06",
+                "endDate": "2016-10-13"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3852027757332293914",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-13",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16807468737470862813"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17345000122087306643"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-13",
+                "endDate": "2019-12-03"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-13",
+                "endDate": "2019-12-03"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-10-13",
+                "endDate": "2019-12-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-12-10T10:45:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13500353556890485664",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Mallatite Limited",
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01084535/persons-with-significant-control/corporate-entity/jpP6Zr-8dgD_tP32_wE9vqFjA0M"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5def86729dfc3fae18efce30",
+                "uri": "http://register.openownership.org/entities/5def86729dfc3fae18efce30"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17345000122087306643",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SWARCO UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754698"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754698"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754698"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02754698"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02754698",
+                "uri": "https://opencorporates.com/companies/gb/02754698"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9313067e4ebf34033b1fb",
+                "uri": "http://register.openownership.org/entities/59b9313067e4ebf34033b1fb"
+            }
+        ],
+        "foundingDate": "1992-10-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Maxted Corner, Maxted Road, Hemel Hempstead Industrial Estate, Hemel Hempstead, HP2 7RA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13443814005295362056",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SIGNPOST SOLUTIONS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04594308"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04594308"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04594308",
+                "uri": "https://opencorporates.com/companies/gb/04594308"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba0a2a9dfc3fae18528676",
+                "uri": "http://register.openownership.org/entities/5aba0a2a9dfc3fae18528676"
+            }
+        ],
+        "foundingDate": "2002-11-19",
+        "dissolutionDate": "2017-01-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 5 Clarendon Drive, The Parkway, Tipton, West Midlands, DY4 0QA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01096654_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01096654_bods.json
@@ -1,1 +1,164 @@
-[{"statementID": "openownership-register-5642018348323984043", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HAINENKO LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01096654"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01096654", "uri": "https://opencorporates.com/companies/gb/01096654"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b9d867e4ebf340828538", "uri": "http://register.openownership.org/entities/59b9b9d867e4ebf340828538"}], "foundingDate": "1973-02-16", "addresses": [{"type": "registered", "address": "284 Chase Road, London, N14 6HF", "country": "GB"}]}, {"statementID": "openownership-register-12532278687631890847", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5642018348323984043"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12189559353278164606"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-16121789243170392432", "statementType": "ownershipOrControlStatement", "statementDate": "2019-06-06", "subject": {"describedByEntityStatement": "openownership-register-5642018348323984043"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14261962281225172175"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2019-06-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-12189559353278164606", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Douglas Edward John Ashpole"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01096654/persons-with-significant-control/individual/2iwAEvkHgQRHGv1_qmnJfR5lNIQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b9d867e4ebf34082855e", "uri": "http://register.openownership.org/entities/59b9b9d867e4ebf34082855e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1932-11-01", "addresses": [{"address": "284 Chase Road, London, N14 6HF"}]}, {"statementID": "openownership-register-14261962281225172175", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Yao Changyin"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01096654/persons-with-significant-control/individual/MuShEPS-7HFOPNpa1C0-Dwpf0aQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5d7223a09dfc3fae18f04ae4", "uri": "http://register.openownership.org/entities/5d7223a09dfc3fae18f04ae4"}], "birthDate": "1972-08-01", "addresses": [{"address": "284 Chase Road, London, N14 6HF", "country": "CN"}]}]
+[
+    {
+        "statementID": "openownership-register-5642018348323984043",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HAINENKO LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01096654"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01096654",
+                "uri": "https://opencorporates.com/companies/gb/01096654"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b9d867e4ebf340828538",
+                "uri": "http://register.openownership.org/entities/59b9b9d867e4ebf340828538"
+            }
+        ],
+        "foundingDate": "1973-02-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "284 Chase Road, London, N14 6HF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12532278687631890847",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5642018348323984043"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12189559353278164606"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16121789243170392432",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-06-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5642018348323984043"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14261962281225172175"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-06-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12189559353278164606",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Douglas Edward John Ashpole"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01096654/persons-with-significant-control/individual/2iwAEvkHgQRHGv1_qmnJfR5lNIQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b9d867e4ebf34082855e",
+                "uri": "http://register.openownership.org/entities/59b9b9d867e4ebf34082855e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1932-11-01",
+        "addresses": [
+            {
+                "address": "284 Chase Road, London, N14 6HF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14261962281225172175",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Yao Changyin"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01096654/persons-with-significant-control/individual/MuShEPS-7HFOPNpa1C0-Dwpf0aQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5d7223a09dfc3fae18f04ae4",
+                "uri": "http://register.openownership.org/entities/5d7223a09dfc3fae18f04ae4"
+            }
+        ],
+        "birthDate": "1972-08-01",
+        "addresses": [
+            {
+                "address": "284 Chase Road, London, N14 6HF",
+                "country": "CN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01123045_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01123045_bods.json
@@ -1,1 +1,135 @@
-[{"statementID": "openownership-register-2592903823244249914", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "3M UNITED KINGDOM PUBLIC LIMITED COMPANY", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01123045"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01123045"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01123045"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01123045", "uri": "https://opencorporates.com/companies/gb/01123045"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cec567e4ebf340d12888", "uri": "http://register.openownership.org/entities/59b9cec567e4ebf340d12888"}], "foundingDate": "1973-07-17", "addresses": [{"type": "registered", "address": "3m Centre, Cain Road, Bracknell, Berkshire, RG12 8HT", "country": "GB"}]}, {"statementID": "openownership-register-1436628467429008531", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2592903823244249914"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5326772258577031885"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5326772258577031885", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "3M PRODUCTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01123347"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01123347"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01123347", "uri": "https://opencorporates.com/companies/gb/01123347"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cec767e4ebf340d12f0c", "uri": "http://register.openownership.org/entities/59b9cec767e4ebf340d12f0c"}], "foundingDate": "1973-07-18", "addresses": [{"type": "registered", "address": "3m Centre, Cain Road, Bracknell, Berkshire, RG12 8HT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2592903823244249914",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "3M UNITED KINGDOM PUBLIC LIMITED COMPANY",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01123045"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01123045"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01123045"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01123045",
+                "uri": "https://opencorporates.com/companies/gb/01123045"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cec567e4ebf340d12888",
+                "uri": "http://register.openownership.org/entities/59b9cec567e4ebf340d12888"
+            }
+        ],
+        "foundingDate": "1973-07-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3m Centre, Cain Road, Bracknell, Berkshire, RG12 8HT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1436628467429008531",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2592903823244249914"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5326772258577031885"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5326772258577031885",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "3M PRODUCTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01123347"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01123347"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01123347",
+                "uri": "https://opencorporates.com/companies/gb/01123347"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cec767e4ebf340d12f0c",
+                "uri": "http://register.openownership.org/entities/59b9cec767e4ebf340d12f0c"
+            }
+        ],
+        "foundingDate": "1973-07-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3m Centre, Cain Road, Bracknell, Berkshire, RG12 8HT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01132885_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01132885_bods.json
@@ -1,1 +1,130 @@
-[{"statementID": "openownership-register-4990606606035353058", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KONICA MINOLTA BUSINESS SOLUTIONS (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01132885"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01132885", "uri": "https://opencorporates.com/companies/gb/01132885"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a9967e4ebf34060cfb8", "uri": "http://register.openownership.org/entities/59b93a9967e4ebf34060cfb8"}], "foundingDate": "1973-09-06", "addresses": [{"type": "registered", "address": "Konica House, Miles Gray Road, Basildon, Essex.,, SS14 3AR", "country": "GB"}]}, {"statementID": "openownership-register-11457405398976650151", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4990606606035353058"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13765493510809101634"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13765493510809101634", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Konica Minolta Incorporated", "incorporatedInJurisdiction": {"name": "Japan", "code": "JP"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01132885/persons-with-significant-control/corporate-entity/Jg8ZDKpCsp4lOrM063DIfWoNR7I"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96afe67e4ebf3404079b0", "uri": "http://register.openownership.org/entities/59b96afe67e4ebf3404079b0"}], "addresses": [{"type": "registered", "address": "Jp Tower, 2-7-2 Marunouchi, Chiyoda-Ku, Tokyo 100-7015", "country": "JP"}]}]
+[
+    {
+        "statementID": "openownership-register-4990606606035353058",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KONICA MINOLTA BUSINESS SOLUTIONS (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01132885"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01132885",
+                "uri": "https://opencorporates.com/companies/gb/01132885"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a9967e4ebf34060cfb8",
+                "uri": "http://register.openownership.org/entities/59b93a9967e4ebf34060cfb8"
+            }
+        ],
+        "foundingDate": "1973-09-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Konica House, Miles Gray Road, Basildon, Essex.,, SS14 3AR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11457405398976650151",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4990606606035353058"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13765493510809101634"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13765493510809101634",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Konica Minolta Incorporated",
+        "incorporatedInJurisdiction": {
+            "name": "Japan",
+            "code": "JP"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01132885/persons-with-significant-control/corporate-entity/Jg8ZDKpCsp4lOrM063DIfWoNR7I"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96afe67e4ebf3404079b0",
+                "uri": "http://register.openownership.org/entities/59b96afe67e4ebf3404079b0"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Jp Tower, 2-7-2 Marunouchi, Chiyoda-Ku, Tokyo 100-7015",
+                "country": "JP"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01189836_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01189836_bods.json
@@ -1,1 +1,183 @@
-[{"statementID": "openownership-register-16675071395240509387", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STANNAH LIFTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01189836"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01189836", "uri": "https://opencorporates.com/companies/gb/01189836"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93f2c67e4ebf34075a821", "uri": "http://register.openownership.org/entities/59b93f2c67e4ebf34075a821"}], "foundingDate": "1974-11-07", "addresses": [{"type": "registered", "address": "Watt Close, East Portway, Andover, Hampshire, SP10 3SD", "country": "GB"}]}, {"statementID": "openownership-register-15084152428264343689", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16675071395240509387"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17801542654977391440"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17801542654977391440", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STANNAH LIFTS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00686996"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00686996", "uri": "https://opencorporates.com/companies/gb/00686996"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93f1167e4ebf340751f3c", "uri": "http://register.openownership.org/entities/59b93f1167e4ebf340751f3c"}], "foundingDate": "1961-03-20", "addresses": [{"type": "registered", "address": "Watt Close, East Portway, Andover, Hampshire, SP10 3SD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16675071395240509387",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STANNAH LIFTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01189836"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01189836",
+                "uri": "https://opencorporates.com/companies/gb/01189836"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93f2c67e4ebf34075a821",
+                "uri": "http://register.openownership.org/entities/59b93f2c67e4ebf34075a821"
+            }
+        ],
+        "foundingDate": "1974-11-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Watt Close, East Portway, Andover, Hampshire, SP10 3SD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15084152428264343689",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16675071395240509387"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17801542654977391440"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17801542654977391440",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STANNAH LIFTS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00686996"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00686996",
+                "uri": "https://opencorporates.com/companies/gb/00686996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93f1167e4ebf340751f3c",
+                "uri": "http://register.openownership.org/entities/59b93f1167e4ebf340751f3c"
+            }
+        ],
+        "foundingDate": "1961-03-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Watt Close, East Portway, Andover, Hampshire, SP10 3SD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01233447_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01233447_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-2803404044275772433", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HILSON MORAN PARTNERSHIP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01233447"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01233447", "uri": "https://opencorporates.com/companies/gb/01233447"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c51767e4ebf340ae2827", "uri": "http://register.openownership.org/entities/59b9c51767e4ebf340ae2827"}], "foundingDate": "1975-11-13", "addresses": [{"type": "registered", "address": "One Discovery Place Columbus Drive, Southwood West, Farnborough, Hampshire, GU14 0NZ", "country": "GB"}]}, {"statementID": "openownership-register-15132941004519020457", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2803404044275772433"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11098677032159811389"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11098677032159811389", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HILSON MORAN HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07735466"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07735466"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07735466", "uri": "https://opencorporates.com/companies/gb/07735466"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e8167e4ebf340277bab", "uri": "http://register.openownership.org/entities/59b92e8167e4ebf340277bab"}], "foundingDate": "2011-08-10", "addresses": [{"type": "registered", "address": "One Discovery Place, Columbus Drive, Farnborough, Hampshire, GU14 0NZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2803404044275772433",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HILSON MORAN PARTNERSHIP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01233447"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01233447",
+                "uri": "https://opencorporates.com/companies/gb/01233447"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c51767e4ebf340ae2827",
+                "uri": "http://register.openownership.org/entities/59b9c51767e4ebf340ae2827"
+            }
+        ],
+        "foundingDate": "1975-11-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Discovery Place Columbus Drive, Southwood West, Farnborough, Hampshire, GU14 0NZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15132941004519020457",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2803404044275772433"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11098677032159811389"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11098677032159811389",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HILSON MORAN HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07735466"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07735466"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07735466",
+                "uri": "https://opencorporates.com/companies/gb/07735466"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e8167e4ebf340277bab",
+                "uri": "http://register.openownership.org/entities/59b92e8167e4ebf340277bab"
+            }
+        ],
+        "foundingDate": "2011-08-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Discovery Place, Columbus Drive, Farnborough, Hampshire, GU14 0NZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01243441_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01243441_bods.json
@@ -1,1 +1,130 @@
-[{"statementID": "openownership-register-16125129160736724526", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PRICE WESTERN LEATHER COMPANY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01243441"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01243441", "uri": "https://opencorporates.com/companies/gb/01243441"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9317067e4ebf34034fc9b", "uri": "http://register.openownership.org/entities/59b9317067e4ebf34034fc9b"}], "foundingDate": "1976-02-06", "addresses": [{"type": "registered", "address": "Ponsford Road Works, Ponsford Road, Minehead, Somerset, TA24 5DX", "country": "GB"}]}, {"statementID": "openownership-register-15819376309379914103", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-16125129160736724526"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11366283131241866429"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11366283131241866429", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JJL HOLDING CO LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06426349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06426349"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06426349", "uri": "https://opencorporates.com/companies/gb/06426349"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9317067e4ebf34034ff8c", "uri": "http://register.openownership.org/entities/59b9317067e4ebf34034ff8c"}], "foundingDate": "2007-11-13", "addresses": [{"type": "registered", "address": "Broughton Lodge Mews, Field Broughton, Grange-Over-Sands, Cumbria, LA11 6HL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16125129160736724526",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PRICE WESTERN LEATHER COMPANY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243441"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01243441",
+                "uri": "https://opencorporates.com/companies/gb/01243441"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9317067e4ebf34034fc9b",
+                "uri": "http://register.openownership.org/entities/59b9317067e4ebf34034fc9b"
+            }
+        ],
+        "foundingDate": "1976-02-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ponsford Road Works, Ponsford Road, Minehead, Somerset, TA24 5DX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15819376309379914103",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16125129160736724526"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11366283131241866429"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11366283131241866429",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JJL HOLDING CO LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06426349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06426349"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06426349",
+                "uri": "https://opencorporates.com/companies/gb/06426349"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9317067e4ebf34034ff8c",
+                "uri": "http://register.openownership.org/entities/59b9317067e4ebf34034ff8c"
+            }
+        ],
+        "foundingDate": "2007-11-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Broughton Lodge Mews, Field Broughton, Grange-Over-Sands, Cumbria, LA11 6HL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01243967_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01243967_bods.json
@@ -1,1056 +1,1056 @@
 [
-  {
-    "statementID": "openownership-register-12412166931884434028",
-    "statementType": "entityStatement",
-    "entityType": "registeredEntity",
-    "name": "MOTT MACDONALD LIMITED",
-    "incorporatedInJurisdiction": {
-      "name": "United Kingdom of Great Britain and Northern Ireland",
-      "code": "GB"
-    },
-    "identifiers": [
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01243967"
-      },
-      {
-        "schemeName": "OpenCorporates",
-        "id": "https://opencorporates.com/companies/gb/01243967",
-        "uri": "https://opencorporates.com/companies/gb/01243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1243967"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "01243967"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/59b923d767e4ebf340f755e5",
-        "uri": "http://register.openownership.org/entities/59b923d767e4ebf340f755e5"
-      }
-    ],
-    "foundingDate": "1976-02-11",
-    "addresses": [
-      {
-        "type": "registered",
-        "address": "Mott Macdonald House, 8-10 Sydenham Road, Croydon, Surrey, CR0 2EE",
-        "country": "GB"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-13416259708579999790",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-05-09",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByEntityStatement": "openownership-register-8272585305242789906"
-    },
-    "interests": [
-      {
-        "type": "shareholding",
-        "details": "ownership-of-shares-75-to-100-percent",
-        "share": {
-          "minimum": 75,
-          "maximum": 100,
-          "exclusiveMinimum": false,
-          "exclusiveMaximum": false
+    {
+        "statementID": "openownership-register-12412166931884434028",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MOTT MACDONALD LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
         },
-        "startDate": "2017-05-09"
-      }
-    ],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "GB Persons Of Significant Control Register",
-      "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
-      "retrievedAt": "2019-07-08T10:37:11Z"
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01243967"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01243967",
+                "uri": "https://opencorporates.com/companies/gb/01243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1243967"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "01243967"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b923d767e4ebf340f755e5",
+                "uri": "http://register.openownership.org/entities/59b923d767e4ebf340f755e5"
+            }
+        ],
+        "foundingDate": "1976-02-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Mott Macdonald House, 8-10 Sydenham Road, Croydon, Surrey, CR0 2EE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13416259708579999790",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-09",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8272585305242789906"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-05-09"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-709183127545527059",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-362652536092605588"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5608728347821584355",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10447218472470648696"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-981050694837409662",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-149814307409698796"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14464599896469742875",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13686190153104578487"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12653215739039427433",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8567263034979970504"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1028261758000190613",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2509655900434586632"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3996166786602668766",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4654948816767308256"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6317241322484341036",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-12-28",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6008205498718995750"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10454667785720218283",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-12-28",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12412166931884434028"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17162336046308620048"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8272585305242789906",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MOTT MACDONALD GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01110949"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01110949",
+                "uri": "https://opencorporates.com/companies/gb/01110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1110949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92f4367e4ebf3402b67f7",
+                "uri": "http://register.openownership.org/entities/59b92f4367e4ebf3402b67f7"
+            }
+        ],
+        "foundingDate": "1973-04-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Mott Macdonald House, 8-10 Sydenham Road, Croydon, Surrey, CR0 2EE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-362652536092605588",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michael David Haigh"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24139"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24139"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea320",
+                "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea320"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "122 St Katherine\u00b4s Way, London, W1W 5BB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10447218472470648696",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Keith John Howells"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24140"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24140"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea359",
+                "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea359"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "Flat 49 Anchor Brewhouse, London, W1W 5BB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-149814307409698796",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Guy William Ingledew Leonard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24141"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24141"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea387",
+                "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea387"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "Greycourt, Dunmow Hill, GU51 3 AN, Fleet, Hampshire"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13686190153104578487",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Edwin George Roud"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24142"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24142"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea3b7",
+                "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea3b7"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "Stone Court Farm, Biddenden road, TN17 2 BE, Frittenden, Kent"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8567263034979970504",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Joanna Maria Field"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24143"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24143"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea3e3",
+                "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea3e3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "7 East Street, Rusper, RH12 4 RB, Horsham, West Sussex"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2509655900434586632",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Paul Edward Ferguson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24144"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24144"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea41b",
+                "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea41b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "\"Seers Croft\", Faygate Lane, Rusper, RH12 4SN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4654948816767308256",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Nicholas Mauro DeNichilo"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "24145"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "24145"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea452",
+                "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea452"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United States of America",
+                "code": "US"
+            }
+        ],
+        "addresses": [
+            {
+                "address": "16 Marion Lane, Scotch Plains, New Jersey, 07076"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6008205498718995750",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Edwin George Roud"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "95117"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "95117"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f0a",
+                "uri": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f0a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-09-29",
+        "addresses": [
+            {
+                "address": "Stone Court Farm, Biddenden Road, Frittenden, Kent, TN17 2BE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17162336046308620048",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Guy William Ingledew Leonard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "95118"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "95118"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f24",
+                "uri": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f24"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-11-19",
+        "addresses": [
+            {
+                "address": "13 Greycourt, Dunmow Hill, Fleet, Hampshire, GU51 3AN"
+            }
+        ]
     }
-  },
-  {
-    "statementID": "openownership-register-709183127545527059",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-362652536092605588"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-5608728347821584355",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-10447218472470648696"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-981050694837409662",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-149814307409698796"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-14464599896469742875",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-13686190153104578487"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-12653215739039427433",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-8567263034979970504"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-1028261758000190613",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-2509655900434586632"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-3996166786602668766",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-02-01",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-4654948816767308256"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-6317241322484341036",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-12-28",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-6008205498718995750"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-10454667785720218283",
-    "statementType": "ownershipOrControlStatement",
-    "statementDate": "2017-12-28",
-    "subject": {
-      "describedByEntityStatement": "openownership-register-12412166931884434028"
-    },
-    "interestedParty": {
-      "describedByPersonStatement": "openownership-register-17162336046308620048"
-    },
-    "interests": [],
-    "source": {
-      "type": [
-        "officialRegister"
-      ],
-      "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
-      "url": "https://rpvs.gov.sk/",
-      "retrievedAt": "2019-11-04T10:52:49Z"
-    }
-  },
-  {
-    "statementID": "openownership-register-8272585305242789906",
-    "statementType": "entityStatement",
-    "entityType": "registeredEntity",
-    "name": "MOTT MACDONALD GROUP LIMITED",
-    "incorporatedInJurisdiction": {
-      "name": "United Kingdom of Great Britain and Northern Ireland",
-      "code": "GB"
-    },
-    "identifiers": [
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "01110949"
-      },
-      {
-        "schemeName": "OpenCorporates",
-        "id": "https://opencorporates.com/companies/gb/01110949",
-        "uri": "https://opencorporates.com/companies/gb/01110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House",
-        "id": "1110949"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "scheme": "GB-COH",
-        "schemeName": "Companies House"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/59b92f4367e4ebf3402b67f7",
-        "uri": "http://register.openownership.org/entities/59b92f4367e4ebf3402b67f7"
-      }
-    ],
-    "foundingDate": "1973-04-30",
-    "addresses": [
-      {
-        "type": "registered",
-        "address": "Mott Macdonald House, 8-10 Sydenham Road, Croydon, Surrey, CR0 2EE",
-        "country": "GB"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-362652536092605588",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Michael David Haigh"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24139"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24139"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea320",
-        "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea320"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "122 St Katherine\u00b4s Way, London, W1W 5BB"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-10447218472470648696",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Keith John Howells"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24140"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24140"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea359",
-        "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea359"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "Flat 49 Anchor Brewhouse, London, W1W 5BB"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-149814307409698796",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Guy William Ingledew Leonard"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24141"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24141"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea387",
-        "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea387"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "Greycourt, Dunmow Hill, GU51 3 AN, Fleet, Hampshire"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-13686190153104578487",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Edwin George Roud"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24142"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24142"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea3b7",
-        "uri": "http://register.openownership.org/entities/5dc0078a9dfc3fae187ea3b7"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "Stone Court Farm, Biddenden road, TN17 2 BE, Frittenden, Kent"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-8567263034979970504",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Joanna Maria Field"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24143"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24143"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea3e3",
-        "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea3e3"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "7 East Street, Rusper, RH12 4 RB, Horsham, West Sussex"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-2509655900434586632",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Paul Edward Ferguson"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24144"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24144"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea41b",
-        "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea41b"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "\"Seers Croft\", Faygate Lane, Rusper, RH12 4SN"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-4654948816767308256",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Nicholas Mauro DeNichilo"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "24145"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "24145"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea452",
-        "uri": "http://register.openownership.org/entities/5dc0078b9dfc3fae187ea452"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United States of America",
-        "code": "US"
-      }
-    ],
-    "addresses": [
-      {
-        "address": "16 Marion Lane, Scotch Plains, New Jersey, 07076"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-6008205498718995750",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Edwin George Roud"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "95117"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "95117"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f0a",
-        "uri": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f0a"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "birthDate": "1963-09-29",
-    "addresses": [
-      {
-        "address": "Stone Court Farm, Biddenden Road, Frittenden, Kent, TN17 2BE"
-      }
-    ]
-  },
-  {
-    "statementID": "openownership-register-17162336046308620048",
-    "statementType": "personStatement",
-    "personType": "knownPerson",
-    "names": [
-      {
-        "type": "individual",
-        "fullName": "Guy William Ingledew Leonard"
-      }
-    ],
-    "identifiers": [
-      {
-        "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
-        "id": "95118"
-      },
-      {
-        "scheme": "MISC-Slovakia PSP Register",
-        "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
-        "id": "95118"
-      },
-      {
-        "schemeName": "OpenOwnership Register",
-        "id": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f24",
-        "uri": "http://register.openownership.org/entities/5dc00d179dfc3fae18866f24"
-      }
-    ],
-    "nationalities": [
-      {
-        "name": "United Kingdom of Great Britain and Northern Ireland",
-        "code": "GB"
-      }
-    ],
-    "birthDate": "1955-11-19",
-    "addresses": [
-      {
-        "address": "13 Greycourt, Dunmow Hill, Fleet, Hampshire, GU51 3AN"
-      }
-    ]
-  }
 ]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01269836_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01269836_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-13106034932330973312", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WESSEX LIFT CO LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01269836"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01269836", "uri": "https://opencorporates.com/companies/gb/01269836"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec71", "uri": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec71"}], "foundingDate": "1976-07-21", "addresses": [{"type": "registered", "address": "No 38 The Maltings No 38 The Malting Business Centre, The Maltings, Stanstead Abbotts, Herts, SG12 8HG", "country": "GB"}]}, {"statementID": "openownership-register-13685537761390889248", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-01", "subject": {"describedByEntityStatement": "openownership-register-13106034932330973312"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14973362371849072357"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-06T11:44:23Z"}}, {"statementID": "openownership-register-14973362371849072357", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Ratcliff"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01269836/persons-with-significant-control/individual/tvbKY3jZ2pntXmBKsda3KYYcYHc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec88", "uri": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec88"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1935-06-01", "addresses": [{"address": "No 38 The Maltings, No 38 The Malting Business Centre, The Maltings, Stanstead Abbotts, Herts, SG12 8HG"}]}]
+[
+    {
+        "statementID": "openownership-register-13106034932330973312",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WESSEX LIFT CO LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01269836"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01269836",
+                "uri": "https://opencorporates.com/companies/gb/01269836"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec71",
+                "uri": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec71"
+            }
+        ],
+        "foundingDate": "1976-07-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "No 38 The Maltings No 38 The Malting Business Centre, The Maltings, Stanstead Abbotts, Herts, SG12 8HG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13685537761390889248",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13106034932330973312"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14973362371849072357"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-06T11:44:23Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14973362371849072357",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Ratcliff"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01269836/persons-with-significant-control/individual/tvbKY3jZ2pntXmBKsda3KYYcYHc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec88",
+                "uri": "http://register.openownership.org/entities/59b9c83c67e4ebf340b8ec88"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1935-06-01",
+        "addresses": [
+            {
+                "address": "No 38 The Maltings, No 38 The Malting Business Centre, The Maltings, Stanstead Abbotts, Herts, SG12 8HG"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01324925_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01324925_bods.json
@@ -1,1 +1,235 @@
-[{"statementID": "openownership-register-934378333706848254", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INSTARMAC GROUP PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01324925"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01324925", "uri": "https://opencorporates.com/companies/gb/01324925"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b62", "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b62"}], "foundingDate": "1977-08-10", "addresses": [{"type": "registered", "address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE", "country": "GB"}]}, {"statementID": "openownership-register-6209296181412301419", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-934378333706848254"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14984666176983959024"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-trust", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17737689235627197752", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-934378333706848254"}, "interestedParty": {"describedByPersonStatement": "openownership-register-529915453268623662"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-trust", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4959483087715707871", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-934378333706848254"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6881329244549050179"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-trust", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14984666176983959024", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jacqueline Sandra Hudson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01324925/persons-with-significant-control/individual/BreiewFezGepM0BnrrIv_L142s0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c6d", "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c6d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-06-01", "addresses": [{"address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"}]}, {"statementID": "openownership-register-529915453268623662", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Keith Leslie Peters"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01324925/persons-with-significant-control/individual/E81ocrNrCCTAkwIseU2CvnAqrzE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b6f", "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b6f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-02-01", "addresses": [{"address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"}]}, {"statementID": "openownership-register-6881329244549050179", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Anthony Holcroft"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01324925/persons-with-significant-control/individual/NQi9o_iaW2h2Lvc3wMuNbI8yU0Y"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c7e", "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c7e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-07-01", "addresses": [{"address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"}]}]
+[
+    {
+        "statementID": "openownership-register-934378333706848254",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INSTARMAC GROUP PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01324925"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01324925",
+                "uri": "https://opencorporates.com/companies/gb/01324925"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b62",
+                "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b62"
+            }
+        ],
+        "foundingDate": "1977-08-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6209296181412301419",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-934378333706848254"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14984666176983959024"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-trust",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17737689235627197752",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-934378333706848254"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-529915453268623662"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-trust",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4959483087715707871",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-934378333706848254"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6881329244549050179"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-trust",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14984666176983959024",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jacqueline Sandra Hudson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01324925/persons-with-significant-control/individual/BreiewFezGepM0BnrrIv_L142s0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c6d",
+                "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c6d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-06-01",
+        "addresses": [
+            {
+                "address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-529915453268623662",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Keith Leslie Peters"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01324925/persons-with-significant-control/individual/E81ocrNrCCTAkwIseU2CvnAqrzE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b6f",
+                "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1b6f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-02-01",
+        "addresses": [
+            {
+                "address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6881329244549050179",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Anthony Holcroft"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01324925/persons-with-significant-control/individual/NQi9o_iaW2h2Lvc3wMuNbI8yU0Y"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c7e",
+                "uri": "http://register.openownership.org/entities/59b952a067e4ebf340cc1c7e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-07-01",
+        "addresses": [
+            {
+                "address": "Danny Morson Way, Birch Coppice Business Park, Dordon, Tamworth, Staffs, B78 1SE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01383511_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01383511_bods.json
@@ -1,1 +1,138 @@
-[{"statementID": "openownership-register-16550674300497556751", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WSP UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01383511"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01383511", "uri": "https://opencorporates.com/companies/gb/01383511"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e98e", "uri": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e98e"}], "foundingDate": "1978-08-11", "addresses": [{"type": "registered", "address": "Wsp House, 70 Chancery Lane, London, WC2A 1AF", "country": "GB"}]}, {"statementID": "openownership-register-15116312190390628916", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16550674300497556751"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8941219148148058300"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8941219148148058300", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Wsp Group Holding Ab", "incorporatedInJurisdiction": {"name": "Sweden", "code": "SE"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01383511/persons-with-significant-control/corporate-entity/_INGiMeayP4dp01bKcVLhVqNwxw"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/se/556874-1705", "uri": "https://opencorporates.com/companies/se/556874-1705"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e994", "uri": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e994"}], "addresses": [{"type": "registered", "address": "Arenavagen 7, 121 88, Stockholm-Globen", "country": "SE"}]}]
+[
+    {
+        "statementID": "openownership-register-16550674300497556751",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WSP UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01383511"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01383511",
+                "uri": "https://opencorporates.com/companies/gb/01383511"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e98e",
+                "uri": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e98e"
+            }
+        ],
+        "foundingDate": "1978-08-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Wsp House, 70 Chancery Lane, London, WC2A 1AF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15116312190390628916",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16550674300497556751"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8941219148148058300"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8941219148148058300",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Wsp Group Holding Ab",
+        "incorporatedInJurisdiction": {
+            "name": "Sweden",
+            "code": "SE"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01383511/persons-with-significant-control/corporate-entity/_INGiMeayP4dp01bKcVLhVqNwxw"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/se/556874-1705",
+                "uri": "https://opencorporates.com/companies/se/556874-1705"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e994",
+                "uri": "http://register.openownership.org/entities/59b9c6b867e4ebf340b3e994"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Arenavagen 7, 121 88, Stockholm-Globen",
+                "country": "SE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01428210_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01428210_bods.json
@@ -1,1 +1,175 @@
-[{"statementID": "openownership-register-13879849984851914088", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SPECIALIST COMPUTER CENTRES PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01428210", "uri": "https://opencorporates.com/companies/gb/01428210"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01428210"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92f5e67e4ebf3402bf18f", "uri": "http://register.openownership.org/entities/59b92f5e67e4ebf3402bf18f"}], "foundingDate": "1979-06-12", "addresses": [{"type": "registered", "address": "James House, Warwick Road, Birmingham, B11 2LE", "country": "GB"}]}, {"statementID": "openownership-register-8248021722467363580", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13879849984851914088"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1583431076884699635"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1583431076884699635", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SCC UK HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01160482", "uri": "https://opencorporates.com/companies/gb/01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01160482"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92f3367e4ebf3402b0eca", "uri": "http://register.openownership.org/entities/59b92f3367e4ebf3402b0eca"}], "foundingDate": "1974-02-18", "addresses": [{"type": "registered", "address": "James House, Warwick Road, Birmingham, B11 2LE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13879849984851914088",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SPECIALIST COMPUTER CENTRES PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01428210",
+                "uri": "https://opencorporates.com/companies/gb/01428210"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01428210"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92f5e67e4ebf3402bf18f",
+                "uri": "http://register.openownership.org/entities/59b92f5e67e4ebf3402bf18f"
+            }
+        ],
+        "foundingDate": "1979-06-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "James House, Warwick Road, Birmingham, B11 2LE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8248021722467363580",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13879849984851914088"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1583431076884699635"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1583431076884699635",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SCC UK HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01160482",
+                "uri": "https://opencorporates.com/companies/gb/01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01160482"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92f3367e4ebf3402b0eca",
+                "uri": "http://register.openownership.org/entities/59b92f3367e4ebf3402b0eca"
+            }
+        ],
+        "foundingDate": "1974-02-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "James House, Warwick Road, Birmingham, B11 2LE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01442431_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01442431_bods.json
@@ -1,1 +1,113 @@
-[{"statementID": "openownership-register-718205271537256273", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BIOTRONIK U.K. LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01442431"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01442431", "uri": "https://opencorporates.com/companies/gb/01442431"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea5d", "uri": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea5d"}], "foundingDate": "1979-08-08", "addresses": [{"type": "registered", "address": "Biotronik House, Avonbury Business Park, Bicester, Oxfordshire, OX26 2UA", "country": "GB"}]}, {"statementID": "openownership-register-7743782702787622287", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-718205271537256273"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2344645658060870937"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-06-30"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2344645658060870937", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "International Biotronik Beteiligungs Kg Bt Verwaltungs Gmbh", "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01442431/persons-with-significant-control/corporate-entity/pBmlgkZuTfLO5c5e5CJ4yjfqnaI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea68", "uri": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea68"}], "addresses": [{"type": "registered", "address": "1, Woermannkehre, Berlin"}]}]
+[
+    {
+        "statementID": "openownership-register-718205271537256273",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BIOTRONIK U.K. LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01442431"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01442431",
+                "uri": "https://opencorporates.com/companies/gb/01442431"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea5d",
+                "uri": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea5d"
+            }
+        ],
+        "foundingDate": "1979-08-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Biotronik House, Avonbury Business Park, Bicester, Oxfordshire, OX26 2UA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7743782702787622287",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-718205271537256273"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2344645658060870937"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2344645658060870937",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "International Biotronik Beteiligungs Kg Bt Verwaltungs Gmbh",
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01442431/persons-with-significant-control/corporate-entity/pBmlgkZuTfLO5c5e5CJ4yjfqnaI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea68",
+                "uri": "http://register.openownership.org/entities/59b98b8067e4ebf340d7ea68"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1, Woermannkehre, Berlin"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01623146_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01623146_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-3906713934552393104", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MANGAR INTERNATIONAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01623146"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01623146", "uri": "https://opencorporates.com/companies/gb/01623146"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d2b567e4ebf340dfc1f9", "uri": "http://register.openownership.org/entities/59b9d2b567e4ebf340dfc1f9"}], "foundingDate": "1982-03-19", "addresses": [{"type": "registered", "address": "Presteigne, Powys, LD8 2UF", "country": "GB"}]}, {"statementID": "openownership-register-7055110416884687046", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3906713934552393104"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7787150357561173227"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7787150357561173227", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MANGAR INTERNATIONAL (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04493857"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04493857"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04493857"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04493857", "uri": "https://opencorporates.com/companies/gb/04493857"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93abf67e4ebf3406184f8", "uri": "http://register.openownership.org/entities/59b93abf67e4ebf3406184f8"}], "foundingDate": "2002-07-24", "addresses": [{"type": "registered", "address": "2nd Floor Padmore House Hall Court, Hall Park Way, Town Centre, Telford, England, TF3 4LX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3906713934552393104",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MANGAR INTERNATIONAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01623146"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01623146",
+                "uri": "https://opencorporates.com/companies/gb/01623146"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d2b567e4ebf340dfc1f9",
+                "uri": "http://register.openownership.org/entities/59b9d2b567e4ebf340dfc1f9"
+            }
+        ],
+        "foundingDate": "1982-03-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Presteigne, Powys, LD8 2UF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7055110416884687046",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3906713934552393104"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7787150357561173227"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7787150357561173227",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MANGAR INTERNATIONAL (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04493857"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04493857"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04493857"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04493857",
+                "uri": "https://opencorporates.com/companies/gb/04493857"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93abf67e4ebf3406184f8",
+                "uri": "http://register.openownership.org/entities/59b93abf67e4ebf3406184f8"
+            }
+        ],
+        "foundingDate": "2002-07-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2nd Floor Padmore House Hall Court, Hall Park Way, Town Centre, Telford, England, TF3 4LX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01644241_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01644241_bods.json
@@ -1,1 +1,97 @@
-[{"statementID": "openownership-register-1517892930083515990", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PERTEMPS RECRUITMENT PARTNERSHIP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01644241"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01644241", "uri": "https://opencorporates.com/companies/gb/01644241"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9405167e4ebf3407b0685", "uri": "http://register.openownership.org/entities/59b9405167e4ebf3407b0685"}], "foundingDate": "1982-06-17", "addresses": [{"type": "registered", "address": "Meriden Hall, Main Road, Meriden, Warwickshire, CV7 7PT", "country": "GB"}]}, {"statementID": "openownership-register-7552622028874956876", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-08", "subject": {"describedByEntityStatement": "openownership-register-1517892930083515990"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16528430912259203198"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-09-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16528430912259203198", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tim Watts"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04012218/persons-with-significant-control/individual/RCqyyzxmu-NMWcFiHqxxaDMKy-0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91a5f67e4ebf340d5e8e2", "uri": "http://register.openownership.org/entities/59b91a5f67e4ebf340d5e8e2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1949-09-01", "addresses": [{"address": "Meriden Hall, Main Road, Meriden, Warwickshire, CV7 7PT"}]}]
+[
+    {
+        "statementID": "openownership-register-1517892930083515990",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PERTEMPS RECRUITMENT PARTNERSHIP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01644241"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01644241",
+                "uri": "https://opencorporates.com/companies/gb/01644241"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9405167e4ebf3407b0685",
+                "uri": "http://register.openownership.org/entities/59b9405167e4ebf3407b0685"
+            }
+        ],
+        "foundingDate": "1982-06-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Meriden Hall, Main Road, Meriden, Warwickshire, CV7 7PT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7552622028874956876",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-08",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1517892930083515990"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16528430912259203198"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-09-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16528430912259203198",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tim Watts"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04012218/persons-with-significant-control/individual/RCqyyzxmu-NMWcFiHqxxaDMKy-0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91a5f67e4ebf340d5e8e2",
+                "uri": "http://register.openownership.org/entities/59b91a5f67e4ebf340d5e8e2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1949-09-01",
+        "addresses": [
+            {
+                "address": "Meriden Hall, Main Road, Meriden, Warwickshire, CV7 7PT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01683339_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01683339_bods.json
@@ -1,1 +1,98 @@
-[{"statementID": "openownership-register-5358955263063167580", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TERRY GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01683339"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01683339", "uri": "https://opencorporates.com/companies/gb/01683339"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9751f67e4ebf34072a650", "uri": "http://register.openownership.org/entities/59b9751f67e4ebf34072a650"}], "foundingDate": "1982-12-02", "addresses": [{"type": "registered", "address": "1 Longridge Trading Estate, Knutsford, Cheshire, WA16 8PR", "country": "GB"}]}, {"statementID": "openownership-register-7653167092824433937", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5358955263063167580"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7359153696972719072"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7359153696972719072", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter Morrey"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04949477/persons-with-significant-control/individual/A7KXEez5zhEL-C_vGOmq-VhYdXw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9560267e4ebf340dc084a", "uri": "http://register.openownership.org/entities/59b9560267e4ebf340dc084a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1947-05-01", "addresses": [{"address": "1 Longridge Trading Estate, Knutsford, Cheshire, WA16 8PR", "country": "GG"}]}]
+[
+    {
+        "statementID": "openownership-register-5358955263063167580",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TERRY GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01683339"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01683339",
+                "uri": "https://opencorporates.com/companies/gb/01683339"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9751f67e4ebf34072a650",
+                "uri": "http://register.openownership.org/entities/59b9751f67e4ebf34072a650"
+            }
+        ],
+        "foundingDate": "1982-12-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Longridge Trading Estate, Knutsford, Cheshire, WA16 8PR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7653167092824433937",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5358955263063167580"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7359153696972719072"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7359153696972719072",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter Morrey"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04949477/persons-with-significant-control/individual/A7KXEez5zhEL-C_vGOmq-VhYdXw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9560267e4ebf340dc084a",
+                "uri": "http://register.openownership.org/entities/59b9560267e4ebf340dc084a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1947-05-01",
+        "addresses": [
+            {
+                "address": "1 Longridge Trading Estate, Knutsford, Cheshire, WA16 8PR",
+                "country": "GG"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01738371_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01738371_bods.json
@@ -1,1 +1,160 @@
-[{"statementID": "openownership-register-17046275416402427893", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ENGIE REGENERATION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01738371", "uri": "https://opencorporates.com/companies/gb/01738371"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01738371"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98ca567e4ebf340dc381f", "uri": "http://register.openownership.org/entities/59b98ca567e4ebf340dc381f"}], "foundingDate": "1983-07-11", "addresses": [{"type": "registered", "address": "Shared Services Centre, Q3 Office Quorum Business Park, Benton Lane, Newcastle Upon Tyne, NE12 8EX", "country": "GB"}]}, {"statementID": "openownership-register-12320650087730830032", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17046275416402427893"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3649209501846024425"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3649209501846024425", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ENGIE REGENERATION HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08514907"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08514907"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08514907"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08514907"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08514907", "uri": "https://opencorporates.com/companies/gb/08514907"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b965f167e4ebf340269d95", "uri": "http://register.openownership.org/entities/59b965f167e4ebf340269d95"}], "foundingDate": "2013-05-02", "addresses": [{"type": "registered", "address": "Shared Services Centre, Q3 Office Quorum Business Park, Benton Lane, Newcastle Upon Tyne, NE12 8EX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17046275416402427893",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ENGIE REGENERATION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01738371",
+                "uri": "https://opencorporates.com/companies/gb/01738371"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01738371"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98ca567e4ebf340dc381f",
+                "uri": "http://register.openownership.org/entities/59b98ca567e4ebf340dc381f"
+            }
+        ],
+        "foundingDate": "1983-07-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Shared Services Centre, Q3 Office Quorum Business Park, Benton Lane, Newcastle Upon Tyne, NE12 8EX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12320650087730830032",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17046275416402427893"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3649209501846024425"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3649209501846024425",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ENGIE REGENERATION HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08514907"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08514907"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08514907"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08514907"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08514907",
+                "uri": "https://opencorporates.com/companies/gb/08514907"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b965f167e4ebf340269d95",
+                "uri": "http://register.openownership.org/entities/59b965f167e4ebf340269d95"
+            }
+        ],
+        "foundingDate": "2013-05-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Shared Services Centre, Q3 Office Quorum Business Park, Benton Lane, Newcastle Upon Tyne, NE12 8EX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01812908_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01812908_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-8881783635191456703", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EAST LONDON ADVANCED TECHNOLOGY TRAINING", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01812908"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01812908", "uri": "https://opencorporates.com/companies/gb/01812908"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4fcd667e4ebf340552528", "uri": "http://register.openownership.org/entities/59c4fcd667e4ebf340552528"}], "foundingDate": "1984-05-01", "addresses": [{"type": "registered", "address": "260-264 Kingsland Road, London, E8 4DG", "country": "GB"}]}, {"statementID": "openownership-register-8830280272934176460", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-17", "subject": {"describedByEntityStatement": "openownership-register-8881783635191456703"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-8881783635191456703",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EAST LONDON ADVANCED TECHNOLOGY TRAINING",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01812908"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01812908",
+                "uri": "https://opencorporates.com/companies/gb/01812908"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4fcd667e4ebf340552528",
+                "uri": "http://register.openownership.org/entities/59c4fcd667e4ebf340552528"
+            }
+        ],
+        "foundingDate": "1984-05-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "260-264 Kingsland Road, London, E8 4DG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8830280272934176460",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-17",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8881783635191456703"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01818133_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01818133_bods.json
@@ -1,1 +1,281 @@
-[{"statementID": "openownership-register-17477539187240747416", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HYDRO-X WATER TREATMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01818133"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01818133"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01818133", "uri": "https://opencorporates.com/companies/gb/01818133"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01818133"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92bc167e4ebf340195f01", "uri": "http://register.openownership.org/entities/59b92bc167e4ebf340195f01"}], "foundingDate": "1984-05-22", "addresses": [{"type": "registered", "address": "Unit 1 Manor Drive, Dinnington, Sheffield, S25 3QU", "country": "GB"}]}, {"statementID": "openownership-register-16893819015607329008", "statementType": "ownershipOrControlStatement", "statementDate": "2019-10-01", "subject": {"describedByEntityStatement": "openownership-register-17477539187240747416"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5814367874939647823"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-10-01"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-10-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-10-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-15456988415738366778", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17477539187240747416"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1049941371778791306"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-11610290663567508249", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17477539187240747416"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13397063835563184984"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-10-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-5814367874939647823", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HYDRO-X HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09208285"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09208285", "uri": "https://opencorporates.com/companies/gb/09208285"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09208285"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09208285"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09208285"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94aa267e4ebf340a92198", "uri": "http://register.openownership.org/entities/59b94aa267e4ebf340a92198"}], "foundingDate": "2014-09-08", "addresses": [{"type": "registered", "address": "Unit 1 Manor Drive, Dinnington, Sheffield, S25 3QU", "country": "GB"}]}, {"statementID": "openownership-register-1049941371778791306", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Richard Edwin Sanderson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01818133/persons-with-significant-control/individual/CW0gTN74xcpgtMk1JRFPu1ZkW58"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96f7567e4ebf34056748d", "uri": "http://register.openownership.org/entities/59b96f7567e4ebf34056748d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-11-01", "addresses": [{"address": "Woodland Barn, Oldfield Lane, Darley Bridge, Matlock, DE4 2JY", "country": "GB"}]}, {"statementID": "openownership-register-13397063835563184984", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Patrick Loveday"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01818133/persons-with-significant-control/individual/b1mL5nzznotxRTwXCFe1OVRJgFE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96f7567e4ebf340567485", "uri": "http://register.openownership.org/entities/59b96f7567e4ebf340567485"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1944-08-01", "addresses": [{"address": "10, Penny Piece Place, Anston, Sheffield, S31 7JZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17477539187240747416",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HYDRO-X WATER TREATMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01818133"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01818133"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01818133",
+                "uri": "https://opencorporates.com/companies/gb/01818133"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01818133"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92bc167e4ebf340195f01",
+                "uri": "http://register.openownership.org/entities/59b92bc167e4ebf340195f01"
+            }
+        ],
+        "foundingDate": "1984-05-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 1 Manor Drive, Dinnington, Sheffield, S25 3QU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16893819015607329008",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-10-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17477539187240747416"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5814367874939647823"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-10-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-10-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-10-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15456988415738366778",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17477539187240747416"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1049941371778791306"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11610290663567508249",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17477539187240747416"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13397063835563184984"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-10-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5814367874939647823",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HYDRO-X HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09208285"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09208285",
+                "uri": "https://opencorporates.com/companies/gb/09208285"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09208285"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09208285"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09208285"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94aa267e4ebf340a92198",
+                "uri": "http://register.openownership.org/entities/59b94aa267e4ebf340a92198"
+            }
+        ],
+        "foundingDate": "2014-09-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 1 Manor Drive, Dinnington, Sheffield, S25 3QU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1049941371778791306",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Richard Edwin Sanderson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01818133/persons-with-significant-control/individual/CW0gTN74xcpgtMk1JRFPu1ZkW58"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96f7567e4ebf34056748d",
+                "uri": "http://register.openownership.org/entities/59b96f7567e4ebf34056748d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-11-01",
+        "addresses": [
+            {
+                "address": "Woodland Barn, Oldfield Lane, Darley Bridge, Matlock, DE4 2JY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13397063835563184984",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Patrick Loveday"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01818133/persons-with-significant-control/individual/b1mL5nzznotxRTwXCFe1OVRJgFE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96f7567e4ebf340567485",
+                "uri": "http://register.openownership.org/entities/59b96f7567e4ebf340567485"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1944-08-01",
+        "addresses": [
+            {
+                "address": "10, Penny Piece Place, Anston, Sheffield, S31 7JZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01823459_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01823459_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-6774826385858692215", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SCARAB SWEEPERS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01823459"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01823459", "uri": "https://opencorporates.com/companies/gb/01823459"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b1a67e4ebf3401664ba", "uri": "http://register.openownership.org/entities/59b92b1a67e4ebf3401664ba"}], "foundingDate": "1984-06-11", "addresses": [{"type": "registered", "address": "Pattenden Lane, Marden, Tonbridge, Kent, TN12 9QD", "country": "GB"}]}, {"statementID": "openownership-register-11724158710847601856", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-26", "subject": {"describedByEntityStatement": "openownership-register-6774826385858692215"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17039009893337720386"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-26"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17039009893337720386", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SCARAB HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02086673"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02086673"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02086673"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02086673", "uri": "https://opencorporates.com/companies/gb/02086673"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b0467e4ebf34016009f", "uri": "http://register.openownership.org/entities/59b92b0467e4ebf34016009f"}], "foundingDate": "1987-01-02", "addresses": [{"type": "registered", "address": "Pattenden Lane, Marden, Tonbridge, Kent,, TN12 9QD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6774826385858692215",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SCARAB SWEEPERS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01823459"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01823459",
+                "uri": "https://opencorporates.com/companies/gb/01823459"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b1a67e4ebf3401664ba",
+                "uri": "http://register.openownership.org/entities/59b92b1a67e4ebf3401664ba"
+            }
+        ],
+        "foundingDate": "1984-06-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Pattenden Lane, Marden, Tonbridge, Kent, TN12 9QD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11724158710847601856",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-26",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6774826385858692215"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17039009893337720386"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-26"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17039009893337720386",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SCARAB HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02086673"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02086673"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02086673"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02086673",
+                "uri": "https://opencorporates.com/companies/gb/02086673"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b0467e4ebf34016009f",
+                "uri": "http://register.openownership.org/entities/59b92b0467e4ebf34016009f"
+            }
+        ],
+        "foundingDate": "1987-01-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Pattenden Lane, Marden, Tonbridge, Kent,, TN12 9QD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01846493_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01846493_bods.json
@@ -1,1 +1,649 @@
-[{"statementID": "openownership-register-16727345696602400977", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AECOM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01846493"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01846493", "uri": "https://opencorporates.com/companies/gb/01846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1846493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1846493"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b959c867e4ebf340ecaa7b", "uri": "http://register.openownership.org/entities/59b959c867e4ebf340ecaa7b"}], "foundingDate": "1984-09-06", "addresses": [{"type": "registered", "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA", "country": "GB"}]}, {"statementID": "openownership-register-953839648288620695", "statementType": "ownershipOrControlStatement", "statementDate": "2018-09-25", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5140612033240982684"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-25", "endDate": "2018-09-28"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-25", "endDate": "2018-09-28"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-09-25", "endDate": "2018-09-28"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7110755545919375484", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11798942707333959813"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-27"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-12-10T10:45:26Z"}}, {"statementID": "openownership-register-6110020582317603517", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-26", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11798942707333959813"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-26", "endDate": "2019-09-26"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-26", "endDate": "2019-09-26"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-09-26", "endDate": "2019-09-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-2874844571086319525", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-26", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1163671405918178199"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-26", "endDate": "2019-09-27"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-09-26", "endDate": "2019-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-09-26", "endDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-11-27T19:27:34Z"}}, {"statementID": "openownership-register-15764505854418922296", "statementType": "ownershipOrControlStatement", "statementDate": "2018-09-28", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1163671405918178199"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-28", "endDate": "2019-09-26"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-28", "endDate": "2019-09-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-10876025015406167524", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16727345696602400977"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3252309800968529912"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3252309800968529912", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AECOM HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03745592", "uri": "https://opencorporates.com/companies/gb/03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3745592"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3745592"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee8b", "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee8b"}], "foundingDate": "1999-04-01", "addresses": [{"type": "registered", "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA", "country": "GB"}]}, {"statementID": "openownership-register-1163671405918178199", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AMENTUM INTERNATIONAL HOLDINGS UK LTD.", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00530311", "uri": "https://opencorporates.com/companies/gb/00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00530311"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97b5167e4ebf34091909c", "uri": "http://register.openownership.org/entities/59b97b5167e4ebf34091909c"}], "foundingDate": "1954-03-13", "addresses": [{"type": "registered", "address": "1st Floor, 303 Bridgewater Place, Birchwood, Warrington, WA3 6XF", "country": "GB"}]}, {"statementID": "openownership-register-11798942707333959813", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AECOM DESIGN & CONSULTING SERVICES UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07840752"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07840752", "uri": "https://opencorporates.com/companies/gb/07840752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07840752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07840752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07840752"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07840752"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b960d567e4ebf3400e5877", "uri": "http://register.openownership.org/entities/59b960d567e4ebf3400e5877"}], "foundingDate": "2011-11-09", "addresses": [{"type": "registered", "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA", "country": "GB"}]}, {"statementID": "openownership-register-5140612033240982684", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AECOM UKRC LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11577908"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11577908", "uri": "https://opencorporates.com/companies/gb/11577908"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "11577908"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbb900a9dfc3fae187ffac5", "uri": "http://register.openownership.org/entities/5bbb900a9dfc3fae187ffac5"}], "foundingDate": "2018-09-19", "addresses": [{"type": "registered", "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16727345696602400977",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AECOM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01846493"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01846493",
+                "uri": "https://opencorporates.com/companies/gb/01846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1846493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b959c867e4ebf340ecaa7b",
+                "uri": "http://register.openownership.org/entities/59b959c867e4ebf340ecaa7b"
+            }
+        ],
+        "foundingDate": "1984-09-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-953839648288620695",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-09-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5140612033240982684"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-25",
+                "endDate": "2018-09-28"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-25",
+                "endDate": "2018-09-28"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-09-25",
+                "endDate": "2018-09-28"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7110755545919375484",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11798942707333959813"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-12-10T10:45:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6110020582317603517",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-26",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11798942707333959813"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-26"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-26"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2874844571086319525",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-26",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1163671405918178199"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-09-26",
+                "endDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-11-27T19:27:34Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15764505854418922296",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-09-28",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1163671405918178199"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-28",
+                "endDate": "2019-09-26"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-28",
+                "endDate": "2019-09-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10876025015406167524",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16727345696602400977"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3252309800968529912"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3252309800968529912",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AECOM HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03745592",
+                "uri": "https://opencorporates.com/companies/gb/03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3745592"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3745592"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee8b",
+                "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee8b"
+            }
+        ],
+        "foundingDate": "1999-04-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1163671405918178199",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AMENTUM INTERNATIONAL HOLDINGS UK LTD.",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00530311",
+                "uri": "https://opencorporates.com/companies/gb/00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00530311"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97b5167e4ebf34091909c",
+                "uri": "http://register.openownership.org/entities/59b97b5167e4ebf34091909c"
+            }
+        ],
+        "foundingDate": "1954-03-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1st Floor, 303 Bridgewater Place, Birchwood, Warrington, WA3 6XF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11798942707333959813",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AECOM DESIGN & CONSULTING SERVICES UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07840752"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07840752",
+                "uri": "https://opencorporates.com/companies/gb/07840752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07840752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07840752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07840752"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07840752"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b960d567e4ebf3400e5877",
+                "uri": "http://register.openownership.org/entities/59b960d567e4ebf3400e5877"
+            }
+        ],
+        "foundingDate": "2011-11-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5140612033240982684",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AECOM UKRC LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11577908"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11577908",
+                "uri": "https://opencorporates.com/companies/gb/11577908"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11577908"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbb900a9dfc3fae187ffac5",
+                "uri": "http://register.openownership.org/entities/5bbb900a9dfc3fae187ffac5"
+            }
+        ],
+        "foundingDate": "2018-09-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Aldgate Tower, 2 Leman Street, London, E1 8FA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01879212_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01879212_bods.json
@@ -1,1 +1,235 @@
-[{"statementID": "openownership-register-10170726218031835232", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GOOD RELATIONS CONSULTANTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01879212"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01879212", "uri": "https://opencorporates.com/companies/gb/01879212"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ec967e4ebf340bb1aed", "uri": "http://register.openownership.org/entities/59b94ec967e4ebf340bb1aed"}], "foundingDate": "1985-01-21", "dissolutionDate": "2019-12-17", "addresses": [{"type": "registered", "address": "PO BOX 70693 62 Buckingham Gate, London, SW1P 9ZP", "country": "GB"}]}, {"statementID": "openownership-register-14366206517940448165", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10170726218031835232"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2156720068108250678"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2156720068108250678", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CHIME LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02370011"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02370011", "uri": "https://opencorporates.com/companies/gb/02370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2370011"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92f5667e4ebf3402bd421", "uri": "http://register.openownership.org/entities/59b92f5667e4ebf3402bd421"}], "foundingDate": "1989-04-10", "addresses": [{"type": "registered", "address": "PO BOX 70693 62 Buckingham Gate, London, SW1P 9ZP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-10170726218031835232",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GOOD RELATIONS CONSULTANTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01879212"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01879212",
+                "uri": "https://opencorporates.com/companies/gb/01879212"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ec967e4ebf340bb1aed",
+                "uri": "http://register.openownership.org/entities/59b94ec967e4ebf340bb1aed"
+            }
+        ],
+        "foundingDate": "1985-01-21",
+        "dissolutionDate": "2019-12-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "PO BOX 70693 62 Buckingham Gate, London, SW1P 9ZP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14366206517940448165",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10170726218031835232"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2156720068108250678"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2156720068108250678",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CHIME LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02370011"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02370011",
+                "uri": "https://opencorporates.com/companies/gb/02370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2370011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92f5667e4ebf3402bd421",
+                "uri": "http://register.openownership.org/entities/59b92f5667e4ebf3402bd421"
+            }
+        ],
+        "foundingDate": "1989-04-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "PO BOX 70693 62 Buckingham Gate, London, SW1P 9ZP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01910661_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01910661_bods.json
@@ -1,1 +1,191 @@
-[{"statementID": "openownership-register-14023663788199108597", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FABRIKAT (NOTTINGHAM) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01910661"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01910661", "uri": "https://opencorporates.com/companies/gb/01910661"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a6b", "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a6b"}], "foundingDate": "1985-05-02", "addresses": [{"type": "registered", "address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN", "country": "GB"}]}, {"statementID": "openownership-register-11901235873576836045", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14023663788199108597"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14786816398141616965"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1127318169227072007", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14023663788199108597"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2304286285234595227"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14786816398141616965", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Martin Hopkins"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01910661/persons-with-significant-control/individual/3Y83j5b-qGwiL1cHQGCCzLTIJvk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a82", "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a82"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-11-01", "addresses": [{"address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN"}]}, {"statementID": "openownership-register-2304286285234595227", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Matthew Housley Wass"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01910661/persons-with-significant-control/individual/6nr-wSNG8ABOI6YDzx3I3u9Gac4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a89", "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a89"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1981-04-01", "addresses": [{"address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN"}]}]
+[
+    {
+        "statementID": "openownership-register-14023663788199108597",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FABRIKAT (NOTTINGHAM) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01910661"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01910661",
+                "uri": "https://opencorporates.com/companies/gb/01910661"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a6b",
+                "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a6b"
+            }
+        ],
+        "foundingDate": "1985-05-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11901235873576836045",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14023663788199108597"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14786816398141616965"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1127318169227072007",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14023663788199108597"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2304286285234595227"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14786816398141616965",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Martin Hopkins"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01910661/persons-with-significant-control/individual/3Y83j5b-qGwiL1cHQGCCzLTIJvk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a82",
+                "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a82"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-11-01",
+        "addresses": [
+            {
+                "address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2304286285234595227",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Matthew Housley Wass"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01910661/persons-with-significant-control/individual/6nr-wSNG8ABOI6YDzx3I3u9Gac4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a89",
+                "uri": "http://register.openownership.org/entities/59b97a0b67e4ebf3408b4a89"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1981-04-01",
+        "addresses": [
+            {
+                "address": "Hamilton Road, Sutton-In-Ashfield, Nottingham, NG17 5LN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01918150_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01918150_bods.json
@@ -1,1 +1,604 @@
-[{"statementID": "openownership-register-9645753392441894120", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PENNA PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01918150"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01918150", "uri": "https://opencorporates.com/companies/gb/01918150"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1918150"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b937c667e4ebf34053cbf4", "uri": "http://register.openownership.org/entities/59b937c667e4ebf34053cbf4"}], "foundingDate": "1985-05-31", "addresses": [{"type": "registered", "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG", "country": "GB"}]}, {"statementID": "openownership-register-11707995594517221851", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9645753392441894120"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8960380370949172790"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15549738577916240199", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-10", "subject": {"describedByEntityStatement": "openownership-register-9645753392441894120"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3502109499826504287"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-05-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1926687066126411214", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-10", "subject": {"describedByEntityStatement": "openownership-register-9645753392441894120"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9202658491700072868"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-05-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3502109499826504287", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OLSTEN (U.K.) HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02547754", "uri": "https://opencorporates.com/companies/gb/02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02547754"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9603767e4ebf3400b94d9", "uri": "http://register.openownership.org/entities/59b9603767e4ebf3400b94d9"}], "foundingDate": "1990-10-11", "addresses": [{"type": "registered", "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG", "country": "GB"}]}, {"statementID": "openownership-register-8960380370949172790", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PENNA CONSULTING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03142685", "uri": "https://opencorporates.com/companies/gb/03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3142685"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03142685"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b937c767e4ebf34053d057", "uri": "http://register.openownership.org/entities/59b937c767e4ebf34053d057"}], "foundingDate": "1996-01-02", "addresses": [{"type": "registered", "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG", "country": "GB"}]}, {"statementID": "openownership-register-9202658491700072868", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Adecco Group Ag", "incorporatedInJurisdiction": {"name": "Switzerland", "code": "CH"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01918150/persons-with-significant-control/corporate-entity/O_uyCoflmGXsjGYTQxNPYn1INU0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbb72c59dfc3fae182924e2", "uri": "http://register.openownership.org/entities/5bbb72c59dfc3fae182924e2"}], "addresses": [{"type": "registered", "address": "30, Bellerivestrasse, 8008 Z\u00fcrich", "country": "CH"}]}]
+[
+    {
+        "statementID": "openownership-register-9645753392441894120",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PENNA PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01918150"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01918150",
+                "uri": "https://opencorporates.com/companies/gb/01918150"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1918150"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b937c667e4ebf34053cbf4",
+                "uri": "http://register.openownership.org/entities/59b937c667e4ebf34053cbf4"
+            }
+        ],
+        "foundingDate": "1985-05-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11707995594517221851",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9645753392441894120"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8960380370949172790"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15549738577916240199",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9645753392441894120"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3502109499826504287"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-05-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1926687066126411214",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9645753392441894120"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9202658491700072868"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-05-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3502109499826504287",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OLSTEN (U.K.) HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02547754",
+                "uri": "https://opencorporates.com/companies/gb/02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02547754"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9603767e4ebf3400b94d9",
+                "uri": "http://register.openownership.org/entities/59b9603767e4ebf3400b94d9"
+            }
+        ],
+        "foundingDate": "1990-10-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8960380370949172790",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PENNA CONSULTING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03142685",
+                "uri": "https://opencorporates.com/companies/gb/03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03142685"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b937c767e4ebf34053d057",
+                "uri": "http://register.openownership.org/entities/59b937c767e4ebf34053d057"
+            }
+        ],
+        "foundingDate": "1996-01-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Millennium Bridge House, 2 Lambeth Hill, London, EC4V 4BG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9202658491700072868",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Adecco Group Ag",
+        "incorporatedInJurisdiction": {
+            "name": "Switzerland",
+            "code": "CH"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01918150/persons-with-significant-control/corporate-entity/O_uyCoflmGXsjGYTQxNPYn1INU0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbb72c59dfc3fae182924e2",
+                "uri": "http://register.openownership.org/entities/5bbb72c59dfc3fae182924e2"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "30, Bellerivestrasse, 8008 Z\u00fcrich",
+                "country": "CH"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01959704_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01959704_bods.json
@@ -1,1 +1,154 @@
-[{"statementID": "openownership-register-15870694892958943673", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WYG ENGINEERING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01959704"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01959704", "uri": "https://opencorporates.com/companies/gb/01959704"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9254767e4ebf340fd5687", "uri": "http://register.openownership.org/entities/59b9254767e4ebf340fd5687"}], "foundingDate": "1985-11-15", "addresses": [{"type": "registered", "address": "3 Sovereign Square, Sovereign Street, Leeds, LS1 4ER", "country": "GB"}]}, {"statementID": "openownership-register-8732229636134778986", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15870694892958943673"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5313834348502548521"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-5313834348502548521", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WYG GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06595608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06595608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06595608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06595608"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06595608"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06595608", "uri": "https://opencorporates.com/companies/gb/06595608"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a2067e4ebf3405e812a", "uri": "http://register.openownership.org/entities/59b93a2067e4ebf3405e812a"}], "foundingDate": "2008-05-16", "addresses": [{"type": "registered", "address": "3 Sovereign Square, Sovereign Street, Leeds, LS1 4ER", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15870694892958943673",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WYG ENGINEERING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01959704"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01959704",
+                "uri": "https://opencorporates.com/companies/gb/01959704"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9254767e4ebf340fd5687",
+                "uri": "http://register.openownership.org/entities/59b9254767e4ebf340fd5687"
+            }
+        ],
+        "foundingDate": "1985-11-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3 Sovereign Square, Sovereign Street, Leeds, LS1 4ER",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8732229636134778986",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15870694892958943673"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5313834348502548521"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5313834348502548521",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WYG GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06595608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06595608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06595608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06595608"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06595608"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06595608",
+                "uri": "https://opencorporates.com/companies/gb/06595608"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a2067e4ebf3405e812a",
+                "uri": "http://register.openownership.org/entities/59b93a2067e4ebf3405e812a"
+            }
+        ],
+        "foundingDate": "2008-05-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3 Sovereign Square, Sovereign Street, Leeds, LS1 4ER",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01977948_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_01977948_bods.json
@@ -1,1 +1,528 @@
-[{"statementID": "openownership-register-2384600244425613538", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WATES CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01977948", "uri": "https://opencorporates.com/companies/gb/01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01977948"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c1567e4ebf34067ac42", "uri": "http://register.openownership.org/entities/59b93c1567e4ebf34067ac42"}], "foundingDate": "1986-01-15", "addresses": [{"type": "registered", "address": "Wates House, Station Approach, Leatherhead, Surrey, KT22 7SW", "country": "GB"}]}, {"statementID": "openownership-register-9307864766552530673", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2384600244425613538"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3142785294162712210"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3142785294162712210", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WATES GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01824828", "uri": "https://opencorporates.com/companies/gb/01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01824828"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e5967e4ebf34071e4d8", "uri": "http://register.openownership.org/entities/59b93e5967e4ebf34071e4d8"}], "foundingDate": "1984-06-14", "addresses": [{"type": "registered", "address": "Wates House, Station Approach, Leatherhead, Surrey, KT22 7SW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2384600244425613538",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WATES CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01977948",
+                "uri": "https://opencorporates.com/companies/gb/01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01977948"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c1567e4ebf34067ac42",
+                "uri": "http://register.openownership.org/entities/59b93c1567e4ebf34067ac42"
+            }
+        ],
+        "foundingDate": "1986-01-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Wates House, Station Approach, Leatherhead, Surrey, KT22 7SW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9307864766552530673",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2384600244425613538"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3142785294162712210"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3142785294162712210",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WATES GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01824828",
+                "uri": "https://opencorporates.com/companies/gb/01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01824828"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e5967e4ebf34071e4d8",
+                "uri": "http://register.openownership.org/entities/59b93e5967e4ebf34071e4d8"
+            }
+        ],
+        "foundingDate": "1984-06-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Wates House, Station Approach, Leatherhead, Surrey, KT22 7SW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02020165_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02020165_bods.json
@@ -1,1 +1,75 @@
-[{"statementID": "openownership-register-17856786424189295640", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HESTIA HOUSING AND SUPPORT", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02020165"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02020165"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02020165", "uri": "https://opencorporates.com/companies/gb/02020165"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Companies House: 2020165 And Charity Commission: 294555"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Companies House: 2020165 And Charity Commission: 294555"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cc6567e4ebf340c8ae07", "uri": "http://register.openownership.org/entities/59b9cc6567e4ebf340c8ae07"}], "foundingDate": "1986-05-15", "addresses": [{"type": "registered", "address": "Maya House, 134-138 Borough High Street, London, SE1 1LB", "country": "GB"}]}, {"statementID": "openownership-register-5305520206615608748", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-31", "subject": {"describedByEntityStatement": "openownership-register-17856786424189295640"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-17856786424189295640",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HESTIA HOUSING AND SUPPORT",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02020165"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02020165"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02020165",
+                "uri": "https://opencorporates.com/companies/gb/02020165"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Companies House: 2020165 And Charity Commission: 294555"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Companies House: 2020165 And Charity Commission: 294555"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cc6567e4ebf340c8ae07",
+                "uri": "http://register.openownership.org/entities/59b9cc6567e4ebf340c8ae07"
+            }
+        ],
+        "foundingDate": "1986-05-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Maya House, 134-138 Borough High Street, London, SE1 1LB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5305520206615608748",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17856786424189295640"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02047278_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02047278_bods.json
@@ -1,1 +1,157 @@
-[{"statementID": "openownership-register-8166747015030019593", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BITUCHEM BUILDING PRODUCTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02047278"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02047278", "uri": "https://opencorporates.com/companies/gb/02047278"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ae1867e4ebf340549090", "uri": "http://register.openownership.org/entities/59b9ae1867e4ebf340549090"}], "foundingDate": "1986-08-15", "addresses": [{"type": "registered", "address": "Bituchem, Laymore Road, Forest Vale Industrial Estate, Cinderford, Gloucestershire, GL14 2YH", "country": "GB"}]}, {"statementID": "openownership-register-3718001391519490898", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8166747015030019593"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8786873610884958572"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8786873610884958572", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BITUCHEM HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02334866", "uri": "https://opencorporates.com/companies/gb/02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2334866"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02334866"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab99e479dfc3fae183de870", "uri": "http://register.openownership.org/entities/5ab99e479dfc3fae183de870"}], "foundingDate": "1989-01-13", "addresses": [{"type": "registered", "address": "Laymore Road, Forest Vale Industrial Estate, Cinderford, Gloucestershire, GL14 2YH", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8166747015030019593",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BITUCHEM BUILDING PRODUCTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02047278"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02047278",
+                "uri": "https://opencorporates.com/companies/gb/02047278"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ae1867e4ebf340549090",
+                "uri": "http://register.openownership.org/entities/59b9ae1867e4ebf340549090"
+            }
+        ],
+        "foundingDate": "1986-08-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Bituchem, Laymore Road, Forest Vale Industrial Estate, Cinderford, Gloucestershire, GL14 2YH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3718001391519490898",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8166747015030019593"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8786873610884958572"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8786873610884958572",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BITUCHEM HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02334866",
+                "uri": "https://opencorporates.com/companies/gb/02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02334866"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab99e479dfc3fae183de870",
+                "uri": "http://register.openownership.org/entities/5ab99e479dfc3fae183de870"
+            }
+        ],
+        "foundingDate": "1989-01-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Laymore Road, Forest Vale Industrial Estate, Cinderford, Gloucestershire, GL14 2YH",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02099533_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02099533_bods.json
@@ -1,1 +1,385 @@
-[{"statementID": "openownership-register-9649111881430692548", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KIER CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02099533"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02099533", "uri": "https://opencorporates.com/companies/gb/02099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2099533"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2099533"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9313167e4ebf34033baf1", "uri": "http://register.openownership.org/entities/59b9313167e4ebf34033baf1"}], "foundingDate": "1987-02-12", "addresses": [{"type": "registered", "address": "81 Fountain Street, Manchester, M2   2EE", "country": "GB"}]}, {"statementID": "openownership-register-11123822713929163367", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9649111881430692548"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9465760036701830037"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-9465760036701830037", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KIER LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01611136", "uri": "https://opencorporates.com/companies/gb/01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01611136"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9313867e4ebf34033db6b", "uri": "http://register.openownership.org/entities/59b9313867e4ebf34033db6b"}], "foundingDate": "1982-02-03", "addresses": [{"type": "registered", "address": "81 Fountain Street, Manchester, M2   2EE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9649111881430692548",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KIER CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02099533"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02099533",
+                "uri": "https://opencorporates.com/companies/gb/02099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2099533"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2099533"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9313167e4ebf34033baf1",
+                "uri": "http://register.openownership.org/entities/59b9313167e4ebf34033baf1"
+            }
+        ],
+        "foundingDate": "1987-02-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "81 Fountain Street, Manchester, M2   2EE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11123822713929163367",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9649111881430692548"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9465760036701830037"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9465760036701830037",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KIER LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01611136",
+                "uri": "https://opencorporates.com/companies/gb/01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01611136"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9313867e4ebf34033db6b",
+                "uri": "http://register.openownership.org/entities/59b9313867e4ebf34033db6b"
+            }
+        ],
+        "foundingDate": "1982-02-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "81 Fountain Street, Manchester, M2   2EE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02122174_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02122174_bods.json
@@ -1,1 +1,280 @@
-[{"statementID": "openownership-register-1252082195026325719", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Savills Plc", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02122174"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02122174", "uri": "https://opencorporates.com/companies/gb/02122174"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02122174"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9dd2e67e4ebf3400697be", "uri": "http://register.openownership.org/entities/59b9dd2e67e4ebf3400697be"}], "foundingDate": "1987-04-10", "addresses": [{"type": "registered", "address": "33, Margaret Street, London, W1G 0JD", "country": "GB"}]}, {"statementID": "openownership-register-797679160286963644", "statementType": "ownershipOrControlStatement", "subject": {"describedByEntityStatement": "openownership-register-1252082195026325719"}, "interestedParty": {"unspecified": {"reason": "unknown", "description": "Unknown person(s)"}}, "interests": []}]
+[
+    {
+        "statementID": "openownership-register-1252082195026325719",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Savills Plc",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02122174"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02122174",
+                "uri": "https://opencorporates.com/companies/gb/02122174"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02122174"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9dd2e67e4ebf3400697be",
+                "uri": "http://register.openownership.org/entities/59b9dd2e67e4ebf3400697be"
+            }
+        ],
+        "foundingDate": "1987-04-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33, Margaret Street, London, W1G 0JD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-797679160286963644",
+        "statementType": "ownershipOrControlStatement",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1252082195026325719"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": []
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02150618_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02150618_bods.json
@@ -1,1 +1,276 @@
-[{"statementID": "openownership-register-7004636950437422831", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KCOM GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02150618"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02150618", "uri": "https://opencorporates.com/companies/gb/02150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2150618"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b926a767e4ebf340031b87", "uri": "http://register.openownership.org/entities/59b926a767e4ebf340031b87"}], "foundingDate": "1987-07-21", "addresses": [{"type": "registered", "address": "37 Carr Lane, Hull, East Yorkshire, HU1 3RE", "country": "GB"}]}, {"statementID": "openownership-register-11544670919305064804", "statementType": "ownershipOrControlStatement", "subject": {"describedByEntityStatement": "openownership-register-7004636950437422831"}, "interestedParty": {"unspecified": {"reason": "unknown", "description": "Unknown person(s)"}}, "interests": []}]
+[
+    {
+        "statementID": "openownership-register-7004636950437422831",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KCOM GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02150618"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02150618",
+                "uri": "https://opencorporates.com/companies/gb/02150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2150618"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b926a767e4ebf340031b87",
+                "uri": "http://register.openownership.org/entities/59b926a767e4ebf340031b87"
+            }
+        ],
+        "foundingDate": "1987-07-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "37 Carr Lane, Hull, East Yorkshire, HU1 3RE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11544670919305064804",
+        "statementType": "ownershipOrControlStatement",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7004636950437422831"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": []
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02151434_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02151434_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-15714745617343152702", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OUTWARD HOUSING", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02151434"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02151434", "uri": "https://opencorporates.com/companies/gb/02151434"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c77867e4ebf340b6678d", "uri": "http://register.openownership.org/entities/59b9c77867e4ebf340b6678d"}], "foundingDate": "1987-07-29", "addresses": [{"type": "registered", "address": "Newlon House 4 Daneland Walk, Hale Village, London, N17 9FE", "country": "GB"}]}, {"statementID": "openownership-register-6846608988713489896", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-18", "subject": {"describedByEntityStatement": "openownership-register-15714745617343152702"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10178342263652973022"}, "interests": [{"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-05-18"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-05-18"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5433386402402511159", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15714745617343152702"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8525559614418959356"}, "interests": [{"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10178342263652973022", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Newlon Housing Trust", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "18449r"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c77d67e4ebf340b66d35", "uri": "http://register.openownership.org/entities/59b9c77d67e4ebf340b66d35"}], "addresses": [{"type": "registered", "address": "4, Daneland Walk, London, N17 9FE", "country": "GB"}]}, {"statementID": "openownership-register-8525559614418959356", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Newlon Housing Trust", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "18449r"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbc49549dfc3fae189366fa", "uri": "http://register.openownership.org/entities/5bbc49549dfc3fae189366fa"}], "addresses": [{"type": "registered", "address": "4, Daneland Walk, London, N17 9FE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15714745617343152702",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OUTWARD HOUSING",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02151434"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02151434",
+                "uri": "https://opencorporates.com/companies/gb/02151434"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c77867e4ebf340b6678d",
+                "uri": "http://register.openownership.org/entities/59b9c77867e4ebf340b6678d"
+            }
+        ],
+        "foundingDate": "1987-07-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Newlon House 4 Daneland Walk, Hale Village, London, N17 9FE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6846608988713489896",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15714745617343152702"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10178342263652973022"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-05-18"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-05-18"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5433386402402511159",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15714745617343152702"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8525559614418959356"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10178342263652973022",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Newlon Housing Trust",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "18449r"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c77d67e4ebf340b66d35",
+                "uri": "http://register.openownership.org/entities/59b9c77d67e4ebf340b66d35"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4, Daneland Walk, London, N17 9FE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8525559614418959356",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Newlon Housing Trust",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "18449r"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbc49549dfc3fae189366fa",
+                "uri": "http://register.openownership.org/entities/5bbc49549dfc3fae189366fa"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4, Daneland Walk, London, N17 9FE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02152073_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02152073_bods.json
@@ -1,1 +1,123 @@
-[{"statementID": "openownership-register-16407312958925021474", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SAP (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02152073"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02152073"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02152073", "uri": "https://opencorporates.com/companies/gb/02152073"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02152073"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96b6f67e4ebf34042bd9a", "uri": "http://register.openownership.org/entities/59b96b6f67e4ebf34042bd9a"}], "foundingDate": "1987-07-31", "addresses": [{"type": "registered", "address": "Clockhouse Place, Bedfont Road, Feltham, Middlesex, TW14 8HD", "country": "GB"}]}, {"statementID": "openownership-register-14678354278031148089", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16407312958925021474"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16785876009676914734"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16785876009676914734", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Sap Se", "incorporatedInJurisdiction": {"name": "Germany", "code": "DE"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02152073/persons-with-significant-control/corporate-entity/5Wo-9wtAQKE0t8RSerUoenIWON0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a56967e4ebf340352976", "uri": "http://register.openownership.org/entities/59b9a56967e4ebf340352976"}], "addresses": [{"type": "registered", "address": "Dietmar-Hopp-Allee, 16, Walldorf, 69190", "country": "DE"}]}]
+[
+    {
+        "statementID": "openownership-register-16407312958925021474",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SAP (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02152073"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02152073"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02152073",
+                "uri": "https://opencorporates.com/companies/gb/02152073"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02152073"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96b6f67e4ebf34042bd9a",
+                "uri": "http://register.openownership.org/entities/59b96b6f67e4ebf34042bd9a"
+            }
+        ],
+        "foundingDate": "1987-07-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Clockhouse Place, Bedfont Road, Feltham, Middlesex, TW14 8HD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14678354278031148089",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16407312958925021474"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16785876009676914734"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16785876009676914734",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Sap Se",
+        "incorporatedInJurisdiction": {
+            "name": "Germany",
+            "code": "DE"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02152073/persons-with-significant-control/corporate-entity/5Wo-9wtAQKE0t8RSerUoenIWON0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a56967e4ebf340352976",
+                "uri": "http://register.openownership.org/entities/59b9a56967e4ebf340352976"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Dietmar-Hopp-Allee, 16, Walldorf, 69190",
+                "country": "DE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02158780_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02158780_bods.json
@@ -1,1 +1,83 @@
-[{"statementID": "openownership-register-3146306363062188114", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VICTIM SUPPORT", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02158780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02158780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02158780"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02158780", "uri": "https://opencorporates.com/companies/gb/02158780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2158780"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9755a67e4ebf34073a7ec", "uri": "http://register.openownership.org/entities/59b9755a67e4ebf34073a7ec"}], "foundingDate": "1987-08-28", "addresses": [{"type": "registered", "address": "1 Bridge Street, Derby, DE1 3HZ", "country": "GB"}]}, {"statementID": "openownership-register-3099049273095959712", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-01", "subject": {"describedByEntityStatement": "openownership-register-3146306363062188114"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-3146306363062188114",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VICTIM SUPPORT",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02158780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02158780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02158780"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02158780",
+                "uri": "https://opencorporates.com/companies/gb/02158780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2158780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9755a67e4ebf34073a7ec",
+                "uri": "http://register.openownership.org/entities/59b9755a67e4ebf34073a7ec"
+            }
+        ],
+        "foundingDate": "1987-08-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Bridge Street, Derby, DE1 3HZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3099049273095959712",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3146306363062188114"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02166058_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02166058_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-205379163316583122", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JOHAL DAIRIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02166058"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02166058", "uri": "https://opencorporates.com/companies/gb/02166058"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c4b967e4ebf340ac90c3", "uri": "http://register.openownership.org/entities/59b9c4b967e4ebf340ac90c3"}], "foundingDate": "1987-09-17", "addresses": [{"type": "registered", "address": "Cannock Road, Wolverhampton, West Midlands, WV1 1PN", "country": "GB"}]}, {"statementID": "openownership-register-15857246597530173498", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-26", "subject": {"describedByEntityStatement": "openownership-register-205379163316583122"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15424577580152430219"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-26"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-26"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15424577580152430219", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JOHAL DAIRIES HOLDING CO LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02931171"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02931171"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02931171", "uri": "https://opencorporates.com/companies/gb/02931171"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c4ba67e4ebf340ac9337", "uri": "http://register.openownership.org/entities/59b9c4ba67e4ebf340ac9337"}], "foundingDate": "1994-05-20", "addresses": [{"type": "registered", "address": "Cannock Road, Wolverhampton, West Midlands, WV1 1PN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-205379163316583122",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JOHAL DAIRIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02166058"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02166058",
+                "uri": "https://opencorporates.com/companies/gb/02166058"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c4b967e4ebf340ac90c3",
+                "uri": "http://register.openownership.org/entities/59b9c4b967e4ebf340ac90c3"
+            }
+        ],
+        "foundingDate": "1987-09-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cannock Road, Wolverhampton, West Midlands, WV1 1PN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15857246597530173498",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-26",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-205379163316583122"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15424577580152430219"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-26"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-26"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15424577580152430219",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JOHAL DAIRIES HOLDING CO LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02931171"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02931171"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02931171",
+                "uri": "https://opencorporates.com/companies/gb/02931171"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c4ba67e4ebf340ac9337",
+                "uri": "http://register.openownership.org/entities/59b9c4ba67e4ebf340ac9337"
+            }
+        ],
+        "foundingDate": "1994-05-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cannock Road, Wolverhampton, West Midlands, WV1 1PN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02207338_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02207338_bods.json
@@ -1,1 +1,505 @@
-[{"statementID": "openownership-register-17133573801113652350", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KEEPMOAT HOMES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02207338", "uri": "https://opencorporates.com/companies/gb/02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02207338"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a2267e4ebf3405e8f09", "uri": "http://register.openownership.org/entities/59b93a2267e4ebf3405e8f09"}], "foundingDate": "1987-12-22", "addresses": [{"type": "registered", "address": "Keepmoat The Waterfront, Lakeside Boulevard, Doncaster, South Yorkshire, DN4 5PL", "country": "GB"}]}, {"statementID": "openownership-register-5422330761193390719", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17133573801113652350"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5925202244900628875"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5925202244900628875", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KEEPMOAT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01998780"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01998780", "uri": "https://opencorporates.com/companies/gb/01998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1998780"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94de467e4ebf340b73625", "uri": "http://register.openownership.org/entities/59b94de467e4ebf340b73625"}], "foundingDate": "1986-03-12", "addresses": [{"type": "registered", "address": "Keepmoat The Waterfront, Lakeside Boulevard, Doncaster, South Yorkshire, DN4 5PL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17133573801113652350",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KEEPMOAT HOMES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02207338",
+                "uri": "https://opencorporates.com/companies/gb/02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02207338"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a2267e4ebf3405e8f09",
+                "uri": "http://register.openownership.org/entities/59b93a2267e4ebf3405e8f09"
+            }
+        ],
+        "foundingDate": "1987-12-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Keepmoat The Waterfront, Lakeside Boulevard, Doncaster, South Yorkshire, DN4 5PL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5422330761193390719",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17133573801113652350"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5925202244900628875"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5925202244900628875",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KEEPMOAT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01998780"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01998780",
+                "uri": "https://opencorporates.com/companies/gb/01998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1998780"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94de467e4ebf340b73625",
+                "uri": "http://register.openownership.org/entities/59b94de467e4ebf340b73625"
+            }
+        ],
+        "foundingDate": "1986-03-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Keepmoat The Waterfront, Lakeside Boulevard, Doncaster, South Yorkshire, DN4 5PL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02212959_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02212959_bods.json
@@ -1,1 +1,149 @@
-[{"statementID": "openownership-register-4797114212718245144", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARCADIS CONSULTING (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02212959"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02212959"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02212959", "uri": "https://opencorporates.com/companies/gb/02212959"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9389867e4ebf340578a81", "uri": "http://register.openownership.org/entities/59b9389867e4ebf340578a81"}], "foundingDate": "1988-01-22", "addresses": [{"type": "registered", "address": "Arcadis House, 34 York Way, London, N1 9AB", "country": "GB"}]}, {"statementID": "openownership-register-15332996039352115947", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4797114212718245144"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5903024216821487819"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5903024216821487819", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARCADIS CONSULTING EUROPE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02273559"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02273559", "uri": "https://opencorporates.com/companies/gb/02273559"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ac3d67e4ebf3404e546e", "uri": "http://register.openownership.org/entities/59b9ac3d67e4ebf3404e546e"}], "foundingDate": "1988-07-01", "addresses": [{"type": "registered", "address": "Arcadis House, 34 York Way, London, N1 9AB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4797114212718245144",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARCADIS CONSULTING (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02212959"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02212959"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02212959",
+                "uri": "https://opencorporates.com/companies/gb/02212959"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9389867e4ebf340578a81",
+                "uri": "http://register.openownership.org/entities/59b9389867e4ebf340578a81"
+            }
+        ],
+        "foundingDate": "1988-01-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Arcadis House, 34 York Way, London, N1 9AB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15332996039352115947",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4797114212718245144"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5903024216821487819"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5903024216821487819",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARCADIS CONSULTING EUROPE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02273559"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02273559",
+                "uri": "https://opencorporates.com/companies/gb/02273559"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ac3d67e4ebf3404e546e",
+                "uri": "http://register.openownership.org/entities/59b9ac3d67e4ebf3404e546e"
+            }
+        ],
+        "foundingDate": "1988-07-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Arcadis House, 34 York Way, London, N1 9AB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02227962_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02227962_bods.json
@@ -1,1 +1,188 @@
-[{"statementID": "openownership-register-12919233566118944401", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MATRIX SCM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02227962"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02227962", "uri": "https://opencorporates.com/companies/gb/02227962"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96d5067e4ebf3404c1c9f", "uri": "http://register.openownership.org/entities/59b96d5067e4ebf3404c1c9f"}], "foundingDate": "1988-03-07", "addresses": [{"type": "registered", "address": "2nd Floor Partis House, Knowlhill, Milton Keynes, MK5 8HJ", "country": "GB"}]}, {"statementID": "openownership-register-10065787368924596462", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12919233566118944401"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17249552802191097592"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16184503758098832573", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-20", "subject": {"describedByEntityStatement": "openownership-register-12919233566118944401"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17249552802191097592"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-20"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-20"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-20"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17249552802191097592", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MATRIX SCM GROUP LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10071010"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10071010"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10071010"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10071010"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10071010", "uri": "https://opencorporates.com/companies/gb/10071010"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10071010"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96d5167e4ebf3404c228a", "uri": "http://register.openownership.org/entities/59b96d5167e4ebf3404c228a"}], "foundingDate": "2016-03-18", "addresses": [{"type": "registered", "address": "2nd Floor Partis House, Knowlhill, Milton Keynes, MK5 8HJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12919233566118944401",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MATRIX SCM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02227962"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02227962",
+                "uri": "https://opencorporates.com/companies/gb/02227962"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96d5067e4ebf3404c1c9f",
+                "uri": "http://register.openownership.org/entities/59b96d5067e4ebf3404c1c9f"
+            }
+        ],
+        "foundingDate": "1988-03-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2nd Floor Partis House, Knowlhill, Milton Keynes, MK5 8HJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10065787368924596462",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12919233566118944401"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17249552802191097592"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16184503758098832573",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-20",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12919233566118944401"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17249552802191097592"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-20"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-20"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-20"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17249552802191097592",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MATRIX SCM GROUP LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10071010"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10071010"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10071010"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10071010"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10071010",
+                "uri": "https://opencorporates.com/companies/gb/10071010"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10071010"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96d5167e4ebf3404c228a",
+                "uri": "http://register.openownership.org/entities/59b96d5167e4ebf3404c228a"
+            }
+        ],
+        "foundingDate": "2016-03-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2nd Floor Partis House, Knowlhill, Milton Keynes, MK5 8HJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02264564_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02264564_bods.json
@@ -1,1 +1,331 @@
-[{"statementID": "openownership-register-16978872598916964281", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AURORA OPTIONS", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02264564"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02264564", "uri": "https://opencorporates.com/companies/gb/02264564"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b62561", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b62561"}], "foundingDate": "1988-06-03", "addresses": [{"type": "registered", "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB", "country": "GB"}]}, {"statementID": "openownership-register-5442628093859183031", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-05", "subject": {"describedByEntityStatement": "openownership-register-16978872598916964281"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4825369952675511509"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-05-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5141430759142017530", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-05", "subject": {"describedByEntityStatement": "openownership-register-16978872598916964281"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11228655992067172683"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-05-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9215918033833049345", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-05", "subject": {"describedByEntityStatement": "openownership-register-16978872598916964281"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14304061789876416412"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-05-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3660110935734417343", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-05", "subject": {"describedByEntityStatement": "openownership-register-16978872598916964281"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18159969709663061491"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-05-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17194212719154598222", "statementType": "ownershipOrControlStatement", "statementDate": "2016-05-05", "subject": {"describedByEntityStatement": "openownership-register-16978872598916964281"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11765096590920476483"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-05-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4825369952675511509", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jerry Tosswell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02264564/persons-with-significant-control/individual/9Jl00MOwXfmZgCgFNbTt1FFgAwY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b62593", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b62593"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-06-01", "addresses": [{"address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"}]}, {"statementID": "openownership-register-11228655992067172683", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "William Scott"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02264564/persons-with-significant-control/individual/G9x93B53k5GQdv2oSWe8IVVjDhY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b625aa", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b625aa"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1955-10-01", "addresses": [{"address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"}]}, {"statementID": "openownership-register-14304061789876416412", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Isabelle Nathalie Terrisson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02264564/persons-with-significant-control/individual/MrfhSkHrd3mtdr83KBUr9Kqw1hU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b6259d", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b6259d"}], "birthDate": "1965-05-01", "addresses": [{"address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"}]}, {"statementID": "openownership-register-18159969709663061491", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jean Young"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02264564/persons-with-significant-control/individual/XIo48u2vh8yYGX03Mc9sbXLupWY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b6259b", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b6259b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1955-06-01", "addresses": [{"address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"}]}, {"statementID": "openownership-register-11765096590920476483", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark Ballantine"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02264564/persons-with-significant-control/individual/cX2186PRJF-DXWVwTv6zd3xc0S4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982df67e4ebf340b625ba", "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b625ba"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-09-01", "addresses": [{"address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"}]}]
+[
+    {
+        "statementID": "openownership-register-16978872598916964281",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AURORA OPTIONS",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02264564"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02264564",
+                "uri": "https://opencorporates.com/companies/gb/02264564"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b62561",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b62561"
+            }
+        ],
+        "foundingDate": "1988-06-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5442628093859183031",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16978872598916964281"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4825369952675511509"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-05-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5141430759142017530",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16978872598916964281"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11228655992067172683"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-05-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9215918033833049345",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16978872598916964281"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14304061789876416412"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-05-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3660110935734417343",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16978872598916964281"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18159969709663061491"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-05-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17194212719154598222",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16978872598916964281"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11765096590920476483"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-05-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4825369952675511509",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jerry Tosswell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02264564/persons-with-significant-control/individual/9Jl00MOwXfmZgCgFNbTt1FFgAwY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b62593",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b62593"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-06-01",
+        "addresses": [
+            {
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11228655992067172683",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "William Scott"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02264564/persons-with-significant-control/individual/G9x93B53k5GQdv2oSWe8IVVjDhY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b625aa",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b625aa"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-10-01",
+        "addresses": [
+            {
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14304061789876416412",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Isabelle Nathalie Terrisson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02264564/persons-with-significant-control/individual/MrfhSkHrd3mtdr83KBUr9Kqw1hU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b6259d",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b6259d"
+            }
+        ],
+        "birthDate": "1965-05-01",
+        "addresses": [
+            {
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18159969709663061491",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jean Young"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02264564/persons-with-significant-control/individual/XIo48u2vh8yYGX03Mc9sbXLupWY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b6259b",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b6259b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-06-01",
+        "addresses": [
+            {
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11765096590920476483",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark Ballantine"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02264564/persons-with-significant-control/individual/cX2186PRJF-DXWVwTv6zd3xc0S4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982df67e4ebf340b625ba",
+                "uri": "http://register.openownership.org/entities/59b982df67e4ebf340b625ba"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-09-01",
+        "addresses": [
+            {
+                "address": "Unit 3 California Building, Deals Gateway, London, SE13 7SB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02290829_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02290829_bods.json
@@ -1,1 +1,109 @@
-[{"statementID": "openownership-register-14139120649944082991", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HUNTER & PARTNERS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02290829"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02290829", "uri": "https://opencorporates.com/companies/gb/02290829"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b972aa67e4ebf340674c57", "uri": "http://register.openownership.org/entities/59b972aa67e4ebf340674c57"}], "foundingDate": "1988-08-30", "addresses": [{"type": "registered", "address": "Space One, Beadon Road, London, W6 0EA", "country": "GB"}]}, {"statementID": "openownership-register-18129745424773797282", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14139120649944082991"}, "interestedParty": {"describedByEntityStatement": "openownership-register-18301420889230001549"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-18301420889230001549", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HUNTER & PARTNERS GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02288274"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02288274"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02288274", "uri": "https://opencorporates.com/companies/gb/02288274"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b972ad67e4ebf340675365", "uri": "http://register.openownership.org/entities/59b972ad67e4ebf340675365"}], "foundingDate": "1988-08-19", "addresses": [{"type": "registered", "address": "Space One, Beadon Road, London, W6 0EA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14139120649944082991",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HUNTER & PARTNERS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02290829"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02290829",
+                "uri": "https://opencorporates.com/companies/gb/02290829"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b972aa67e4ebf340674c57",
+                "uri": "http://register.openownership.org/entities/59b972aa67e4ebf340674c57"
+            }
+        ],
+        "foundingDate": "1988-08-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Space One, Beadon Road, London, W6 0EA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18129745424773797282",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14139120649944082991"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-18301420889230001549"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-18301420889230001549",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HUNTER & PARTNERS GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02288274"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02288274"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02288274",
+                "uri": "https://opencorporates.com/companies/gb/02288274"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b972ad67e4ebf340675365",
+                "uri": "http://register.openownership.org/entities/59b972ad67e4ebf340675365"
+            }
+        ],
+        "foundingDate": "1988-08-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Space One, Beadon Road, London, W6 0EA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02294280_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02294280_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-12267814035574185293", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARROW TAXIS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02294280"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02294280", "uri": "https://opencorporates.com/companies/gb/02294280"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9780567e4ebf3408108df", "uri": "http://register.openownership.org/entities/59b9780567e4ebf3408108df"}], "foundingDate": "1988-09-08", "addresses": [{"type": "registered", "address": "3 St Georges Business Park, Brunswick Road, Ashford, TN23 1EL", "country": "GB"}]}, {"statementID": "openownership-register-351443036153280300", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12267814035574185293"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2812937587979293796"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15709861613945577531", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12267814035574185293"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5857338402210079625"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2812937587979293796", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Karen Boyce"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02294280/persons-with-significant-control/individual/21bS3kLH3taPMCSm5mNc9TvP3fE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9780567e4ebf3408108e5", "uri": "http://register.openownership.org/entities/59b9780567e4ebf3408108e5"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-10-01", "addresses": [{"address": "272, Canterbury Road, Kennington, Ashford, TN24 9QN"}]}, {"statementID": "openownership-register-5857338402210079625", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jennifer Vivien Mary Lucking"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02294280/persons-with-significant-control/individual/sCN93c5BbDmVwSHfjJ8-NMkCD3c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9780567e4ebf34081093d", "uri": "http://register.openownership.org/entities/59b9780567e4ebf34081093d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1946-05-01", "addresses": [{"address": "Casterbridge, Kempes Corner, Boughton Aluph, Ashford, TN25 4ER"}]}]
+[
+    {
+        "statementID": "openownership-register-12267814035574185293",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARROW TAXIS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02294280"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02294280",
+                "uri": "https://opencorporates.com/companies/gb/02294280"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9780567e4ebf3408108df",
+                "uri": "http://register.openownership.org/entities/59b9780567e4ebf3408108df"
+            }
+        ],
+        "foundingDate": "1988-09-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3 St Georges Business Park, Brunswick Road, Ashford, TN23 1EL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-351443036153280300",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12267814035574185293"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2812937587979293796"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15709861613945577531",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12267814035574185293"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5857338402210079625"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2812937587979293796",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Karen Boyce"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02294280/persons-with-significant-control/individual/21bS3kLH3taPMCSm5mNc9TvP3fE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9780567e4ebf3408108e5",
+                "uri": "http://register.openownership.org/entities/59b9780567e4ebf3408108e5"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-10-01",
+        "addresses": [
+            {
+                "address": "272, Canterbury Road, Kennington, Ashford, TN24 9QN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5857338402210079625",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jennifer Vivien Mary Lucking"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02294280/persons-with-significant-control/individual/sCN93c5BbDmVwSHfjJ8-NMkCD3c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9780567e4ebf34081093d",
+                "uri": "http://register.openownership.org/entities/59b9780567e4ebf34081093d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1946-05-01",
+        "addresses": [
+            {
+                "address": "Casterbridge, Kempes Corner, Boughton Aluph, Ashford, TN25 4ER"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02295904_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02295904_bods.json
@@ -1,1 +1,399 @@
-[{"statementID": "openownership-register-10450792830930127716", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VINCI CONSTRUCTION UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02295904"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02295904", "uri": "https://opencorporates.com/companies/gb/02295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2295904"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9466267e4ebf340943a54", "uri": "http://register.openownership.org/entities/59b9466267e4ebf340943a54"}], "foundingDate": "1988-09-13", "addresses": [{"type": "registered", "address": "Astral House, Imperial Way, Watford, Hertfordshire, WD24 4WW", "country": "GB"}]}, {"statementID": "openownership-register-12514178052932451192", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10450792830930127716"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10334771809677326083"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10334771809677326083", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VINCI PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00737204"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00737204", "uri": "https://opencorporates.com/companies/gb/00737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "737204"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9259f67e4ebf340feca25", "uri": "http://register.openownership.org/entities/59b9259f67e4ebf340feca25"}], "foundingDate": "1962-10-05", "addresses": [{"type": "registered", "address": "Astral House, Imperial Way, Watford, Hertfordshire, WD24 4WW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-10450792830930127716",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VINCI CONSTRUCTION UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02295904"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02295904",
+                "uri": "https://opencorporates.com/companies/gb/02295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2295904"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9466267e4ebf340943a54",
+                "uri": "http://register.openownership.org/entities/59b9466267e4ebf340943a54"
+            }
+        ],
+        "foundingDate": "1988-09-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Astral House, Imperial Way, Watford, Hertfordshire, WD24 4WW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12514178052932451192",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10450792830930127716"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10334771809677326083"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10334771809677326083",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VINCI PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00737204"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00737204",
+                "uri": "https://opencorporates.com/companies/gb/00737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "737204"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9259f67e4ebf340feca25",
+                "uri": "http://register.openownership.org/entities/59b9259f67e4ebf340feca25"
+            }
+        ],
+        "foundingDate": "1962-10-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Astral House, Imperial Way, Watford, Hertfordshire, WD24 4WW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02299375_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02299375_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-1825439650577601514", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "POTENS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299375"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299375"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02299375", "uri": "https://opencorporates.com/companies/gb/02299375"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2299375"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9564a67e4ebf340dd2e6f", "uri": "http://register.openownership.org/entities/59b9564a67e4ebf340dd2e6f"}], "foundingDate": "1988-09-23", "addresses": [{"type": "registered", "address": "9 Coombe Neville, Kingston Upon Thames, Surrey, KT2 7HW", "country": "GB"}]}, {"statementID": "openownership-register-7478248111033917294", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-1825439650577601514"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3319912804641622728"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent-as-firm", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3319912804641622728", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Bernard Edward Kinchin"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03295452/persons-with-significant-control/individual/Oy5dZ8JQv38Jf35lmHVVWvAtaXE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9721f67e4ebf34064ac26", "uri": "http://register.openownership.org/entities/59b9721f67e4ebf34064ac26"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1949-10-01", "addresses": [{"address": "9, Coombe Neville, Kingston Upon Thames, Surrey, KT2 7HW"}]}]
+[
+    {
+        "statementID": "openownership-register-1825439650577601514",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "POTENS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299375"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299375"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02299375",
+                "uri": "https://opencorporates.com/companies/gb/02299375"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2299375"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9564a67e4ebf340dd2e6f",
+                "uri": "http://register.openownership.org/entities/59b9564a67e4ebf340dd2e6f"
+            }
+        ],
+        "foundingDate": "1988-09-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "9 Coombe Neville, Kingston Upon Thames, Surrey, KT2 7HW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7478248111033917294",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1825439650577601514"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3319912804641622728"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent-as-firm",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3319912804641622728",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Bernard Edward Kinchin"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03295452/persons-with-significant-control/individual/Oy5dZ8JQv38Jf35lmHVVWvAtaXE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9721f67e4ebf34064ac26",
+                "uri": "http://register.openownership.org/entities/59b9721f67e4ebf34064ac26"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1949-10-01",
+        "addresses": [
+            {
+                "address": "9, Coombe Neville, Kingston Upon Thames, Surrey, KT2 7HW"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02299747_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02299747_bods.json
@@ -1,1 +1,769 @@
-[{"statementID": "openownership-register-13717729088423334355", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CAPITA BUSINESS SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02299747", "uri": "https://opencorporates.com/companies/gb/02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02299747"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91f1b67e4ebf340e517bf", "uri": "http://register.openownership.org/entities/59b91f1b67e4ebf340e517bf"}], "foundingDate": "1988-09-26", "addresses": [{"type": "registered", "address": "30 Berners Street, London, W1T 3LR", "country": "GB"}]}, {"statementID": "openownership-register-13526674966463777560", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13717729088423334355"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17185303026053538812"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17185303026053538812", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CAPITA HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06027254", "uri": "https://opencorporates.com/companies/gb/06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06027254"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91f0e67e4ebf340e4f4de", "uri": "http://register.openownership.org/entities/59b91f0e67e4ebf340e4f4de"}], "foundingDate": "2006-12-13", "addresses": [{"type": "registered", "address": "30 Berners Street, London, W1T 3LR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13717729088423334355",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CAPITA BUSINESS SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02299747",
+                "uri": "https://opencorporates.com/companies/gb/02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02299747"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91f1b67e4ebf340e517bf",
+                "uri": "http://register.openownership.org/entities/59b91f1b67e4ebf340e517bf"
+            }
+        ],
+        "foundingDate": "1988-09-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "30 Berners Street, London, W1T 3LR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13526674966463777560",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13717729088423334355"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17185303026053538812"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17185303026053538812",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CAPITA HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06027254",
+                "uri": "https://opencorporates.com/companies/gb/06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06027254"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91f0e67e4ebf340e4f4de",
+                "uri": "http://register.openownership.org/entities/59b91f0e67e4ebf340e4f4de"
+            }
+        ],
+        "foundingDate": "2006-12-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "30 Berners Street, London, W1T 3LR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02329448_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02329448_bods.json
@@ -1,1 +1,241 @@
-[{"statementID": "openownership-register-7038137213261171897", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INTERSERVE FS (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02329448"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02329448", "uri": "https://opencorporates.com/companies/gb/02329448"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91f8667e4ebf340e677e9", "uri": "http://register.openownership.org/entities/59b91f8667e4ebf340e677e9"}], "foundingDate": "1988-12-19", "addresses": [{"type": "registered", "address": "Capital Tower, 91 Waterloo Road, London, SE1 8RT", "country": "GB"}]}, {"statementID": "openownership-register-2176715420753808559", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7038137213261171897"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10446104643415693684"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10446104643415693684", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INTERSERVEFM LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02820560"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02820560", "uri": "https://opencorporates.com/companies/gb/02820560"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b942c567e4ebf34084cb82", "uri": "http://register.openownership.org/entities/59b942c567e4ebf34084cb82"}], "foundingDate": "1993-05-21", "addresses": [{"type": "registered", "address": "Capital Tower, 91 Waterloo Road, London, SE1 8RT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7038137213261171897",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INTERSERVE FS (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02329448"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02329448",
+                "uri": "https://opencorporates.com/companies/gb/02329448"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91f8667e4ebf340e677e9",
+                "uri": "http://register.openownership.org/entities/59b91f8667e4ebf340e677e9"
+            }
+        ],
+        "foundingDate": "1988-12-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Capital Tower, 91 Waterloo Road, London, SE1 8RT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2176715420753808559",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7038137213261171897"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10446104643415693684"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10446104643415693684",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INTERSERVEFM LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02820560"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02820560",
+                "uri": "https://opencorporates.com/companies/gb/02820560"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b942c567e4ebf34084cb82",
+                "uri": "http://register.openownership.org/entities/59b942c567e4ebf34084cb82"
+            }
+        ],
+        "foundingDate": "1993-05-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Capital Tower, 91 Waterloo Road, London, SE1 8RT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02373535_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02373535_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-16779427147761808328", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASHE CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02373535"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02373535", "uri": "https://opencorporates.com/companies/gb/02373535"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9456767e4ebf3408f89ef", "uri": "http://register.openownership.org/entities/59b9456767e4ebf3408f89ef"}], "foundingDate": "1989-04-18", "addresses": [{"type": "registered", "address": "Ashe House, Cooks Way, Hitchin, Hertfordshire, SG4 0JE", "country": "GB"}]}, {"statementID": "openownership-register-7842211433775674466", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16779427147761808328"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12223315009720834291"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12223315009720834291", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Stephen Blake"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02373535/persons-with-significant-control/individual/zXjNVe7q4v6-Z2QkZOJojB_nRaE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9456767e4ebf3408f89f7", "uri": "http://register.openownership.org/entities/59b9456767e4ebf3408f89f7"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1938-09-01", "addresses": [{"address": "73 Pasture Road, Letchworth, Hertfordshire, SG6 3LS"}]}]
+[
+    {
+        "statementID": "openownership-register-16779427147761808328",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASHE CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02373535"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02373535",
+                "uri": "https://opencorporates.com/companies/gb/02373535"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9456767e4ebf3408f89ef",
+                "uri": "http://register.openownership.org/entities/59b9456767e4ebf3408f89ef"
+            }
+        ],
+        "foundingDate": "1989-04-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ashe House, Cooks Way, Hitchin, Hertfordshire, SG4 0JE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7842211433775674466",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16779427147761808328"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12223315009720834291"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12223315009720834291",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Stephen Blake"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02373535/persons-with-significant-control/individual/zXjNVe7q4v6-Z2QkZOJojB_nRaE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9456767e4ebf3408f89f7",
+                "uri": "http://register.openownership.org/entities/59b9456767e4ebf3408f89f7"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1938-09-01",
+        "addresses": [
+            {
+                "address": "73 Pasture Road, Letchworth, Hertfordshire, SG6 3LS"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02379469_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02379469_bods.json
@@ -1,1 +1,218 @@
-[{"statementID": "openownership-register-13116189938749466509", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BAM CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379469"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02379469", "uri": "https://opencorporates.com/companies/gb/02379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379469"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379469"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bf8267e4ebf340985115", "uri": "http://register.openownership.org/entities/59b9bf8267e4ebf340985115"}], "foundingDate": "1989-05-04", "addresses": [{"type": "registered", "address": "Breakspear Park, Breakspear Way, Hemel Hempstead, HP2 4FL", "country": "GB"}]}, {"statementID": "openownership-register-4682636302554575539", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13116189938749466509"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12055941528223019016"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12055941528223019016", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BAM CONSTRUCT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03311781"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03311781", "uri": "https://opencorporates.com/companies/gb/03311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3311781"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b968c667e4ebf3403505c1", "uri": "http://register.openownership.org/entities/59b968c667e4ebf3403505c1"}], "foundingDate": "1997-02-03", "addresses": [{"type": "registered", "address": "Breakspear Park, Breakspear Way, Hemel Hempstead, HP2 4FL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13116189938749466509",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BAM CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379469"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02379469",
+                "uri": "https://opencorporates.com/companies/gb/02379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379469"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379469"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bf8267e4ebf340985115",
+                "uri": "http://register.openownership.org/entities/59b9bf8267e4ebf340985115"
+            }
+        ],
+        "foundingDate": "1989-05-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Breakspear Park, Breakspear Way, Hemel Hempstead, HP2 4FL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4682636302554575539",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13116189938749466509"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12055941528223019016"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12055941528223019016",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BAM CONSTRUCT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03311781"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03311781",
+                "uri": "https://opencorporates.com/companies/gb/03311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3311781"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b968c667e4ebf3403505c1",
+                "uri": "http://register.openownership.org/entities/59b968c667e4ebf3403505c1"
+            }
+        ],
+        "foundingDate": "1997-02-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Breakspear Park, Breakspear Way, Hemel Hempstead, HP2 4FL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02389033_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02389033_bods.json
@@ -1,1 +1,190 @@
-[{"statementID": "openownership-register-13238425266875273098", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RANDSTAD SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02389033"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02389033", "uri": "https://opencorporates.com/companies/gb/02389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2389033"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2389033"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97c1c67e4ebf34095a073", "uri": "http://register.openownership.org/entities/59b97c1c67e4ebf34095a073"}], "foundingDate": "1989-05-25", "addresses": [{"type": "registered", "address": "450 Capability Green, Luton, Bedfordshire, LU1 3LU", "country": "GB"}]}, {"statementID": "openownership-register-911570196070524330", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-29", "subject": {"describedByEntityStatement": "openownership-register-13238425266875273098"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3569459344457134267"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-29"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-29"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-29"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3569459344457134267", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RANDSTAD UK HOLDING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01753882"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01753882", "uri": "https://opencorporates.com/companies/gb/01753882"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9564167e4ebf340dd0db5", "uri": "http://register.openownership.org/entities/59b9564167e4ebf340dd0db5"}], "foundingDate": "1983-09-19", "addresses": [{"type": "registered", "address": "450 Capability Green, Luton, Bedfordshire, LU1 3LU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13238425266875273098",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RANDSTAD SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02389033"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02389033",
+                "uri": "https://opencorporates.com/companies/gb/02389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2389033"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2389033"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97c1c67e4ebf34095a073",
+                "uri": "http://register.openownership.org/entities/59b97c1c67e4ebf34095a073"
+            }
+        ],
+        "foundingDate": "1989-05-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "450 Capability Green, Luton, Bedfordshire, LU1 3LU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-911570196070524330",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13238425266875273098"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3569459344457134267"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-29"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-29"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-29"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3569459344457134267",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RANDSTAD UK HOLDING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01753882"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01753882",
+                "uri": "https://opencorporates.com/companies/gb/01753882"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9564167e4ebf340dd0db5",
+                "uri": "http://register.openownership.org/entities/59b9564167e4ebf340dd0db5"
+            }
+        ],
+        "foundingDate": "1983-09-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "450 Capability Green, Luton, Bedfordshire, LU1 3LU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02413137_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02413137_bods.json
@@ -1,1 +1,250 @@
-[{"statementID": "openownership-register-8193690666033265385", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "QA LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02413137"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02413137"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02413137"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02413137", "uri": "https://opencorporates.com/companies/gb/02413137"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2413137"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2413137"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2413137"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9dcad67e4ebf34004c341", "uri": "http://register.openownership.org/entities/59b9dcad67e4ebf34004c341"}], "foundingDate": "1989-08-14", "addresses": [{"type": "registered", "address": "Rath House, 55-65 Uxbridge Road, Slough, Berkshire, SL1 1SG", "country": "GB"}]}, {"statementID": "openownership-register-4139369446066628291", "statementType": "ownershipOrControlStatement", "statementDate": "2017-06-23", "subject": {"describedByEntityStatement": "openownership-register-8193690666033265385"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7000781160411308409"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-06-23"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-06-23"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-06-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7000781160411308409", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SECKLOE 208 LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03684770"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03684770", "uri": "https://opencorporates.com/companies/gb/03684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3684770"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab99f6c9dfc3fae1840b4af", "uri": "http://register.openownership.org/entities/5ab99f6c9dfc3fae1840b4af"}], "foundingDate": "1998-12-16", "addresses": [{"type": "registered", "address": "Rath House, 55-65 Uxbridge Road, Slough, Berkshire, SL1 1SG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8193690666033265385",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "QA LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02413137"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02413137"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02413137"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02413137",
+                "uri": "https://opencorporates.com/companies/gb/02413137"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2413137"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2413137"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2413137"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9dcad67e4ebf34004c341",
+                "uri": "http://register.openownership.org/entities/59b9dcad67e4ebf34004c341"
+            }
+        ],
+        "foundingDate": "1989-08-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Rath House, 55-65 Uxbridge Road, Slough, Berkshire, SL1 1SG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4139369446066628291",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-06-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8193690666033265385"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7000781160411308409"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-06-23"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-06-23"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-06-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7000781160411308409",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SECKLOE 208 LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03684770"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03684770",
+                "uri": "https://opencorporates.com/companies/gb/03684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3684770"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab99f6c9dfc3fae1840b4af",
+                "uri": "http://register.openownership.org/entities/5ab99f6c9dfc3fae1840b4af"
+            }
+        ],
+        "foundingDate": "1998-12-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Rath House, 55-65 Uxbridge Road, Slough, Berkshire, SL1 1SG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02425951_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02425951_bods.json
@@ -1,1 +1,143 @@
-[{"statementID": "openownership-register-7419853740771495613", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HSL COMPLIANCE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02425951"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02425951", "uri": "https://opencorporates.com/companies/gb/02425951"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ece67e4ebf340bb38f5", "uri": "http://register.openownership.org/entities/59b94ece67e4ebf340bb38f5"}], "foundingDate": "1989-09-25", "addresses": [{"type": "registered", "address": "Alton House Alton Business Park, Alton Road, Ross-On-Wye, Herefordshire, HR9 5BP", "country": "GB"}]}, {"statementID": "openownership-register-11638115688545527753", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7419853740771495613"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6550412390684688546"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6550412390684688546", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KIWA UK COMPLIANCE HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08313030"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08313030", "uri": "https://opencorporates.com/companies/gb/08313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8313030"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08313030"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ed067e4ebf340bb3de0", "uri": "http://register.openownership.org/entities/59b94ed067e4ebf340bb3de0"}], "foundingDate": "2012-11-29", "addresses": [{"type": "registered", "address": "Alton House, Alton Road, Ross-On-Wye, Herefordshire, HR9 5BP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7419853740771495613",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HSL COMPLIANCE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02425951"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02425951",
+                "uri": "https://opencorporates.com/companies/gb/02425951"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ece67e4ebf340bb38f5",
+                "uri": "http://register.openownership.org/entities/59b94ece67e4ebf340bb38f5"
+            }
+        ],
+        "foundingDate": "1989-09-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Alton House Alton Business Park, Alton Road, Ross-On-Wye, Herefordshire, HR9 5BP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11638115688545527753",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7419853740771495613"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6550412390684688546"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6550412390684688546",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KIWA UK COMPLIANCE HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08313030"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08313030",
+                "uri": "https://opencorporates.com/companies/gb/08313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08313030"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ed067e4ebf340bb3de0",
+                "uri": "http://register.openownership.org/entities/59b94ed067e4ebf340bb3de0"
+            }
+        ],
+        "foundingDate": "2012-11-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Alton House, Alton Road, Ross-On-Wye, Herefordshire, HR9 5BP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02472080_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02472080_bods.json
@@ -1,1 +1,290 @@
-[{"statementID": "openownership-register-14812345072639568040", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GALLIFORD TRY CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02472080"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02472080", "uri": "https://opencorporates.com/companies/gb/02472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2472080"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2472080"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368367e4ebf3404dc9b5", "uri": "http://register.openownership.org/entities/59b9368367e4ebf3404dc9b5"}], "foundingDate": "1990-02-20", "addresses": [{"type": "registered", "address": "Cowley Business Park, Cowley, Uxbridge, Middlesex, UB8 2AL", "country": "GB"}]}, {"statementID": "openownership-register-6332512893256649596", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14812345072639568040"}, "interestedParty": {"describedByEntityStatement": "openownership-register-968572071509614404"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-968572071509614404", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GALLIFORD TRY CONSTRUCTION & INVESTMENTS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04530735", "uri": "https://opencorporates.com/companies/gb/04530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4530735"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04530735"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b2167e4ebf34016848c", "uri": "http://register.openownership.org/entities/59b92b2167e4ebf34016848c"}], "foundingDate": "2002-09-10", "addresses": [{"type": "registered", "address": "Cowley Business Park, High Street Cowley, Uxbridge, Middlesex, UB8 2AL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14812345072639568040",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GALLIFORD TRY CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02472080"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02472080",
+                "uri": "https://opencorporates.com/companies/gb/02472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2472080"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2472080"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368367e4ebf3404dc9b5",
+                "uri": "http://register.openownership.org/entities/59b9368367e4ebf3404dc9b5"
+            }
+        ],
+        "foundingDate": "1990-02-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cowley Business Park, Cowley, Uxbridge, Middlesex, UB8 2AL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6332512893256649596",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14812345072639568040"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-968572071509614404"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-968572071509614404",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GALLIFORD TRY CONSTRUCTION & INVESTMENTS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04530735",
+                "uri": "https://opencorporates.com/companies/gb/04530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4530735"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04530735"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b2167e4ebf34016848c",
+                "uri": "http://register.openownership.org/entities/59b92b2167e4ebf34016848c"
+            }
+        ],
+        "foundingDate": "2002-09-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cowley Business Park, High Street Cowley, Uxbridge, Middlesex, UB8 2AL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02481991_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02481991_bods.json
@@ -1,1 +1,323 @@
-[{"statementID": "openownership-register-15423582078868648277", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VEOLIA ES (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02481991", "uri": "https://opencorporates.com/companies/gb/02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02481991"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab946319dfc3fae186849b4", "uri": "http://register.openownership.org/entities/5ab946319dfc3fae186849b4"}], "foundingDate": "1990-03-16", "addresses": [{"type": "registered", "address": "210 Pentonville Road, London, N1 9JY", "country": "GB"}]}, {"statementID": "openownership-register-5247846338404446325", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-15423582078868648277"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15694518436180161071"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15694518436180161071", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VEOLIA ENVIRONMENTAL SERVICES (UK) PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02215767"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02215767", "uri": "https://opencorporates.com/companies/gb/02215767"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b939cb67e4ebf3405ccde2", "uri": "http://register.openownership.org/entities/59b939cb67e4ebf3405ccde2"}], "foundingDate": "1988-02-01", "addresses": [{"type": "registered", "address": "210 Pentonville Road, London, N1 9JY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15423582078868648277",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VEOLIA ES (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02481991",
+                "uri": "https://opencorporates.com/companies/gb/02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02481991"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab946319dfc3fae186849b4",
+                "uri": "http://register.openownership.org/entities/5ab946319dfc3fae186849b4"
+            }
+        ],
+        "foundingDate": "1990-03-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "210 Pentonville Road, London, N1 9JY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5247846338404446325",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15423582078868648277"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15694518436180161071"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15694518436180161071",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VEOLIA ENVIRONMENTAL SERVICES (UK) PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02215767"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02215767",
+                "uri": "https://opencorporates.com/companies/gb/02215767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b939cb67e4ebf3405ccde2",
+                "uri": "http://register.openownership.org/entities/59b939cb67e4ebf3405ccde2"
+            }
+        ],
+        "foundingDate": "1988-02-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "210 Pentonville Road, London, N1 9JY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02490104_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02490104_bods.json
@@ -1,1 +1,102 @@
-[{"statementID": "openownership-register-8131160205928969255", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BIO-TECHNE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02490104"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02490104"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02490104", "uri": "https://opencorporates.com/companies/gb/02490104"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9430567e4ebf34085c86d", "uri": "http://register.openownership.org/entities/59b9430567e4ebf34085c86d"}], "foundingDate": "1990-04-06", "addresses": [{"type": "registered", "address": "19 Barton Lane, Abingdon Science Park, Abingdon, Oxfordshire, OX14 3NB", "country": "GB"}]}, {"statementID": "openownership-register-5664480588659611573", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8131160205928969255"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7352599965217774223"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7352599965217774223", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Bio-Techne Corporation", "incorporatedInJurisdiction": {"name": "United States of America", "code": "US"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02490104/persons-with-significant-control/corporate-entity/uzLNsInNhtfZP9YiNhpafwBWpUI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9430667e4ebf34085caf6", "uri": "http://register.openownership.org/entities/59b9430667e4ebf34085caf6"}], "addresses": [{"type": "registered", "address": "614, Mckinley Place Ne, Minneapolis, Minnesota, MN55413", "country": "US"}]}]
+[
+    {
+        "statementID": "openownership-register-8131160205928969255",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BIO-TECHNE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02490104"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02490104"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02490104",
+                "uri": "https://opencorporates.com/companies/gb/02490104"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9430567e4ebf34085c86d",
+                "uri": "http://register.openownership.org/entities/59b9430567e4ebf34085c86d"
+            }
+        ],
+        "foundingDate": "1990-04-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19 Barton Lane, Abingdon Science Park, Abingdon, Oxfordshire, OX14 3NB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5664480588659611573",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8131160205928969255"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7352599965217774223"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7352599965217774223",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Bio-Techne Corporation",
+        "incorporatedInJurisdiction": {
+            "name": "United States of America",
+            "code": "US"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02490104/persons-with-significant-control/corporate-entity/uzLNsInNhtfZP9YiNhpafwBWpUI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9430667e4ebf34085caf6",
+                "uri": "http://register.openownership.org/entities/59b9430667e4ebf34085caf6"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "614, Mckinley Place Ne, Minneapolis, Minnesota, MN55413",
+                "country": "US"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02519234_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02519234_bods.json
@@ -1,1 +1,397 @@
-[{"statementID": "openownership-register-12306912076612711954", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MEARS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02519234", "uri": "https://opencorporates.com/companies/gb/02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02519234"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91c1e67e4ebf340dbb31a", "uri": "http://register.openownership.org/entities/59b91c1e67e4ebf340dbb31a"}], "foundingDate": "1990-07-06", "addresses": [{"type": "registered", "address": "1390 Montpellier Court, Gloucester Business Park,, Brockworth, Gloucester, GL3 4AH", "country": "GB"}]}, {"statementID": "openownership-register-13312045617606979014", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12306912076612711954"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10426311126133505625"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-firm", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent-as-firm", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10426311126133505625", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MEARS GROUP PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03232863"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03232863", "uri": "https://opencorporates.com/companies/gb/03232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3232863"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91c1f67e4ebf340dbb74d", "uri": "http://register.openownership.org/entities/59b91c1f67e4ebf340dbb74d"}], "foundingDate": "1996-08-01", "addresses": [{"type": "registered", "address": "1390 Montpellier Court, Gloucester Business Park, Brockworth, Gloucester, GL3 4AH", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12306912076612711954",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MEARS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02519234",
+                "uri": "https://opencorporates.com/companies/gb/02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02519234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91c1e67e4ebf340dbb31a",
+                "uri": "http://register.openownership.org/entities/59b91c1e67e4ebf340dbb31a"
+            }
+        ],
+        "foundingDate": "1990-07-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1390 Montpellier Court, Gloucester Business Park,, Brockworth, Gloucester, GL3 4AH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13312045617606979014",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12306912076612711954"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10426311126133505625"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-firm",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent-as-firm",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10426311126133505625",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MEARS GROUP PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03232863"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03232863",
+                "uri": "https://opencorporates.com/companies/gb/03232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3232863"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91c1f67e4ebf340dbb74d",
+                "uri": "http://register.openownership.org/entities/59b91c1f67e4ebf340dbb74d"
+            }
+        ],
+        "foundingDate": "1996-08-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1390 Montpellier Court, Gloucester Business Park, Brockworth, Gloucester, GL3 4AH",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02529939_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02529939_bods.json
@@ -1,1 +1,265 @@
-[{"statementID": "openownership-register-8685105866471461966", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ESH CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02529939"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02529939", "uri": "https://opencorporates.com/companies/gb/02529939"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018cfff", "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018cfff"}], "foundingDate": "1990-08-10", "addresses": [{"type": "registered", "address": "Esh House, Bowburn North Industrial Estate, Bowburn, Durham, DH6 5PF", "country": "GB"}]}, {"statementID": "openownership-register-12285097450855826661", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-10", "subject": {"describedByEntityStatement": "openownership-register-8685105866471461966"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16849053642906720177"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-08-10"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-08-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16849053642906720177", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ESH HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03724890", "uri": "https://opencorporates.com/companies/gb/03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03724890"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018d293", "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018d293"}], "foundingDate": "1999-03-03", "addresses": [{"type": "registered", "address": "Esh House, Bowburn North Industrial Estate, Bowburn, Durham, DH6 5PF", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8685105866471461966",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ESH CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02529939"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02529939",
+                "uri": "https://opencorporates.com/companies/gb/02529939"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018cfff",
+                "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018cfff"
+            }
+        ],
+        "foundingDate": "1990-08-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Esh House, Bowburn North Industrial Estate, Bowburn, Durham, DH6 5PF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12285097450855826661",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8685105866471461966"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16849053642906720177"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-10"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16849053642906720177",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ESH HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03724890",
+                "uri": "https://opencorporates.com/companies/gb/03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03724890"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018d293",
+                "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018d293"
+            }
+        ],
+        "foundingDate": "1999-03-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Esh House, Bowburn North Industrial Estate, Bowburn, Durham, DH6 5PF",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02530207_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02530207_bods.json
@@ -1,1 +1,259 @@
-[{"statementID": "openownership-register-16759715981876063167", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HUNTERS CONTRACTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02530207"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02530207", "uri": "https://opencorporates.com/companies/gb/02530207"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492bd", "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492bd"}], "foundingDate": "1990-08-13", "addresses": [{"type": "registered", "address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP", "country": "GB"}]}, {"statementID": "openownership-register-1848811945709103981", "statementType": "ownershipOrControlStatement", "statementDate": "2019-08-23", "subject": {"describedByEntityStatement": "openownership-register-16759715981876063167"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5181218656863256527"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-08-23"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-08-23"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-08-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-1151005138289814879", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-06", "subject": {"describedByEntityStatement": "openownership-register-16759715981876063167"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7113287072679054831"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-08-06", "endDate": "2019-08-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-7484868920946975944", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-06", "subject": {"describedByEntityStatement": "openownership-register-16759715981876063167"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4693730484952132358"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-08-06", "endDate": "2019-08-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-5181218656863256527", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HUNTERS CONTRACTS (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10015572"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10015572", "uri": "https://opencorporates.com/companies/gb/10015572"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10015572"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d4267e4ebf340de5ec1", "uri": "http://register.openownership.org/entities/59b98d4267e4ebf340de5ec1"}], "foundingDate": "2016-02-19", "addresses": [{"type": "registered", "address": "Unit A Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP", "country": "GB"}]}, {"statementID": "openownership-register-7113287072679054831", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Martin Playell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02530207/persons-with-significant-control/individual/HrXXGb2quBs8pW2qlIsRfxJ6cww"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492c9", "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492c9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-02-01", "addresses": [{"address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP"}]}, {"statementID": "openownership-register-4693730484952132358", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Gary Mark Thomas"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02530207/persons-with-significant-control/individual/StB9AGeAXMMX_HpgoMm9STXGD2E"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492cc", "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492cc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-07-01", "addresses": [{"address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP"}]}]
+[
+    {
+        "statementID": "openownership-register-16759715981876063167",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HUNTERS CONTRACTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02530207"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02530207",
+                "uri": "https://opencorporates.com/companies/gb/02530207"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492bd",
+                "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492bd"
+            }
+        ],
+        "foundingDate": "1990-08-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1848811945709103981",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-08-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16759715981876063167"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5181218656863256527"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-08-23"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-08-23"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-08-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1151005138289814879",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16759715981876063167"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7113287072679054831"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-06",
+                "endDate": "2019-08-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7484868920946975944",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16759715981876063167"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4693730484952132358"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-06",
+                "endDate": "2019-08-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5181218656863256527",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HUNTERS CONTRACTS (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10015572"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10015572",
+                "uri": "https://opencorporates.com/companies/gb/10015572"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10015572"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d4267e4ebf340de5ec1",
+                "uri": "http://register.openownership.org/entities/59b98d4267e4ebf340de5ec1"
+            }
+        ],
+        "foundingDate": "2016-02-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit A Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7113287072679054831",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Martin Playell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02530207/persons-with-significant-control/individual/HrXXGb2quBs8pW2qlIsRfxJ6cww"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492c9",
+                "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492c9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-02-01",
+        "addresses": [
+            {
+                "address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4693730484952132358",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Gary Mark Thomas"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02530207/persons-with-significant-control/individual/StB9AGeAXMMX_HpgoMm9STXGD2E"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9349567e4ebf3404492cc",
+                "uri": "http://register.openownership.org/entities/59b9349567e4ebf3404492cc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-07-01",
+        "addresses": [
+            {
+                "address": "Unit A, Oyo Business Units, Hindmans Way, Dagenham, Essex, RM9 6LP"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02530851_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02530851_bods.json
@@ -1,1 +1,192 @@
-[{"statementID": "openownership-register-2959552535522738718", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "APEM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02530851"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02530851", "uri": "https://opencorporates.com/companies/gb/02530851"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b933e467e4ebf3404179c7", "uri": "http://register.openownership.org/entities/59b933e467e4ebf3404179c7"}], "foundingDate": "1990-08-14", "addresses": [{"type": "registered", "address": "Riverview, A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN", "country": "GB"}]}, {"statementID": "openownership-register-15406016182750710511", "statementType": "ownershipOrControlStatement", "statementDate": "2019-03-05", "subject": {"describedByEntityStatement": "openownership-register-2959552535522738718"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14718192996782187986"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-03-05"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-03-05"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-03-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13319353152943773616", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2959552535522738718"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14730749025880856662"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-03-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-14718192996782187986", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "APEM GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11768489"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11768489", "uri": "https://opencorporates.com/companies/gb/11768489"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "11768489"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5c5bb8419dfc3fae18ebe995", "uri": "http://register.openownership.org/entities/5c5bb8419dfc3fae18ebe995"}], "foundingDate": "2019-01-15", "addresses": [{"type": "registered", "address": "Riverview A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN", "country": "GB"}]}, {"statementID": "openownership-register-14730749025880856662", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Keith Hendry"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02530851/persons-with-significant-control/individual/njbJc0D34Ptc79sST6FeP6seYBQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b933e467e4ebf3404179d6", "uri": "http://register.openownership.org/entities/59b933e467e4ebf3404179d6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-09-01", "addresses": [{"address": "Riverview, A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN"}]}]
+[
+    {
+        "statementID": "openownership-register-2959552535522738718",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "APEM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02530851"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02530851",
+                "uri": "https://opencorporates.com/companies/gb/02530851"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b933e467e4ebf3404179c7",
+                "uri": "http://register.openownership.org/entities/59b933e467e4ebf3404179c7"
+            }
+        ],
+        "foundingDate": "1990-08-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Riverview, A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15406016182750710511",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-03-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2959552535522738718"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14718192996782187986"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-03-05"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-03-05"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-03-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13319353152943773616",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2959552535522738718"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14730749025880856662"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-03-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14718192996782187986",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "APEM GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11768489"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11768489",
+                "uri": "https://opencorporates.com/companies/gb/11768489"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11768489"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5c5bb8419dfc3fae18ebe995",
+                "uri": "http://register.openownership.org/entities/5c5bb8419dfc3fae18ebe995"
+            }
+        ],
+        "foundingDate": "2019-01-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Riverview A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14730749025880856662",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Keith Hendry"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02530851/persons-with-significant-control/individual/njbJc0D34Ptc79sST6FeP6seYBQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b933e467e4ebf3404179d6",
+                "uri": "http://register.openownership.org/entities/59b933e467e4ebf3404179d6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-09-01",
+        "addresses": [
+            {
+                "address": "Riverview, A17 Embankment Business Park, Vale Road Heaton Mersey, Stockport, SK4 3GN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02535286_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02535286_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-3140536593693276898", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STAPLES UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02535286"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02535286", "uri": "https://opencorporates.com/companies/gb/02535286"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a7a67e4ebf340602ac6", "uri": "http://register.openownership.org/entities/59b93a7a67e4ebf340602ac6"}], "foundingDate": "1990-08-29", "addresses": [{"type": "registered", "address": "Hampden Court Kingsmead Business Park, Frederick Place, High Wycombe, Buckinghamshire, HP11 1JU", "country": "GB"}]}, {"statementID": "openownership-register-4702759896178580316", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3140536593693276898"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11762466320884634251"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11762466320884634251", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CORPORATE EXPRESS (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03132440"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03132440"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03132440", "uri": "https://opencorporates.com/companies/gb/03132440"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3132440"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03132440"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a7b67e4ebf3406030da", "uri": "http://register.openownership.org/entities/59b93a7b67e4ebf3406030da"}], "foundingDate": "1995-11-30", "addresses": [{"type": "registered", "address": "Hampden Court Kingsmead Business Park, Frederick Place, High Wycombe, Buckinghamshire, HP11 1JU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3140536593693276898",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STAPLES UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02535286"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02535286",
+                "uri": "https://opencorporates.com/companies/gb/02535286"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a7a67e4ebf340602ac6",
+                "uri": "http://register.openownership.org/entities/59b93a7a67e4ebf340602ac6"
+            }
+        ],
+        "foundingDate": "1990-08-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hampden Court Kingsmead Business Park, Frederick Place, High Wycombe, Buckinghamshire, HP11 1JU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4702759896178580316",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3140536593693276898"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11762466320884634251"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11762466320884634251",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CORPORATE EXPRESS (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03132440"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03132440"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03132440",
+                "uri": "https://opencorporates.com/companies/gb/03132440"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3132440"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03132440"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a7b67e4ebf3406030da",
+                "uri": "http://register.openownership.org/entities/59b93a7b67e4ebf3406030da"
+            }
+        ],
+        "foundingDate": "1995-11-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hampden Court Kingsmead Business Park, Frederick Place, High Wycombe, Buckinghamshire, HP11 1JU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02548628_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02548628_bods.json
@@ -1,1 +1,269 @@
-[{"statementID": "openownership-register-1408225864947173035", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PHOENIX SOFTWARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02548628"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02548628", "uri": "https://opencorporates.com/companies/gb/02548628"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9e22d67e4ebf34019520d", "uri": "http://register.openownership.org/entities/59b9e22d67e4ebf34019520d"}], "foundingDate": "1990-10-15", "addresses": [{"type": "registered", "address": "Bytes House, Randalls Way, Leatherhead, Surrey, KT22 7TW", "country": "GB"}]}, {"statementID": "openownership-register-2911773711195369529", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1408225864947173035"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11218051081178925359"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11421255105105191460", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1408225864947173035"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13801608237357367213"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13307402913362855113", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1408225864947173035"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2291237452346271484"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2291237452346271484", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BLENHEIM GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04070724"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04070724"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04070724"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04070724", "uri": "https://opencorporates.com/companies/gb/04070724"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4070724"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb88", "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb88"}], "foundingDate": "2000-09-13", "addresses": [{"type": "registered", "address": "Bytes House, Randalls Way, Leatherhead, Surrey, KT22 7TW", "country": "GB"}]}, {"statementID": "openownership-register-13801608237357367213", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Ewan Forsyth"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04070724/persons-with-significant-control/individual/69BDliv7ULkC4UmB6pPQuMmrhSY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069ebf2", "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069ebf2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-03-01", "addresses": [{"address": "Blenheim House, York Road Pocklington, York, YO42 1NS"}]}, {"statementID": "openownership-register-11218051081178925359", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Suzanne Elizabeth Marshall-Forsyth"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04070724/persons-with-significant-control/individual/zCOPNvNOmZhOxUIAKrIwUHwLVnQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb98", "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb98"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-10-01", "addresses": [{"address": "Blenheim House, York Road Pocklington, York, YO42 1NS"}]}]
+[
+    {
+        "statementID": "openownership-register-1408225864947173035",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PHOENIX SOFTWARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02548628"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02548628",
+                "uri": "https://opencorporates.com/companies/gb/02548628"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9e22d67e4ebf34019520d",
+                "uri": "http://register.openownership.org/entities/59b9e22d67e4ebf34019520d"
+            }
+        ],
+        "foundingDate": "1990-10-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Bytes House, Randalls Way, Leatherhead, Surrey, KT22 7TW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2911773711195369529",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1408225864947173035"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11218051081178925359"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11421255105105191460",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1408225864947173035"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13801608237357367213"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13307402913362855113",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1408225864947173035"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2291237452346271484"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2291237452346271484",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BLENHEIM GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04070724"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04070724"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04070724"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04070724",
+                "uri": "https://opencorporates.com/companies/gb/04070724"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4070724"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb88",
+                "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb88"
+            }
+        ],
+        "foundingDate": "2000-09-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Bytes House, Randalls Way, Leatherhead, Surrey, KT22 7TW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13801608237357367213",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Ewan Forsyth"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04070724/persons-with-significant-control/individual/69BDliv7ULkC4UmB6pPQuMmrhSY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069ebf2",
+                "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069ebf2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-03-01",
+        "addresses": [
+            {
+                "address": "Blenheim House, York Road Pocklington, York, YO42 1NS"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11218051081178925359",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Suzanne Elizabeth Marshall-Forsyth"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04070724/persons-with-significant-control/individual/zCOPNvNOmZhOxUIAKrIwUHwLVnQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb98",
+                "uri": "http://register.openownership.org/entities/59b93c9867e4ebf34069eb98"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-10-01",
+        "addresses": [
+            {
+                "address": "Blenheim House, York Road Pocklington, York, YO42 1NS"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02549296_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02549296_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-17668807612686345858", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LAND USE CONSULTANTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02549296"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02549296"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02549296", "uri": "https://opencorporates.com/companies/gb/02549296"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94a8167e4ebf340a88ade", "uri": "http://register.openownership.org/entities/59b94a8167e4ebf340a88ade"}], "foundingDate": "1990-10-17", "addresses": [{"type": "registered", "address": "250 Waterloo Road, London, SE1 8RD", "country": "GB"}]}, {"statementID": "openownership-register-5545381169558994637", "statementType": "ownershipOrControlStatement", "statementDate": "2019-12-24", "subject": {"describedByEntityStatement": "openownership-register-17668807612686345858"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3113747546022031505"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-24"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-3113747546022031505", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LAND USE CONSULTANTS TRUSTEE (EOT) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "12349809"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/12349809", "uri": "https://opencorporates.com/companies/gb/12349809"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "12349809"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5def86529dfc3fae18ef7562", "uri": "http://register.openownership.org/entities/5def86529dfc3fae18ef7562"}], "foundingDate": "2019-12-05", "addresses": [{"type": "registered", "address": "250 Waterloo Road, London, SE1 8RD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17668807612686345858",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LAND USE CONSULTANTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02549296"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02549296"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02549296",
+                "uri": "https://opencorporates.com/companies/gb/02549296"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94a8167e4ebf340a88ade",
+                "uri": "http://register.openownership.org/entities/59b94a8167e4ebf340a88ade"
+            }
+        ],
+        "foundingDate": "1990-10-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "250 Waterloo Road, London, SE1 8RD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5545381169558994637",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-12-24",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17668807612686345858"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3113747546022031505"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3113747546022031505",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LAND USE CONSULTANTS TRUSTEE (EOT) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12349809"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/12349809",
+                "uri": "https://opencorporates.com/companies/gb/12349809"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12349809"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5def86529dfc3fae18ef7562",
+                "uri": "http://register.openownership.org/entities/5def86529dfc3fae18ef7562"
+            }
+        ],
+        "foundingDate": "2019-12-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "250 Waterloo Road, London, SE1 8RD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02562870_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02562870_bods.json
@@ -1,1 +1,296 @@
-[{"statementID": "openownership-register-4257617163209321874", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FRAZER-NASH CONSULTANCY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02562870"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02562870", "uri": "https://opencorporates.com/companies/gb/02562870"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2562870"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95d1367e4ebf340fd5384", "uri": "http://register.openownership.org/entities/59b95d1367e4ebf340fd5384"}], "foundingDate": "1990-11-27", "addresses": [{"type": "registered", "address": "C/O Devonport Royal Dockyard Ltd, Devonport, Plymouth, Devon, PL1 4SG", "country": "GB"}]}, {"statementID": "openownership-register-9579119561319370635", "statementType": "ownershipOrControlStatement", "statementDate": "2019-12-17", "subject": {"describedByEntityStatement": "openownership-register-4257617163209321874"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12668376474713728518"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-17"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-17"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-12-17"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-14939241739353717158", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4257617163209321874"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8633567886917943349"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-12-17"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-12-17"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2019-12-17"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-12668376474713728518", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BABCOCK MARINE HOLDINGS (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05265569"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05265569", "uri": "https://opencorporates.com/companies/gb/05265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5265569"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94a1367e4ebf340a6cbbd", "uri": "http://register.openownership.org/entities/59b94a1367e4ebf340a6cbbd"}], "foundingDate": "2004-10-20", "addresses": [{"type": "registered", "address": "33 Wigmore Street, London, W1U 1QX", "country": "GB"}]}, {"statementID": "openownership-register-8633567886917943349", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FNCG 2019 LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04331183"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04331183"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04331183"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04331183", "uri": "https://opencorporates.com/companies/gb/04331183"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4331183"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4331183"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95d1467e4ebf340fd54f1", "uri": "http://register.openownership.org/entities/59b95d1467e4ebf340fd54f1"}], "foundingDate": "2001-11-29", "addresses": [{"type": "registered", "address": "1 New Street Square, London, EC4A 3HQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4257617163209321874",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FRAZER-NASH CONSULTANCY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02562870"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02562870",
+                "uri": "https://opencorporates.com/companies/gb/02562870"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2562870"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95d1367e4ebf340fd5384",
+                "uri": "http://register.openownership.org/entities/59b95d1367e4ebf340fd5384"
+            }
+        ],
+        "foundingDate": "1990-11-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "C/O Devonport Royal Dockyard Ltd, Devonport, Plymouth, Devon, PL1 4SG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9579119561319370635",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-12-17",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4257617163209321874"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12668376474713728518"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-17"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-17"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-12-17"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14939241739353717158",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4257617163209321874"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8633567886917943349"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-12-17"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-12-17"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2019-12-17"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12668376474713728518",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BABCOCK MARINE HOLDINGS (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05265569"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05265569",
+                "uri": "https://opencorporates.com/companies/gb/05265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5265569"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94a1367e4ebf340a6cbbd",
+                "uri": "http://register.openownership.org/entities/59b94a1367e4ebf340a6cbbd"
+            }
+        ],
+        "foundingDate": "2004-10-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33 Wigmore Street, London, W1U 1QX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8633567886917943349",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FNCG 2019 LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04331183"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04331183"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04331183"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04331183",
+                "uri": "https://opencorporates.com/companies/gb/04331183"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4331183"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4331183"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95d1467e4ebf340fd54f1",
+                "uri": "http://register.openownership.org/entities/59b95d1467e4ebf340fd54f1"
+            }
+        ],
+        "foundingDate": "2001-11-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 New Street Square, London, EC4A 3HQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02564794_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02564794_bods.json
@@ -1,1 +1,276 @@
-[{"statementID": "openownership-register-15333213545504162654", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AMEY COMMUNITY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02564794"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02564794"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02564794", "uri": "https://opencorporates.com/companies/gb/02564794"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2564794"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2564794"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92ef167e4ebf34029c229", "uri": "http://register.openownership.org/entities/59b92ef167e4ebf34029c229"}], "foundingDate": "1990-12-03", "addresses": [{"type": "registered", "address": "Chancery Exchange, 10 Furnival Street, London, EC4A 1AB", "country": "GB"}]}, {"statementID": "openownership-register-9686886833912995466", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15333213545504162654"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2122879985261218586"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-2122879985261218586", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AMEY PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379479"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02379479", "uri": "https://opencorporates.com/companies/gb/02379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2379479"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96c7a67e4ebf34047bd4d", "uri": "http://register.openownership.org/entities/59b96c7a67e4ebf34047bd4d"}], "foundingDate": "1989-05-04", "addresses": [{"type": "registered", "address": "Chancery Exchange, 10 Furnival Street, London, EC4A 1AB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15333213545504162654",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AMEY COMMUNITY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02564794"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02564794"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02564794",
+                "uri": "https://opencorporates.com/companies/gb/02564794"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2564794"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2564794"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92ef167e4ebf34029c229",
+                "uri": "http://register.openownership.org/entities/59b92ef167e4ebf34029c229"
+            }
+        ],
+        "foundingDate": "1990-12-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Chancery Exchange, 10 Furnival Street, London, EC4A 1AB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9686886833912995466",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15333213545504162654"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2122879985261218586"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2122879985261218586",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AMEY PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379479"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02379479",
+                "uri": "https://opencorporates.com/companies/gb/02379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2379479"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96c7a67e4ebf34047bd4d",
+                "uri": "http://register.openownership.org/entities/59b96c7a67e4ebf34047bd4d"
+            }
+        ],
+        "foundingDate": "1989-05-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Chancery Exchange, 10 Furnival Street, London, EC4A 1AB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02575953_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02575953_bods.json
@@ -1,1 +1,139 @@
-[{"statementID": "openownership-register-3406203956039984843", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FIBRE TECHNOLOGIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02575953", "uri": "https://opencorporates.com/companies/gb/02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02575953"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab96ced9dfc3fae18c53d8f", "uri": "http://register.openownership.org/entities/5ab96ced9dfc3fae18c53d8f"}], "foundingDate": "1991-01-22", "addresses": [{"type": "registered", "address": "29 Wellington Business Park, Dukes Ride, Crowthorne, Berkshire, RG45 6LS", "country": "GB"}]}, {"statementID": "openownership-register-3508165659285383733", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3406203956039984843"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3057702524389327157"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3057702524389327157", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FIBRE TECHNOLOGIES HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05543269"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05543269"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05543269", "uri": "https://opencorporates.com/companies/gb/05543269"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b935e167e4ebf3404b10ce", "uri": "http://register.openownership.org/entities/59b935e167e4ebf3404b10ce"}], "foundingDate": "2005-08-23", "addresses": [{"type": "registered", "address": "29 Wellington Business Park, Dukes Ride, Crowthorne, RG45 6LS", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3406203956039984843",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FIBRE TECHNOLOGIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02575953",
+                "uri": "https://opencorporates.com/companies/gb/02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02575953"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab96ced9dfc3fae18c53d8f",
+                "uri": "http://register.openownership.org/entities/5ab96ced9dfc3fae18c53d8f"
+            }
+        ],
+        "foundingDate": "1991-01-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "29 Wellington Business Park, Dukes Ride, Crowthorne, Berkshire, RG45 6LS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3508165659285383733",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3406203956039984843"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3057702524389327157"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3057702524389327157",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FIBRE TECHNOLOGIES HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05543269"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05543269"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05543269",
+                "uri": "https://opencorporates.com/companies/gb/05543269"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b935e167e4ebf3404b10ce",
+                "uri": "http://register.openownership.org/entities/59b935e167e4ebf3404b10ce"
+            }
+        ],
+        "foundingDate": "2005-08-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "29 Wellington Business Park, Dukes Ride, Crowthorne, RG45 6LS",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02579852_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02579852_bods.json
@@ -1,1 +1,144 @@
-[{"statementID": "openownership-register-13335817268510139543", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INSIGHT DIRECT (UK) LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02579852"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02579852", "uri": "https://opencorporates.com/companies/gb/02579852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02579852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02579852"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4ff5367e4ebf3405a2a87", "uri": "http://register.openownership.org/entities/59c4ff5367e4ebf3405a2a87"}], "foundingDate": "1991-02-05", "addresses": [{"type": "registered", "address": "Technology Building, Insight Campus, Terry Street, Sheffield, S9 2BU", "country": "GB"}]}, {"statementID": "openownership-register-17009092599668753863", "statementType": "ownershipOrControlStatement", "statementDate": "2018-10-18", "subject": {"describedByEntityStatement": "openownership-register-13335817268510139543"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17064044562223848680"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-10-18"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17064044562223848680", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INSIGHT ENTERPRISES UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04051772", "uri": "https://opencorporates.com/companies/gb/04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04051772"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4f26d67e4ebf340413dbc", "uri": "http://register.openownership.org/entities/59c4f26d67e4ebf340413dbc"}], "foundingDate": "2000-08-08", "addresses": [{"type": "registered", "address": "Technology Building, Insight Campus, Terry Street, Sheffield, S9 2BU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13335817268510139543",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INSIGHT DIRECT (UK) LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02579852"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02579852",
+                "uri": "https://opencorporates.com/companies/gb/02579852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02579852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02579852"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4ff5367e4ebf3405a2a87",
+                "uri": "http://register.openownership.org/entities/59c4ff5367e4ebf3405a2a87"
+            }
+        ],
+        "foundingDate": "1991-02-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Technology Building, Insight Campus, Terry Street, Sheffield, S9 2BU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17009092599668753863",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-10-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13335817268510139543"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17064044562223848680"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-10-18"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17064044562223848680",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INSIGHT ENTERPRISES UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04051772",
+                "uri": "https://opencorporates.com/companies/gb/04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04051772"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4f26d67e4ebf340413dbc",
+                "uri": "http://register.openownership.org/entities/59c4f26d67e4ebf340413dbc"
+            }
+        ],
+        "foundingDate": "2000-08-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Technology Building, Insight Campus, Terry Street, Sheffield, S9 2BU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02594504_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02594504_bods.json
@@ -1,1 +1,235 @@
-[{"statementID": "openownership-register-17891087983698594942", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JACOBS U.K. LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02594504", "uri": "https://opencorporates.com/companies/gb/02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02594504"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b933ea67e4ebf340419ca3", "uri": "http://register.openownership.org/entities/59b933ea67e4ebf340419ca3"}], "foundingDate": "1991-03-22", "addresses": [{"type": "registered", "address": "1180 Eskdale Road, Winnersh, Wokingham, Berkshire, RG41 5TU", "country": "GB"}]}, {"statementID": "openownership-register-1311320963342862276", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17891087983698594942"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8964494432867451303"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8964494432867451303", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JACOBS UK HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04420029"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04420029"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04420029", "uri": "https://opencorporates.com/companies/gb/04420029"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4420029"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ac5767e4ebf3404ea194", "uri": "http://register.openownership.org/entities/59b9ac5767e4ebf3404ea194"}], "foundingDate": "2002-04-18", "addresses": [{"type": "registered", "address": "1180 Eskdale Road, Winnersh, Wokingham, Berkshire, RG41 5TU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17891087983698594942",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JACOBS U.K. LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02594504",
+                "uri": "https://opencorporates.com/companies/gb/02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02594504"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b933ea67e4ebf340419ca3",
+                "uri": "http://register.openownership.org/entities/59b933ea67e4ebf340419ca3"
+            }
+        ],
+        "foundingDate": "1991-03-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1180 Eskdale Road, Winnersh, Wokingham, Berkshire, RG41 5TU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1311320963342862276",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17891087983698594942"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8964494432867451303"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8964494432867451303",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JACOBS UK HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04420029"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04420029"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04420029",
+                "uri": "https://opencorporates.com/companies/gb/04420029"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4420029"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ac5767e4ebf3404ea194",
+                "uri": "http://register.openownership.org/entities/59b9ac5767e4ebf3404ea194"
+            }
+        ],
+        "foundingDate": "2002-04-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1180 Eskdale Road, Winnersh, Wokingham, Berkshire, RG41 5TU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02621328_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02621328_bods.json
@@ -1,1 +1,345 @@
-[{"statementID": "openownership-register-7503482064527853763", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MALLATITE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02621328"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02621328", "uri": "https://opencorporates.com/companies/gb/02621328"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d01d67e4ebf340d62893", "uri": "http://register.openownership.org/entities/59b9d01d67e4ebf340d62893"}], "foundingDate": "1991-06-18", "addresses": [{"type": "registered", "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH", "country": "GB"}]}, {"statementID": "openownership-register-15822346580211119231", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7503482064527853763"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12312947673110834715"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12312947673110834715", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HILL & SMITH HOLDINGS PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00671474"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00671474", "uri": "https://opencorporates.com/companies/gb/00671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "671474"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9330a67e4ebf3403d3fdb", "uri": "http://register.openownership.org/entities/59b9330a67e4ebf3403d3fdb"}], "foundingDate": "1960-09-30", "addresses": [{"type": "registered", "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7503482064527853763",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MALLATITE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02621328"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02621328",
+                "uri": "https://opencorporates.com/companies/gb/02621328"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d01d67e4ebf340d62893",
+                "uri": "http://register.openownership.org/entities/59b9d01d67e4ebf340d62893"
+            }
+        ],
+        "foundingDate": "1991-06-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15822346580211119231",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7503482064527853763"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12312947673110834715"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12312947673110834715",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HILL & SMITH HOLDINGS PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00671474"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00671474",
+                "uri": "https://opencorporates.com/companies/gb/00671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "671474"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9330a67e4ebf3403d3fdb",
+                "uri": "http://register.openownership.org/entities/59b9330a67e4ebf3403d3fdb"
+            }
+        ],
+        "foundingDate": "1960-09-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Westhaven House, Arleston Way, Shirley, Solihull, West Midlands, B90 4LH",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02644726_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02644726_bods.json
@@ -1,1 +1,401 @@
-[{"statementID": "openownership-register-5246387748061677790", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COLAS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02644726", "uri": "https://opencorporates.com/companies/gb/02644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2644726"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02644726"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c8a67e4ebf340699517", "uri": "http://register.openownership.org/entities/59b93c8a67e4ebf340699517"}], "foundingDate": "1991-09-11", "addresses": [{"type": "registered", "address": "Wallage Lane, Rowfant, Crawley, West Sussex, RH10 4NF", "country": "GB"}]}, {"statementID": "openownership-register-3435155227681897898", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5246387748061677790"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6310981953560931669"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6310981953560931669", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COLAS SA", "incorporatedInJurisdiction": {"name": "France", "code": "FR"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10883476/persons-with-significant-control/corporate-entity/bGj9ciaGB8LAP-AVU2lpKRKlu1U"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/fr/552025314", "uri": "https://opencorporates.com/companies/fr/552025314"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/12547167/persons-with-significant-control/corporate-entity/sLnSTnzVFebJboS3TwMB4aVI0ns"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d59c67e4ebf340eac8f8", "uri": "http://register.openownership.org/entities/59b9d59c67e4ebf340eac8f8"}], "foundingDate": "1955-01-01", "addresses": [{"type": "registered", "address": "1 RUE DU COLONEL PIERRE AVIA, PARIS 15, PARIS, 75015", "country": "FR"}]}]
+[
+    {
+        "statementID": "openownership-register-5246387748061677790",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COLAS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02644726",
+                "uri": "https://opencorporates.com/companies/gb/02644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2644726"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02644726"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c8a67e4ebf340699517",
+                "uri": "http://register.openownership.org/entities/59b93c8a67e4ebf340699517"
+            }
+        ],
+        "foundingDate": "1991-09-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Wallage Lane, Rowfant, Crawley, West Sussex, RH10 4NF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3435155227681897898",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5246387748061677790"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6310981953560931669"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6310981953560931669",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COLAS SA",
+        "incorporatedInJurisdiction": {
+            "name": "France",
+            "code": "FR"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10883476/persons-with-significant-control/corporate-entity/bGj9ciaGB8LAP-AVU2lpKRKlu1U"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/fr/552025314",
+                "uri": "https://opencorporates.com/companies/fr/552025314"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02644726/persons-with-significant-control/corporate-entity/7t05kWo8yxpEVn8VOz1j5JsIGAc"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05148685/persons-with-significant-control/corporate-entity/-qksGljsTzaCymFZafJhlCYenXI"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/12547167/persons-with-significant-control/corporate-entity/sLnSTnzVFebJboS3TwMB4aVI0ns"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d59c67e4ebf340eac8f8",
+                "uri": "http://register.openownership.org/entities/59b9d59c67e4ebf340eac8f8"
+            }
+        ],
+        "foundingDate": "1955-01-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 RUE DU COLONEL PIERRE AVIA, PARIS 15, PARIS, 75015",
+                "country": "FR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02654682_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02654682_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-4589486585213724790", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OFFICE DEPOT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02654682"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02654682"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02654682", "uri": "https://opencorporates.com/companies/gb/02654682"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92d9567e4ebf34022c75f", "uri": "http://register.openownership.org/entities/59b92d9567e4ebf34022c75f"}], "foundingDate": "1991-10-16", "addresses": [{"type": "registered", "address": "501 Beaumont Leys Lane, Leicester, Leicestershire, LE4 2BN", "country": "GB"}]}, {"statementID": "openownership-register-4388295847822376966", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4589486585213724790"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14626987625006538213"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14626987625006538213", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GUILBERT UK HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02898888"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02898888"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02898888"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02898888", "uri": "https://opencorporates.com/companies/gb/02898888"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2898888"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9391367e4ebf340599f8e", "uri": "http://register.openownership.org/entities/59b9391367e4ebf340599f8e"}], "foundingDate": "1994-02-16", "addresses": [{"type": "registered", "address": "501 Beaumont Leys Lane, Leicester, Leicestershire, LE4 2BN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4589486585213724790",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OFFICE DEPOT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02654682"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02654682"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02654682",
+                "uri": "https://opencorporates.com/companies/gb/02654682"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92d9567e4ebf34022c75f",
+                "uri": "http://register.openownership.org/entities/59b92d9567e4ebf34022c75f"
+            }
+        ],
+        "foundingDate": "1991-10-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "501 Beaumont Leys Lane, Leicester, Leicestershire, LE4 2BN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4388295847822376966",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4589486585213724790"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14626987625006538213"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14626987625006538213",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GUILBERT UK HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02898888"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02898888"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02898888"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02898888",
+                "uri": "https://opencorporates.com/companies/gb/02898888"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2898888"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9391367e4ebf340599f8e",
+                "uri": "http://register.openownership.org/entities/59b9391367e4ebf340599f8e"
+            }
+        ],
+        "foundingDate": "1994-02-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "501 Beaumont Leys Lane, Leicester, Leicestershire, LE4 2BN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02658324_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02658324_bods.json
@@ -1,1 +1,389 @@
-[{"statementID": "openownership-register-7690538674266260982", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "QUADIENT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02658324"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02658324"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02658324"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02658324", "uri": "https://opencorporates.com/companies/gb/02658324"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2658324"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9206f67e4ebf340e97de6", "uri": "http://register.openownership.org/entities/59b9206f67e4ebf340e97de6"}], "foundingDate": "1991-10-29", "addresses": [{"type": "registered", "address": "3rd Floor Press Centre Here East, 14 East Bay Lane, London, E15 2GW", "country": "GB"}]}, {"statementID": "openownership-register-2864742783811548161", "statementType": "ownershipOrControlStatement", "statementDate": "2018-06-15", "subject": {"describedByEntityStatement": "openownership-register-7690538674266260982"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8606438373303215258"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-06-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16476948700546019018", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-29", "subject": {"describedByEntityStatement": "openownership-register-7690538674266260982"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16968586312774382275"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-10-29", "endDate": "2018-08-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8898999774763611394", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-29", "subject": {"describedByEntityStatement": "openownership-register-7690538674266260982"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10919542730179380883"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-10-29", "endDate": "2018-06-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4943229575819712633", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-29", "subject": {"describedByEntityStatement": "openownership-register-7690538674266260982"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3418436551293632288"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-10-29", "endDate": "2018-06-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4384224003441209104", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-29", "subject": {"describedByEntityStatement": "openownership-register-7690538674266260982"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8418377173381867585"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-10-29", "endDate": "2018-06-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8606438373303215258", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NEOPOST SA", "incorporatedInJurisdiction": {"name": "France", "code": "FR"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08713557/persons-with-significant-control/corporate-entity/CM-bq2c_ONjQII8NmWWuWUDDCFM"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10228019/persons-with-significant-control/corporate-entity/6zy1CPvwWi1-ymzzo3dLiI-IEvQ"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02658324/persons-with-significant-control/corporate-entity/ZXGbVe-46-i-QaIeeR4sPyXVZ_M"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/fr/402103907", "uri": "https://opencorporates.com/companies/fr/402103907"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03186665/persons-with-significant-control/corporate-entity/KQFlRWgJ0yx2r9DMD6r05VhgtEc"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01997384/persons-with-significant-control/corporate-entity/VkELFR6KP4NomG2sMk_tljV3Aqw"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02670823/persons-with-significant-control/corporate-entity/2MwjVkBXJ7_CC9PHak676ZyA9zU"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08270545/persons-with-significant-control/corporate-entity/1jRPWlvLe_lGdZoGxCbSx0ATXdY"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08713557/persons-with-significant-control/corporate-entity/CM-bq2c_ONjQII8NmWWuWUDDCFM"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05178432/persons-with-significant-control/corporate-entity/mwStI9QyBnn2kqzuh1MiCE1RVDU"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/01997384/persons-with-significant-control/corporate-entity/uYrABiU1JxH2GN0H0o2VxagQaUk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b6135f79dfc3fae187bb1cf", "uri": "http://register.openownership.org/entities/5b6135f79dfc3fae187bb1cf"}], "foundingDate": "1995-02-21", "addresses": [{"type": "registered", "address": "42 AVENUE ARISTIDE BRIAND, BAGNEUX, HAUTS-DE-SEINE, 92220", "country": "FR"}]}, {"statementID": "openownership-register-16968586312774382275", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Denis Thiery"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02658324/persons-with-significant-control/individual/6OVoUBwTnD61wJU-dtwYXuOUeHU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa0b", "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa0b"}], "birthDate": "1955-06-01", "addresses": [{"address": "Neopost House, South Street, Romford, Essex, RM1 2AR", "country": "FR"}]}, {"statementID": "openownership-register-10919542730179380883", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jean Francois Labadie"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02658324/persons-with-significant-control/individual/UeAFcWjbAKI2jG6c3u7rf95x760"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa32", "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa32"}], "birthDate": "1967-01-01", "addresses": [{"address": "Neopost House, South Street, Romford, Essex, RM1 2AR", "country": "FR"}]}, {"statementID": "openownership-register-3418436551293632288", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Paul Richard Puxty"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02658324/persons-with-significant-control/individual/cA5Kn7XNo2dK7pftGdbJhqjxHU8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa15", "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa15"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-08-01", "addresses": [{"address": "Neopost House, South Street, Romford, Essex, RM1 2AR"}]}, {"statementID": "openownership-register-8418377173381867585", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Michael Adrian Stone"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08270545/persons-with-significant-control/individual/rYSQ5T1clq2tQJd4ERjlcS2yNaA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b959de67e4ebf340ed0ef4", "uri": "http://register.openownership.org/entities/59b959de67e4ebf340ed0ef4"}], "nationalities": [{"name": "Ireland", "code": "IE"}], "birthDate": "1960-06-01", "addresses": [{"address": "Neopost House, South Street, Romford, Essex, RM1 2AR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7690538674266260982",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "QUADIENT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02658324"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02658324"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02658324"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02658324",
+                "uri": "https://opencorporates.com/companies/gb/02658324"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2658324"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9206f67e4ebf340e97de6",
+                "uri": "http://register.openownership.org/entities/59b9206f67e4ebf340e97de6"
+            }
+        ],
+        "foundingDate": "1991-10-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3rd Floor Press Centre Here East, 14 East Bay Lane, London, E15 2GW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2864742783811548161",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-06-15",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7690538674266260982"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8606438373303215258"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-06-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16476948700546019018",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7690538674266260982"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16968586312774382275"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-10-29",
+                "endDate": "2018-08-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8898999774763611394",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7690538674266260982"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10919542730179380883"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-10-29",
+                "endDate": "2018-06-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4943229575819712633",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7690538674266260982"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3418436551293632288"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-10-29",
+                "endDate": "2018-06-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4384224003441209104",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7690538674266260982"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8418377173381867585"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-10-29",
+                "endDate": "2018-06-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8606438373303215258",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NEOPOST SA",
+        "incorporatedInJurisdiction": {
+            "name": "France",
+            "code": "FR"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08713557/persons-with-significant-control/corporate-entity/CM-bq2c_ONjQII8NmWWuWUDDCFM"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10228019/persons-with-significant-control/corporate-entity/6zy1CPvwWi1-ymzzo3dLiI-IEvQ"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02658324/persons-with-significant-control/corporate-entity/ZXGbVe-46-i-QaIeeR4sPyXVZ_M"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/fr/402103907",
+                "uri": "https://opencorporates.com/companies/fr/402103907"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03186665/persons-with-significant-control/corporate-entity/KQFlRWgJ0yx2r9DMD6r05VhgtEc"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01997384/persons-with-significant-control/corporate-entity/VkELFR6KP4NomG2sMk_tljV3Aqw"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02670823/persons-with-significant-control/corporate-entity/2MwjVkBXJ7_CC9PHak676ZyA9zU"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08270545/persons-with-significant-control/corporate-entity/1jRPWlvLe_lGdZoGxCbSx0ATXdY"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08713557/persons-with-significant-control/corporate-entity/CM-bq2c_ONjQII8NmWWuWUDDCFM"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05178432/persons-with-significant-control/corporate-entity/mwStI9QyBnn2kqzuh1MiCE1RVDU"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/01997384/persons-with-significant-control/corporate-entity/uYrABiU1JxH2GN0H0o2VxagQaUk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b6135f79dfc3fae187bb1cf",
+                "uri": "http://register.openownership.org/entities/5b6135f79dfc3fae187bb1cf"
+            }
+        ],
+        "foundingDate": "1995-02-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "42 AVENUE ARISTIDE BRIAND, BAGNEUX, HAUTS-DE-SEINE, 92220",
+                "country": "FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16968586312774382275",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Denis Thiery"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02658324/persons-with-significant-control/individual/6OVoUBwTnD61wJU-dtwYXuOUeHU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa0b",
+                "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa0b"
+            }
+        ],
+        "birthDate": "1955-06-01",
+        "addresses": [
+            {
+                "address": "Neopost House, South Street, Romford, Essex, RM1 2AR",
+                "country": "FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10919542730179380883",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jean Francois Labadie"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02658324/persons-with-significant-control/individual/UeAFcWjbAKI2jG6c3u7rf95x760"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa32",
+                "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa32"
+            }
+        ],
+        "birthDate": "1967-01-01",
+        "addresses": [
+            {
+                "address": "Neopost House, South Street, Romford, Essex, RM1 2AR",
+                "country": "FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3418436551293632288",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Paul Richard Puxty"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02658324/persons-with-significant-control/individual/cA5Kn7XNo2dK7pftGdbJhqjxHU8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95a7067e4ebf340effa15",
+                "uri": "http://register.openownership.org/entities/59b95a7067e4ebf340effa15"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-08-01",
+        "addresses": [
+            {
+                "address": "Neopost House, South Street, Romford, Essex, RM1 2AR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8418377173381867585",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michael Adrian Stone"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08270545/persons-with-significant-control/individual/rYSQ5T1clq2tQJd4ERjlcS2yNaA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b959de67e4ebf340ed0ef4",
+                "uri": "http://register.openownership.org/entities/59b959de67e4ebf340ed0ef4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Ireland",
+                "code": "IE"
+            }
+        ],
+        "birthDate": "1960-06-01",
+        "addresses": [
+            {
+                "address": "Neopost House, South Street, Romford, Essex, RM1 2AR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02673518_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02673518_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-13084198808209370382", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BABINGTON BUSINESS COLLEGE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02673518"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02673518", "uri": "https://opencorporates.com/companies/gb/02673518"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4ff4767e4ebf3405a0fb3", "uri": "http://register.openownership.org/entities/59c4ff4767e4ebf3405a0fb3"}], "foundingDate": "1991-12-20", "addresses": [{"type": "registered", "address": "Babington House Mallard Way, Pride Park, Derby, DE24 8GX", "country": "GB"}]}, {"statementID": "openownership-register-15702317049033738688", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-20", "subject": {"describedByEntityStatement": "openownership-register-13084198808209370382"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-13084198808209370382",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BABINGTON BUSINESS COLLEGE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02673518"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02673518",
+                "uri": "https://opencorporates.com/companies/gb/02673518"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4ff4767e4ebf3405a0fb3",
+                "uri": "http://register.openownership.org/entities/59c4ff4767e4ebf3405a0fb3"
+            }
+        ],
+        "foundingDate": "1991-12-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Babington House Mallard Way, Pride Park, Derby, DE24 8GX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15702317049033738688",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-20",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13084198808209370382"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02703636_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02703636_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-1714073939260799655", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AGE UK EXETER", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02703636"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02703636", "uri": "https://opencorporates.com/companies/gb/02703636"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5039367e4ebf340632a8a", "uri": "http://register.openownership.org/entities/59c5039367e4ebf340632a8a"}], "foundingDate": "1992-04-03", "addresses": [{"type": "registered", "address": "138 Cowick Street, Exeter, Devon, EX4 1HS", "country": "GB"}]}, {"statementID": "openownership-register-8419788460435360947", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-03", "subject": {"describedByEntityStatement": "openownership-register-1714073939260799655"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-1714073939260799655",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AGE UK EXETER",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02703636"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02703636",
+                "uri": "https://opencorporates.com/companies/gb/02703636"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5039367e4ebf340632a8a",
+                "uri": "http://register.openownership.org/entities/59c5039367e4ebf340632a8a"
+            }
+        ],
+        "foundingDate": "1992-04-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "138 Cowick Street, Exeter, Devon, EX4 1HS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8419788460435360947",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1714073939260799655"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02729626_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02729626_bods.json
@@ -1,1 +1,128 @@
-[{"statementID": "openownership-register-2126136202767722312", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BOSTON SCIENTIFIC LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02729626"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02729626", "uri": "https://opencorporates.com/companies/gb/02729626"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cd7167e4ebf340cc491b", "uri": "http://register.openownership.org/entities/59b9cd7167e4ebf340cc491b"}], "foundingDate": "1992-07-08", "addresses": [{"type": "registered", "address": "100 New Bridge Street, London, EC4V 6JA", "country": "GB"}]}, {"statementID": "openownership-register-13485977531083057494", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2126136202767722312"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7330244249400677134"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7330244249400677134", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BOSTON SCIENTIFIC CORPORATION", "incorporatedInJurisdiction": {"name": "United States of America", "code": "US"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02729626/persons-with-significant-control/corporate-entity/1H5DnHfhtm4eIVDgRSsCKy6SKLY"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03792886/persons-with-significant-control/corporate-entity/MEthz5IZhUvF_MKRD26Gy-lV_VM"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/us_de/874815", "uri": "https://opencorporates.com/companies/us_de/874815"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03792886/persons-with-significant-control/corporate-entity/MEthz5IZhUvF_MKRD26Gy-lV_VM"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10998036/persons-with-significant-control/corporate-entity/-VOlt7p0vAW6zWduzmOHYszuQC4"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11682272/persons-with-significant-control/corporate-entity/my4KnjMLTz8zX0IM3NfRLupttUM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cd7267e4ebf340cc4b94", "uri": "http://register.openownership.org/entities/59b9cd7267e4ebf340cc4b94"}], "foundingDate": "1979-06-22"}]
+[
+    {
+        "statementID": "openownership-register-2126136202767722312",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BOSTON SCIENTIFIC LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02729626"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02729626",
+                "uri": "https://opencorporates.com/companies/gb/02729626"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cd7167e4ebf340cc491b",
+                "uri": "http://register.openownership.org/entities/59b9cd7167e4ebf340cc491b"
+            }
+        ],
+        "foundingDate": "1992-07-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 New Bridge Street, London, EC4V 6JA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13485977531083057494",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2126136202767722312"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7330244249400677134"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7330244249400677134",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BOSTON SCIENTIFIC CORPORATION",
+        "incorporatedInJurisdiction": {
+            "name": "United States of America",
+            "code": "US"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02729626/persons-with-significant-control/corporate-entity/1H5DnHfhtm4eIVDgRSsCKy6SKLY"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03792886/persons-with-significant-control/corporate-entity/MEthz5IZhUvF_MKRD26Gy-lV_VM"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/us_de/874815",
+                "uri": "https://opencorporates.com/companies/us_de/874815"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03792886/persons-with-significant-control/corporate-entity/MEthz5IZhUvF_MKRD26Gy-lV_VM"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10998036/persons-with-significant-control/corporate-entity/-VOlt7p0vAW6zWduzmOHYszuQC4"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11682272/persons-with-significant-control/corporate-entity/my4KnjMLTz8zX0IM3NfRLupttUM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cd7267e4ebf340cc4b94",
+                "uri": "http://register.openownership.org/entities/59b9cd7267e4ebf340cc4b94"
+            }
+        ],
+        "foundingDate": "1979-06-22"
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02738102_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02738102_bods.json
@@ -1,1 +1,125 @@
-[{"statementID": "openownership-register-7522046522155026461", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ONE CREATIVE ENVIRONMENTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02738102"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02738102", "uri": "https://opencorporates.com/companies/gb/02738102"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e7e67e4ebf340276a9a", "uri": "http://register.openownership.org/entities/59b92e7e67e4ebf340276a9a"}], "foundingDate": "1992-08-06", "addresses": [{"type": "registered", "address": "5 The Triangle, Wildwood Drive, Worcester, Worcestershire, WR5 2QX", "country": "GB"}]}, {"statementID": "openownership-register-12991474328174625737", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7522046522155026461"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1449056005506614611"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1449056005506614611", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OCE HOLDCO LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09310385"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09310385"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09310385", "uri": "https://opencorporates.com/companies/gb/09310385"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e7f67e4ebf340276dd2", "uri": "http://register.openownership.org/entities/59b92e7f67e4ebf340276dd2"}], "foundingDate": "2014-11-13", "addresses": [{"type": "registered", "address": "5 The Triangle, Wildwood Drive, Worcester, WR5 2QX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7522046522155026461",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ONE CREATIVE ENVIRONMENTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02738102"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02738102",
+                "uri": "https://opencorporates.com/companies/gb/02738102"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e7e67e4ebf340276a9a",
+                "uri": "http://register.openownership.org/entities/59b92e7e67e4ebf340276a9a"
+            }
+        ],
+        "foundingDate": "1992-08-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 The Triangle, Wildwood Drive, Worcester, Worcestershire, WR5 2QX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12991474328174625737",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7522046522155026461"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1449056005506614611"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1449056005506614611",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OCE HOLDCO LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09310385"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09310385"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09310385",
+                "uri": "https://opencorporates.com/companies/gb/09310385"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e7f67e4ebf340276dd2",
+                "uri": "http://register.openownership.org/entities/59b92e7f67e4ebf340276dd2"
+            }
+        ],
+        "foundingDate": "2014-11-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 The Triangle, Wildwood Drive, Worcester, WR5 2QX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02748952_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02748952_bods.json
@@ -1,1 +1,215 @@
-[{"statementID": "openownership-register-9453015105478539871", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TVS SUPPLY CHAIN SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02748952"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02748952", "uri": "https://opencorporates.com/companies/gb/02748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2748952"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2748952"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99e2b67e4ebf3401a0b9d", "uri": "http://register.openownership.org/entities/59b99e2b67e4ebf3401a0b9d"}], "foundingDate": "1992-09-21", "addresses": [{"type": "registered", "address": "Logistics House, Buckshaw Avenue, Chorley, Lancashire, PR6 7AJ", "country": "GB"}]}, {"statementID": "openownership-register-12267259586664236615", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9453015105478539871"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12751343604025125925"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17514572138185635972", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9453015105478539871"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13408966325747066079"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12751343604025125925", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Tvs Logistics Services Limited", "incorporatedInJurisdiction": {"name": "India", "code": "IN"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02748952/persons-with-significant-control/corporate-entity/Og1PWmokRNVUN2qQ0lI0KnyCoeg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9843e9dfc3fae18fe90ff", "uri": "http://register.openownership.org/entities/5ab9843e9dfc3fae18fe90ff"}], "addresses": [{"type": "registered", "address": "Cathedral Road, Gopalapuram, Chennai, Tamil Nadu, 600086", "country": "IN"}]}, {"statementID": "openownership-register-13408966325747066079", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TVS LOGISTICS INVESTMENT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07003943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07003943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07003943"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07003943", "uri": "https://opencorporates.com/companies/gb/07003943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7003943"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7003943"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9e29767e4ebf3401add11", "uri": "http://register.openownership.org/entities/59b9e29767e4ebf3401add11"}], "foundingDate": "2009-08-28", "addresses": [{"type": "registered", "address": "Logistics House, Buckshaw Avenue, Chorley, Lancashire, PR6 7AJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9453015105478539871",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TVS SUPPLY CHAIN SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02748952"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02748952",
+                "uri": "https://opencorporates.com/companies/gb/02748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2748952"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2748952"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99e2b67e4ebf3401a0b9d",
+                "uri": "http://register.openownership.org/entities/59b99e2b67e4ebf3401a0b9d"
+            }
+        ],
+        "foundingDate": "1992-09-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Logistics House, Buckshaw Avenue, Chorley, Lancashire, PR6 7AJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12267259586664236615",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9453015105478539871"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12751343604025125925"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17514572138185635972",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9453015105478539871"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13408966325747066079"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12751343604025125925",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Tvs Logistics Services Limited",
+        "incorporatedInJurisdiction": {
+            "name": "India",
+            "code": "IN"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02748952/persons-with-significant-control/corporate-entity/Og1PWmokRNVUN2qQ0lI0KnyCoeg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9843e9dfc3fae18fe90ff",
+                "uri": "http://register.openownership.org/entities/5ab9843e9dfc3fae18fe90ff"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cathedral Road, Gopalapuram, Chennai, Tamil Nadu, 600086",
+                "country": "IN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13408966325747066079",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TVS LOGISTICS INVESTMENT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07003943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07003943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07003943"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07003943",
+                "uri": "https://opencorporates.com/companies/gb/07003943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7003943"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7003943"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9e29767e4ebf3401add11",
+                "uri": "http://register.openownership.org/entities/59b9e29767e4ebf3401add11"
+            }
+        ],
+        "foundingDate": "2009-08-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Logistics House, Buckshaw Avenue, Chorley, Lancashire, PR6 7AJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02762085_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02762085_bods.json
@@ -1,1 +1,123 @@
-[{"statementID": "openownership-register-4305673906550885510", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AVATU LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02762085"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02762085"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02762085", "uri": "https://opencorporates.com/companies/gb/02762085"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95c1e67e4ebf340f88a84", "uri": "http://register.openownership.org/entities/59b95c1e67e4ebf340f88a84"}], "foundingDate": "1992-11-05", "addresses": [{"type": "registered", "address": "Unit E2 Regent Parlk, Summerleys Road, Princes Risborough, Buckinghamshire, HP27 9LE", "country": "GB"}]}, {"statementID": "openownership-register-685515824686135856", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4305673906550885510"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15487481009166086041"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15487481009166086041", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DATA DUPLICATION (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08414024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08414024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08414024"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08414024", "uri": "https://opencorporates.com/companies/gb/08414024"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b930e167e4ebf340326374", "uri": "http://register.openownership.org/entities/59b930e167e4ebf340326374"}], "foundingDate": "2013-02-21", "addresses": [{"type": "registered", "address": "Unit E2 Regent Park, Summerleys Road, Princes Risborough, Buckinghamshire, HP27 9LE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4305673906550885510",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AVATU LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02762085"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02762085"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02762085",
+                "uri": "https://opencorporates.com/companies/gb/02762085"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95c1e67e4ebf340f88a84",
+                "uri": "http://register.openownership.org/entities/59b95c1e67e4ebf340f88a84"
+            }
+        ],
+        "foundingDate": "1992-11-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit E2 Regent Parlk, Summerleys Road, Princes Risborough, Buckinghamshire, HP27 9LE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-685515824686135856",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4305673906550885510"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15487481009166086041"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15487481009166086041",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DATA DUPLICATION (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08414024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08414024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08414024"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08414024",
+                "uri": "https://opencorporates.com/companies/gb/08414024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b930e167e4ebf340326374",
+                "uri": "http://register.openownership.org/entities/59b930e167e4ebf340326374"
+            }
+        ],
+        "foundingDate": "2013-02-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit E2 Regent Park, Summerleys Road, Princes Risborough, Buckinghamshire, HP27 9LE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02765630_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02765630_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-11262187175752919619", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MARLBOROUGH HIGHWAYS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02765630"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02765630", "uri": "https://opencorporates.com/companies/gb/02765630"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9729567e4ebf34066de57", "uri": "http://register.openownership.org/entities/59b9729567e4ebf34066de57"}], "foundingDate": "1992-11-18", "addresses": [{"type": "registered", "address": "Woolf House 15 Regiment Business Park, Eagle Way, Little Waltham, Chelmsford, CM3 3FY", "country": "GB"}]}, {"statementID": "openownership-register-18115667173070243302", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11262187175752919619"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16584437793644969866"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-firm", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent-as-firm", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16584437793644969866", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MARLBOROUGH HIGHWAYS GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08479092"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08479092"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08479092"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08479092"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08479092", "uri": "https://opencorporates.com/companies/gb/08479092"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08479092"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93bdb67e4ebf340669704", "uri": "http://register.openownership.org/entities/59b93bdb67e4ebf340669704"}], "foundingDate": "2013-04-08", "addresses": [{"type": "registered", "address": "Woolf House 15 Regiment Business Park, Eagle Way Little Waltham, Chelmsford, Essex, CM3 3FY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-11262187175752919619",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MARLBOROUGH HIGHWAYS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02765630"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02765630",
+                "uri": "https://opencorporates.com/companies/gb/02765630"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9729567e4ebf34066de57",
+                "uri": "http://register.openownership.org/entities/59b9729567e4ebf34066de57"
+            }
+        ],
+        "foundingDate": "1992-11-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Woolf House 15 Regiment Business Park, Eagle Way, Little Waltham, Chelmsford, CM3 3FY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18115667173070243302",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11262187175752919619"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16584437793644969866"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-firm",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent-as-firm",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16584437793644969866",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MARLBOROUGH HIGHWAYS GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08479092"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08479092"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08479092"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08479092"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08479092",
+                "uri": "https://opencorporates.com/companies/gb/08479092"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08479092"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93bdb67e4ebf340669704",
+                "uri": "http://register.openownership.org/entities/59b93bdb67e4ebf340669704"
+            }
+        ],
+        "foundingDate": "2013-04-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Woolf House 15 Regiment Business Park, Eagle Way Little Waltham, Chelmsford, Essex, CM3 3FY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02786035_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02786035_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-13199141596048989804", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LEWISHAM NEXUS SERVICE", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02786035"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02786035", "uri": "https://opencorporates.com/companies/gb/02786035"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c500ac67e4ebf3405cfda0", "uri": "http://register.openownership.org/entities/59c500ac67e4ebf3405cfda0"}], "foundingDate": "1993-02-02", "addresses": [{"type": "registered", "address": "84-86 Rushey Green, Catford, London, SE6 4HW", "country": "GB"}]}, {"statementID": "openownership-register-14460321953187683318", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-02", "subject": {"describedByEntityStatement": "openownership-register-13199141596048989804"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-13199141596048989804",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LEWISHAM NEXUS SERVICE",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02786035"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02786035",
+                "uri": "https://opencorporates.com/companies/gb/02786035"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c500ac67e4ebf3405cfda0",
+                "uri": "http://register.openownership.org/entities/59c500ac67e4ebf3405cfda0"
+            }
+        ],
+        "foundingDate": "1993-02-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "84-86 Rushey Green, Catford, London, SE6 4HW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14460321953187683318",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-02",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13199141596048989804"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02800266_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02800266_bods.json
@@ -1,1 +1,398 @@
-[{"statementID": "openownership-register-7467589745693019485", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASKHAM BRYAN COLLEGE COMPANY LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02800266"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02800266", "uri": "https://opencorporates.com/companies/gb/02800266"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6", "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6"}], "foundingDate": "1993-03-16", "addresses": [{"type": "registered", "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR", "country": "GB"}]}, {"statementID": "openownership-register-2211890866620559286", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17007445041095320227", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-17", "subject": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2292139226777605985"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-10-17", "endDate": "2019-06-17"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11659743295692737675", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12164003245588251409"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01", "endDate": "2018-12-17"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11604748353368028686", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-17", "subject": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6470216727310615539"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-10-17", "endDate": "2019-05-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9406779807799341863", "statementType": "ownershipOrControlStatement", "statementDate": "2018-05-14", "subject": {"describedByEntityStatement": "openownership-register-7467589745693019485"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13406178187780011426"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2018-05-14", "endDate": "2018-09-26"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7467589745693019485", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASKHAM BRYAN COLLEGE COMPANY LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02800266"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02800266", "uri": "https://opencorporates.com/companies/gb/02800266"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6", "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6"}], "foundingDate": "1993-03-16", "addresses": [{"type": "registered", "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR", "country": "GB"}]}, {"statementID": "openownership-register-2292139226777605985", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Standen"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02800266/persons-with-significant-control/individual/0Z0ZgKyo9Q9BVbI8nq3jmUJqVQM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378d4", "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378d4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1973-03-01", "addresses": [{"address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"}]}, {"statementID": "openownership-register-12164003245588251409", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "William Anthony Alton"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02800266/persons-with-significant-control/individual/BZKUah5OSKJMvhm23zcJ0EPtJLI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378a6", "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378a6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1947-05-01", "addresses": [{"address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"}]}, {"statementID": "openownership-register-6470216727310615539", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alan Moore Bowe"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02800266/persons-with-significant-control/individual/qgSwkb9NQnvXwdy6uI2G9CQuv7g"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377e9", "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377e9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1943-04-01", "addresses": [{"address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"}]}, {"statementID": "openownership-register-13406178187780011426", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ian William Brown"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02800266/persons-with-significant-control/individual/tcb6P72Nhgp8kaeSTO7at7QhX84"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b613cc89dfc3fae18898907", "uri": "http://register.openownership.org/entities/5b613cc89dfc3fae18898907"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-03-01", "addresses": [{"address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"}]}]
+[
+    {
+        "statementID": "openownership-register-7467589745693019485",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASKHAM BRYAN COLLEGE COMPANY LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02800266"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02800266",
+                "uri": "https://opencorporates.com/companies/gb/02800266"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6",
+                "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6"
+            }
+        ],
+        "foundingDate": "1993-03-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2211890866620559286",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17007445041095320227",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-17",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2292139226777605985"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-17",
+                "endDate": "2019-06-17"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11659743295692737675",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12164003245588251409"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01",
+                "endDate": "2018-12-17"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11604748353368028686",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-17",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6470216727310615539"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-17",
+                "endDate": "2019-05-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9406779807799341863",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-05-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7467589745693019485"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13406178187780011426"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2018-05-14",
+                "endDate": "2018-09-26"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7467589745693019485",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASKHAM BRYAN COLLEGE COMPANY LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02800266"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02800266",
+                "uri": "https://opencorporates.com/companies/gb/02800266"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6",
+                "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377d6"
+            }
+        ],
+        "foundingDate": "1993-03-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2292139226777605985",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Standen"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02800266/persons-with-significant-control/individual/0Z0ZgKyo9Q9BVbI8nq3jmUJqVQM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378d4",
+                "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378d4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1973-03-01",
+        "addresses": [
+            {
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12164003245588251409",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "William Anthony Alton"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02800266/persons-with-significant-control/individual/BZKUah5OSKJMvhm23zcJ0EPtJLI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378a6",
+                "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403378a6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1947-05-01",
+        "addresses": [
+            {
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6470216727310615539",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alan Moore Bowe"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02800266/persons-with-significant-control/individual/qgSwkb9NQnvXwdy6uI2G9CQuv7g"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377e9",
+                "uri": "http://register.openownership.org/entities/59b9a4fb67e4ebf3403377e9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1943-04-01",
+        "addresses": [
+            {
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13406178187780011426",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ian William Brown"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02800266/persons-with-significant-control/individual/tcb6P72Nhgp8kaeSTO7at7QhX84"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b613cc89dfc3fae18898907",
+                "uri": "http://register.openownership.org/entities/5b613cc89dfc3fae18898907"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-03-01",
+        "addresses": [
+            {
+                "address": "Askham Bryan College, Askham Bryan, York, North Yorkshire, YO23 3FR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02828135_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02828135_bods.json
@@ -1,1 +1,92 @@
-[{"statementID": "openownership-register-5470584835391738347", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HELENA BIOSCIENCES EUROPE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02828135"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02828135", "uri": "https://opencorporates.com/companies/gb/02828135"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c5ea67e4ebf340b145b7", "uri": "http://register.openownership.org/entities/59b9c5ea67e4ebf340b145b7"}], "foundingDate": "1993-06-17", "addresses": [{"type": "registered", "address": "Helena Biosciences Unit B M361, Queensway South, Team Valley Trad Est, Gateshead, Tyne And Wear, NE11 0SD", "country": "GB"}]}, {"statementID": "openownership-register-2944674923190272292", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5470584835391738347"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5387042237678861921"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5387042237678861921", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tipton Lee Golias"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03247668/persons-with-significant-control/individual/Ul4U5nGaAQfLLtZ1AGcg2YwY5wk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9390b67e4ebf3405972bb", "uri": "http://register.openownership.org/entities/59b9390b67e4ebf3405972bb"}], "birthDate": "1941-12-01", "addresses": [{"address": "1530, Lindbergh Dr, Beaumont, Texas", "country": "US"}]}]
+[
+    {
+        "statementID": "openownership-register-5470584835391738347",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HELENA BIOSCIENCES EUROPE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02828135"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02828135",
+                "uri": "https://opencorporates.com/companies/gb/02828135"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c5ea67e4ebf340b145b7",
+                "uri": "http://register.openownership.org/entities/59b9c5ea67e4ebf340b145b7"
+            }
+        ],
+        "foundingDate": "1993-06-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Helena Biosciences Unit B M361, Queensway South, Team Valley Trad Est, Gateshead, Tyne And Wear, NE11 0SD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2944674923190272292",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5470584835391738347"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5387042237678861921"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5387042237678861921",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tipton Lee Golias"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03247668/persons-with-significant-control/individual/Ul4U5nGaAQfLLtZ1AGcg2YwY5wk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9390b67e4ebf3405972bb",
+                "uri": "http://register.openownership.org/entities/59b9390b67e4ebf3405972bb"
+            }
+        ],
+        "birthDate": "1941-12-01",
+        "addresses": [
+            {
+                "address": "1530, Lindbergh Dr, Beaumont, Texas",
+                "country": "US"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02829836_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02829836_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-9601557925262500982", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MORLEY COLLEGE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02829836"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02829836", "uri": "https://opencorporates.com/companies/gb/02829836"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c509fb67e4ebf34071687c", "uri": "http://register.openownership.org/entities/59c509fb67e4ebf34071687c"}], "foundingDate": "1993-06-18", "addresses": [{"type": "registered", "address": "61 Westminster Bridge Road, London, SE1 7HT", "country": "GB"}]}, {"statementID": "openownership-register-1003832559098416050", "statementType": "ownershipOrControlStatement", "statementDate": "2017-06-18", "subject": {"describedByEntityStatement": "openownership-register-9601557925262500982"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-9601557925262500982",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MORLEY COLLEGE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02829836"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02829836",
+                "uri": "https://opencorporates.com/companies/gb/02829836"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c509fb67e4ebf34071687c",
+                "uri": "http://register.openownership.org/entities/59c509fb67e4ebf34071687c"
+            }
+        ],
+        "foundingDate": "1993-06-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "61 Westminster Bridge Road, London, SE1 7HT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1003832559098416050",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-06-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9601557925262500982"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02858230_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02858230_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-5904251069730825774", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VECTAIR ENVIRONMENTAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02858230"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02858230", "uri": "https://opencorporates.com/companies/gb/02858230"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d20d", "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d20d"}], "foundingDate": "1993-09-29", "addresses": [{"type": "registered", "address": "5 Apollo House, Calleva Park, Aldermaston, Berkshire, RG7 8TN", "country": "GB"}]}, {"statementID": "openownership-register-3757173976780896724", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5904251069730825774"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15030313418206581044"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16618186792417843985", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5904251069730825774"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14845565540633825835"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15030313418206581044", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Frank Doran"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02858230/persons-with-significant-control/individual/8PMNh2KhCTbOCaxahDspeLeyBB4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21f", "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1952-10-01", "addresses": [{"address": "100, Thetford Road, New Malden, KT3 5DZ"}]}, {"statementID": "openownership-register-14845565540633825835", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark Corr"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02858230/persons-with-significant-control/individual/pmh-3yHnb6dmKnpuAO0ffozAGdM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21c", "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-10-01", "addresses": [{"address": "33, Brookly Gardens, Fleet, GU51 3LL"}]}]
+[
+    {
+        "statementID": "openownership-register-5904251069730825774",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VECTAIR ENVIRONMENTAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02858230"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02858230",
+                "uri": "https://opencorporates.com/companies/gb/02858230"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d20d",
+                "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d20d"
+            }
+        ],
+        "foundingDate": "1993-09-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Apollo House, Calleva Park, Aldermaston, Berkshire, RG7 8TN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3757173976780896724",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5904251069730825774"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15030313418206581044"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16618186792417843985",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5904251069730825774"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14845565540633825835"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15030313418206581044",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Frank Doran"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02858230/persons-with-significant-control/individual/8PMNh2KhCTbOCaxahDspeLeyBB4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21f",
+                "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1952-10-01",
+        "addresses": [
+            {
+                "address": "100, Thetford Road, New Malden, KT3 5DZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14845565540633825835",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark Corr"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02858230/persons-with-significant-control/individual/pmh-3yHnb6dmKnpuAO0ffozAGdM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21c",
+                "uri": "http://register.openownership.org/entities/59b94cc067e4ebf340b1d21c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-10-01",
+        "addresses": [
+            {
+                "address": "33, Brookly Gardens, Fleet, GU51 3LL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02862423_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02862423_bods.json
@@ -1,1 +1,123 @@
-[{"statementID": "openownership-register-15911758707588967747", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MOBILE MINI UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02862423"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02862423"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02862423"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02862423", "uri": "https://opencorporates.com/companies/gb/02862423"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9516767e4ebf340c686da", "uri": "http://register.openownership.org/entities/59b9516767e4ebf340c686da"}], "foundingDate": "1993-10-14", "addresses": [{"type": "registered", "address": "Ravenstock House 28 Falcon Court, Preston Farm Business Park, Stockton-On-Tees, TS18 3TX", "country": "GB"}]}, {"statementID": "openownership-register-1450789038495430863", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15911758707588967747"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3529772713296240550"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3529772713296240550", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MOBILE MINI UK HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05749804"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05749804"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05749804", "uri": "https://opencorporates.com/companies/gb/05749804"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e1367e4ebf34070a82f", "uri": "http://register.openownership.org/entities/59b93e1367e4ebf34070a82f"}], "foundingDate": "2006-03-21", "addresses": [{"type": "registered", "address": "Ravenstock House 28 Falcon Court, Preston Farm Business Park, Stockton-On-Tees, TS18 3TX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15911758707588967747",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MOBILE MINI UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02862423"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02862423"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02862423"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02862423",
+                "uri": "https://opencorporates.com/companies/gb/02862423"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9516767e4ebf340c686da",
+                "uri": "http://register.openownership.org/entities/59b9516767e4ebf340c686da"
+            }
+        ],
+        "foundingDate": "1993-10-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ravenstock House 28 Falcon Court, Preston Farm Business Park, Stockton-On-Tees, TS18 3TX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1450789038495430863",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15911758707588967747"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3529772713296240550"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3529772713296240550",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MOBILE MINI UK HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05749804"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05749804"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05749804",
+                "uri": "https://opencorporates.com/companies/gb/05749804"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e1367e4ebf34070a82f",
+                "uri": "http://register.openownership.org/entities/59b93e1367e4ebf34070a82f"
+            }
+        ],
+        "foundingDate": "2006-03-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ravenstock House 28 Falcon Court, Preston Farm Business Park, Stockton-On-Tees, TS18 3TX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888194_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888194_bods.json
@@ -1,1 +1,268 @@
-[{"statementID": "openownership-register-2384711765739378211", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NPS PROPERTY CONSULTANTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02888194", "uri": "https://opencorporates.com/companies/gb/02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2888194"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888194"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b931ec67e4ebf34037388a", "uri": "http://register.openownership.org/entities/59b931ec67e4ebf34037388a"}], "foundingDate": "1994-01-17", "addresses": [{"type": "registered", "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ", "country": "GB"}]}, {"statementID": "openownership-register-4403661641560650438", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2384711765739378211"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4733040992128981317"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4733040992128981317", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NORSE GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05694657", "uri": "https://opencorporates.com/companies/gb/05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec", "uri": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec"}], "foundingDate": "2006-02-01", "addresses": [{"type": "registered", "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2384711765739378211",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NPS PROPERTY CONSULTANTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02888194",
+                "uri": "https://opencorporates.com/companies/gb/02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888194"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b931ec67e4ebf34037388a",
+                "uri": "http://register.openownership.org/entities/59b931ec67e4ebf34037388a"
+            }
+        ],
+        "foundingDate": "1994-01-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4403661641560650438",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2384711765739378211"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4733040992128981317"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4733040992128981317",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NORSE GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05694657",
+                "uri": "https://opencorporates.com/companies/gb/05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec",
+                "uri": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec"
+            }
+        ],
+        "foundingDate": "2006-02-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888250_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888250_bods.json
@@ -1,1 +1,375 @@
-[{"statementID": "openownership-register-11347041761580092687", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DAISY CORPORATE SERVICES TRADING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02888250", "uri": "https://opencorporates.com/companies/gb/02888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2888250"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888250"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018d046", "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018d046"}], "foundingDate": "1994-01-17", "addresses": [{"type": "registered", "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR", "country": "GB"}]}, {"statementID": "openownership-register-12794424795558468891", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-23", "subject": {"describedByEntityStatement": "openownership-register-11347041761580092687"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14846022938040873605"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-12-23", "endDate": "2019-07-12"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-12-23", "endDate": "2019-07-12"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-12-23", "endDate": "2019-07-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-12281716176585557898", "statementType": "ownershipOrControlStatement", "statementDate": "2019-07-12", "subject": {"describedByEntityStatement": "openownership-register-11347041761580092687"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15090623716804856248"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-07-12"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-07-12"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-07-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-14846022938040873605", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DAISY INTERMEDIATE HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08384981"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08384981", "uri": "https://opencorporates.com/companies/gb/08384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8384981"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9394167e4ebf3405a4213", "uri": "http://register.openownership.org/entities/59b9394167e4ebf3405a4213"}], "foundingDate": "2013-02-01", "addresses": [{"type": "registered", "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR", "country": "GB"}]}, {"statementID": "openownership-register-15090623716804856248", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DAISY CORPORATE SERVICES HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11508216"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11508216", "uri": "https://opencorporates.com/companies/gb/11508216"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "11508216"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbb733f9dfc3fae182aeb3e", "uri": "http://register.openownership.org/entities/5bbb733f9dfc3fae182aeb3e"}], "foundingDate": "2018-08-09", "addresses": [{"type": "registered", "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-11347041761580092687",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DAISY CORPORATE SERVICES TRADING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02888250",
+                "uri": "https://opencorporates.com/companies/gb/02888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2888250"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888250"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92ba267e4ebf34018d046",
+                "uri": "http://register.openownership.org/entities/59b92ba267e4ebf34018d046"
+            }
+        ],
+        "foundingDate": "1994-01-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12794424795558468891",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11347041761580092687"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14846022938040873605"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-12-23",
+                "endDate": "2019-07-12"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-12-23",
+                "endDate": "2019-07-12"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-12-23",
+                "endDate": "2019-07-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12281716176585557898",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-07-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11347041761580092687"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15090623716804856248"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-07-12"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-07-12"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-07-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14846022938040873605",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DAISY INTERMEDIATE HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08384981"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08384981",
+                "uri": "https://opencorporates.com/companies/gb/08384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8384981"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9394167e4ebf3405a4213",
+                "uri": "http://register.openownership.org/entities/59b9394167e4ebf3405a4213"
+            }
+        ],
+        "foundingDate": "2013-02-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15090623716804856248",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DAISY CORPORATE SERVICES HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11508216"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11508216",
+                "uri": "https://opencorporates.com/companies/gb/11508216"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11508216"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbb733f9dfc3fae182aeb3e",
+                "uri": "http://register.openownership.org/entities/5bbb733f9dfc3fae182aeb3e"
+            }
+        ],
+        "foundingDate": "2018-08-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Lindred House, 20 Lindred Road, Brierfield, Nelson, BB9 5SR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888808_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02888808_bods.json
@@ -1,1 +1,234 @@
-[{"statementID": "openownership-register-12067666758999836395", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NORSE COMMERCIAL SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02888808", "uri": "https://opencorporates.com/companies/gb/02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02888808"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92c7867e4ebf3401cf802", "uri": "http://register.openownership.org/entities/59b92c7867e4ebf3401cf802"}], "foundingDate": "1994-01-18", "addresses": [{"type": "registered", "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ", "country": "GB"}]}, {"statementID": "openownership-register-5226980129208412027", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12067666758999836395"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4733040992128981317"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4733040992128981317", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NORSE GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05694657", "uri": "https://opencorporates.com/companies/gb/05694657"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05694657"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec", "uri": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec"}], "foundingDate": "2006-02-01", "addresses": [{"type": "registered", "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12067666758999836395",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NORSE COMMERCIAL SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02888808",
+                "uri": "https://opencorporates.com/companies/gb/02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02888808"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92c7867e4ebf3401cf802",
+                "uri": "http://register.openownership.org/entities/59b92c7867e4ebf3401cf802"
+            }
+        ],
+        "foundingDate": "1994-01-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5226980129208412027",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12067666758999836395"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4733040992128981317"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4733040992128981317",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NORSE GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05694657",
+                "uri": "https://opencorporates.com/companies/gb/05694657"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05694657"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec",
+                "uri": "http://register.openownership.org/entities/59b9617567e4ebf3401145ec"
+            }
+        ],
+        "foundingDate": "2006-02-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "280 Fifers Lane, Norwich, Norfolk, NR6 6EQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02970219_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02970219_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-6052203515488457821", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JBP ASSOCIATES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02970219"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02970219", "uri": "https://opencorporates.com/companies/gb/02970219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02970219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02970219"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93ccb67e4ebf3406ace61", "uri": "http://register.openownership.org/entities/59b93ccb67e4ebf3406ace61"}], "foundingDate": "1994-09-21", "addresses": [{"type": "registered", "address": "34 Smith Square, London, SW1P 3HL", "country": "GB"}]}, {"statementID": "openownership-register-11504758614185103097", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-6052203515488457821"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8193903272727552987"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8193903272727552987", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JBP (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07233724"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07233724"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07233724", "uri": "https://opencorporates.com/companies/gb/07233724"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93ccc67e4ebf3406ad24b", "uri": "http://register.openownership.org/entities/59b93ccc67e4ebf3406ad24b"}], "foundingDate": "2010-04-23", "addresses": [{"type": "registered", "address": "34 Smith Square, London, SW1P 3HL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6052203515488457821",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JBP ASSOCIATES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02970219"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02970219",
+                "uri": "https://opencorporates.com/companies/gb/02970219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02970219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02970219"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93ccb67e4ebf3406ace61",
+                "uri": "http://register.openownership.org/entities/59b93ccb67e4ebf3406ace61"
+            }
+        ],
+        "foundingDate": "1994-09-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "34 Smith Square, London, SW1P 3HL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11504758614185103097",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6052203515488457821"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8193903272727552987"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8193903272727552987",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JBP (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07233724"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07233724"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07233724",
+                "uri": "https://opencorporates.com/companies/gb/07233724"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93ccc67e4ebf3406ad24b",
+                "uri": "http://register.openownership.org/entities/59b93ccc67e4ebf3406ad24b"
+            }
+        ],
+        "foundingDate": "2010-04-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "34 Smith Square, London, SW1P 3HL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02981404_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_02981404_bods.json
@@ -1,1 +1,107 @@
-[{"statementID": "openownership-register-1482073563839415095", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PRECIOUS HOMES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02981404"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02981404"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02981404", "uri": "https://opencorporates.com/companies/gb/02981404"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96b5b67e4ebf340425d91", "uri": "http://register.openownership.org/entities/59b96b5b67e4ebf340425d91"}], "foundingDate": "1994-10-20", "addresses": [{"type": "registered", "address": "Magic House, 5-11 Green Lanes, Palmers Green, London, N13 4TN", "country": "GB"}]}, {"statementID": "openownership-register-17346033271871298324", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1482073563839415095"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9811749988520686478"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-9811749988520686478", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mitesh Dhanak"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02981404/persons-with-significant-control/individual/Ekwgt619ebIiL-aC7xLgBd_7Uno"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96c1567e4ebf34045f802", "uri": "http://register.openownership.org/entities/59b96c1567e4ebf34045f802"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-04-01", "addresses": [{"address": "Magic House, 5-11 Green Lanes, Palmers Green, London, N13 4TN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1482073563839415095",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PRECIOUS HOMES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02981404"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02981404"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02981404",
+                "uri": "https://opencorporates.com/companies/gb/02981404"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96b5b67e4ebf340425d91",
+                "uri": "http://register.openownership.org/entities/59b96b5b67e4ebf340425d91"
+            }
+        ],
+        "foundingDate": "1994-10-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Magic House, 5-11 Green Lanes, Palmers Green, London, N13 4TN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17346033271871298324",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1482073563839415095"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9811749988520686478"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9811749988520686478",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mitesh Dhanak"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02981404/persons-with-significant-control/individual/Ekwgt619ebIiL-aC7xLgBd_7Uno"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96c1567e4ebf34045f802",
+                "uri": "http://register.openownership.org/entities/59b96c1567e4ebf34045f802"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-04-01",
+        "addresses": [
+            {
+                "address": "Magic House, 5-11 Green Lanes, Palmers Green, London, N13 4TN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03008194_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03008194_bods.json
@@ -1,1 +1,84 @@
-[{"statementID": "openownership-register-1591138865727749012", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BRAMLEY ELDERLY ACTION", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03008194"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03008194", "uri": "https://opencorporates.com/companies/gb/03008194"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4ff6e67e4ebf3405a73d4", "uri": "http://register.openownership.org/entities/59c4ff6e67e4ebf3405a73d4"}], "foundingDate": "1995-01-10", "dissolutionDate": "2018-06-19", "addresses": [{"type": "registered", "address": "Bramley Community Centre Waterloo Lane, Bramley, Leeds, West Yorkshire, LS13 2JB", "country": "GB"}]}, {"statementID": "openownership-register-1516383961145739703", "statementType": "ownershipOrControlStatement", "statementDate": "2019-01-14", "subject": {"describedByEntityStatement": "openownership-register-1591138865727749012"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11120982765704532684", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-10", "subject": {"describedByEntityStatement": "openownership-register-1591138865727749012"}, "interestedParty": {"unspecified": {"reason": "unknown", "description": "Unknown person(s)"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-1591138865727749012",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BRAMLEY ELDERLY ACTION",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03008194"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03008194",
+                "uri": "https://opencorporates.com/companies/gb/03008194"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4ff6e67e4ebf3405a73d4",
+                "uri": "http://register.openownership.org/entities/59c4ff6e67e4ebf3405a73d4"
+            }
+        ],
+        "foundingDate": "1995-01-10",
+        "dissolutionDate": "2018-06-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Bramley Community Centre Waterloo Lane, Bramley, Leeds, West Yorkshire, LS13 2JB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1516383961145739703",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-01-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1591138865727749012"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11120982765704532684",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1591138865727749012"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03078711_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03078711_bods.json
@@ -1,1 +1,962 @@
-[{"statementID": "openownership-register-1779649382785427121", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BRITISH GAS TRADING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03078711"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03078711", "uri": "https://opencorporates.com/companies/gb/03078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3078711"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9491c67e4ebf340a23584", "uri": "http://register.openownership.org/entities/59b9491c67e4ebf340a23584"}], "foundingDate": "1995-07-06", "addresses": [{"type": "registered", "address": "Millstream Maidenhead Road, Windsor, Berkshire, SL4 5GD", "country": "GB"}]}, {"statementID": "openownership-register-10788976476361291933", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1779649382785427121"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11109117381713149657"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11109117381713149657", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GB GAS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03186121"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03186121", "uri": "https://opencorporates.com/companies/gb/03186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3186121"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93fc167e4ebf340784813", "uri": "http://register.openownership.org/entities/59b93fc167e4ebf340784813"}], "foundingDate": "1996-04-15", "addresses": [{"type": "registered", "address": "Millstream Maidenhead Road, Windsor, Berkshire, SL4 5GD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1779649382785427121",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BRITISH GAS TRADING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03078711"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03078711",
+                "uri": "https://opencorporates.com/companies/gb/03078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3078711"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9491c67e4ebf340a23584",
+                "uri": "http://register.openownership.org/entities/59b9491c67e4ebf340a23584"
+            }
+        ],
+        "foundingDate": "1995-07-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Millstream Maidenhead Road, Windsor, Berkshire, SL4 5GD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10788976476361291933",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1779649382785427121"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11109117381713149657"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11109117381713149657",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GB GAS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03186121"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03186121",
+                "uri": "https://opencorporates.com/companies/gb/03186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3186121"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93fc167e4ebf340784813",
+                "uri": "http://register.openownership.org/entities/59b93fc167e4ebf340784813"
+            }
+        ],
+        "foundingDate": "1996-04-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Millstream Maidenhead Road, Windsor, Berkshire, SL4 5GD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03084746_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03084746_bods.json
@@ -1,1 +1,98 @@
-[{"statementID": "openownership-register-1679830396404736633", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LANDAU LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03084746"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03084746", "uri": "https://opencorporates.com/companies/gb/03084746"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9426667e4ebf34083490c", "uri": "http://register.openownership.org/entities/59b9426667e4ebf34083490c"}], "foundingDate": "1995-07-27", "addresses": [{"type": "registered", "address": "5 Landau Court, Tan Bank Wellington, Telford, Shropshire, TF1 1HE", "country": "GB"}]}, {"statementID": "openownership-register-15701613769551375687", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-23", "subject": {"describedByEntityStatement": "openownership-register-1679830396404736633"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9007787972325900665"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-trust", "startDate": "2016-08-23", "endDate": "2019-04-11"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-9007787972325900665", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip John Hall"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03084746/persons-with-significant-control/individual/okPy40SX5Ps8xODpTeccBVKFm1k"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9426667e4ebf34083491b", "uri": "http://register.openownership.org/entities/59b9426667e4ebf34083491b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1940-02-01", "addresses": [{"address": "5 Landau Court, Tan Bank Wellington, Telford, Shropshire, TF1 1HE"}]}]
+[
+    {
+        "statementID": "openownership-register-1679830396404736633",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LANDAU LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03084746"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03084746",
+                "uri": "https://opencorporates.com/companies/gb/03084746"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9426667e4ebf34083490c",
+                "uri": "http://register.openownership.org/entities/59b9426667e4ebf34083490c"
+            }
+        ],
+        "foundingDate": "1995-07-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Landau Court, Tan Bank Wellington, Telford, Shropshire, TF1 1HE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15701613769551375687",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1679830396404736633"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9007787972325900665"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-trust",
+                "startDate": "2016-08-23",
+                "endDate": "2019-04-11"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9007787972325900665",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip John Hall"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03084746/persons-with-significant-control/individual/okPy40SX5Ps8xODpTeccBVKFm1k"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9426667e4ebf34083491b",
+                "uri": "http://register.openownership.org/entities/59b9426667e4ebf34083491b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1940-02-01",
+        "addresses": [
+            {
+                "address": "5 Landau Court, Tan Bank Wellington, Telford, Shropshire, TF1 1HE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03154411_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03154411_bods.json
@@ -1,1 +1,133 @@
-[{"statementID": "openownership-register-14379513363124135875", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Ibi Group (Uk) Limited", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03154411"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03154411"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03154411", "uri": "https://opencorporates.com/companies/gb/03154411"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91fc167e4ebf340e73108", "uri": "http://register.openownership.org/entities/59b91fc167e4ebf340e73108"}], "foundingDate": "1996-02-02", "addresses": [{"type": "registered", "address": "One Didsbury Point, The Avenue, Didsbury, Manchester, M20 2EY", "country": "GB"}]}, {"statementID": "openownership-register-685613857255007028", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14379513363124135875"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16419519222544410941"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-16419519222544410941", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "IBI HOLDCO LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07255939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07255939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07255939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07255939"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07255939"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07255939", "uri": "https://opencorporates.com/companies/gb/07255939"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab94e1d9dfc3fae187b4b63", "uri": "http://register.openownership.org/entities/5ab94e1d9dfc3fae187b4b63"}], "foundingDate": "2010-05-17", "addresses": [{"type": "registered", "address": "One Didsbury Point The Avenue, Didsbury, Manchester, M20 2EY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14379513363124135875",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Ibi Group (Uk) Limited",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03154411"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03154411"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03154411",
+                "uri": "https://opencorporates.com/companies/gb/03154411"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91fc167e4ebf340e73108",
+                "uri": "http://register.openownership.org/entities/59b91fc167e4ebf340e73108"
+            }
+        ],
+        "foundingDate": "1996-02-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Didsbury Point, The Avenue, Didsbury, Manchester, M20 2EY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-685613857255007028",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14379513363124135875"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16419519222544410941"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16419519222544410941",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "IBI HOLDCO LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07255939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07255939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07255939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07255939"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07255939"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07255939",
+                "uri": "https://opencorporates.com/companies/gb/07255939"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab94e1d9dfc3fae187b4b63",
+                "uri": "http://register.openownership.org/entities/5ab94e1d9dfc3fae187b4b63"
+            }
+        ],
+        "foundingDate": "2010-05-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Didsbury Point The Avenue, Didsbury, Manchester, M20 2EY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03167858_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03167858_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-13342972498027729456", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LOGAN CONSTRUCTION (SOUTH EAST) LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03167858"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03167858", "uri": "https://opencorporates.com/companies/gb/03167858"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56973", "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56973"}], "foundingDate": "1996-03-05", "addresses": [{"type": "registered", "address": "Unit 7 Business Park, 238 Green Lane, Eltham, London, SE9 3TL", "country": "GB"}]}, {"statementID": "openownership-register-14124600181223536630", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-31", "subject": {"describedByEntityStatement": "openownership-register-13342972498027729456"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13352352626729001033"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-01-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-10715689353564864064", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-31", "subject": {"describedByEntityStatement": "openownership-register-13342972498027729456"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4261944417252000762"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-01-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13352352626729001033", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "William Patrick Logan"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03167858/persons-with-significant-control/individual/9ngEYifPe8SLdke3gGTF2RqEglg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56982", "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56982"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1973-10-01", "addresses": [{"address": "Unit 7, Business Park, 238 Green Lane, Eltham, London, SE9 3TL"}]}, {"statementID": "openownership-register-4261944417252000762", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "William Patrick Logan"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03167858/persons-with-significant-control/individual/byzSm4lfgDw--NaNbY5NfwmwZ2k"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56994", "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56994"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1947-05-01", "addresses": [{"address": "Unit 7, Business Park, 238 Green Lane, Eltham, London, SE9 3TL"}]}]
+[
+    {
+        "statementID": "openownership-register-13342972498027729456",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LOGAN CONSTRUCTION (SOUTH EAST) LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03167858"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03167858",
+                "uri": "https://opencorporates.com/companies/gb/03167858"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56973",
+                "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56973"
+            }
+        ],
+        "foundingDate": "1996-03-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 7 Business Park, 238 Green Lane, Eltham, London, SE9 3TL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14124600181223536630",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13342972498027729456"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13352352626729001033"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10715689353564864064",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13342972498027729456"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4261944417252000762"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-01-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13352352626729001033",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "William Patrick Logan"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03167858/persons-with-significant-control/individual/9ngEYifPe8SLdke3gGTF2RqEglg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56982",
+                "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56982"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1973-10-01",
+        "addresses": [
+            {
+                "address": "Unit 7, Business Park, 238 Green Lane, Eltham, London, SE9 3TL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4261944417252000762",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "William Patrick Logan"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03167858/persons-with-significant-control/individual/byzSm4lfgDw--NaNbY5NfwmwZ2k"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f4567e4ebf340a56994",
+                "uri": "http://register.openownership.org/entities/59b97f4567e4ebf340a56994"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1947-05-01",
+        "addresses": [
+            {
+                "address": "Unit 7, Business Park, 238 Green Lane, Eltham, London, SE9 3TL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03168455_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03168455_bods.json
@@ -1,1 +1,109 @@
-[{"statementID": "openownership-register-16427177340561407089", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "J. TOMLINSON LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03168455"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03168455", "uri": "https://opencorporates.com/companies/gb/03168455"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9948c67e4ebf340f7807e", "uri": "http://register.openownership.org/entities/59b9948c67e4ebf340f7807e"}], "foundingDate": "1996-03-06", "addresses": [{"type": "registered", "address": "Scimitar House, 100 Lilac Grove, Beeston, Notts, NG9 1FP", "country": "GB"}]}, {"statementID": "openownership-register-2884641688099380630", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16427177340561407089"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15428140571775116783"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15428140571775116783", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "J TOMLINSON (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05572880"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05572880"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05572880", "uri": "https://opencorporates.com/companies/gb/05572880"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9474a67e4ebf34098ced1", "uri": "http://register.openownership.org/entities/59b9474a67e4ebf34098ced1"}], "foundingDate": "2005-09-23", "addresses": [{"type": "registered", "address": "Scimitar House, 100 Lilac Grove, Beeston, Nottingham, NG9 1PF", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16427177340561407089",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "J. TOMLINSON LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03168455"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03168455",
+                "uri": "https://opencorporates.com/companies/gb/03168455"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9948c67e4ebf340f7807e",
+                "uri": "http://register.openownership.org/entities/59b9948c67e4ebf340f7807e"
+            }
+        ],
+        "foundingDate": "1996-03-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Scimitar House, 100 Lilac Grove, Beeston, Notts, NG9 1FP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2884641688099380630",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16427177340561407089"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15428140571775116783"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15428140571775116783",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "J TOMLINSON (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05572880"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05572880"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05572880",
+                "uri": "https://opencorporates.com/companies/gb/05572880"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9474a67e4ebf34098ced1",
+                "uri": "http://register.openownership.org/entities/59b9474a67e4ebf34098ced1"
+            }
+        ],
+        "foundingDate": "2005-09-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Scimitar House, 100 Lilac Grove, Beeston, Nottingham, NG9 1PF",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03172014_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03172014_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-7948139772547949016", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HALSION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03172014"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03172014", "uri": "https://opencorporates.com/companies/gb/03172014"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b976ad67e4ebf3407a2a44", "uri": "http://register.openownership.org/entities/59b976ad67e4ebf3407a2a44"}], "foundingDate": "1996-03-13", "addresses": [{"type": "registered", "address": "Homestead Farm Stone Street, Petham, Canterbury, Kent, CT4 5PP", "country": "GB"}]}, {"statementID": "openownership-register-7988452718993139549", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7948139772547949016"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7424969178598800643"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7424969178598800643", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HALSION HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04246093"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04246093", "uri": "https://opencorporates.com/companies/gb/04246093"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91c6c67e4ebf340dcaaf5", "uri": "http://register.openownership.org/entities/59b91c6c67e4ebf340dcaaf5"}], "foundingDate": "2001-07-04", "addresses": [{"type": "registered", "address": "Homestead Farm Stone Street, Petham, Canterbury, Kent, CT4 5PP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7948139772547949016",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HALSION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03172014"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03172014",
+                "uri": "https://opencorporates.com/companies/gb/03172014"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b976ad67e4ebf3407a2a44",
+                "uri": "http://register.openownership.org/entities/59b976ad67e4ebf3407a2a44"
+            }
+        ],
+        "foundingDate": "1996-03-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Homestead Farm Stone Street, Petham, Canterbury, Kent, CT4 5PP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7988452718993139549",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7948139772547949016"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7424969178598800643"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7424969178598800643",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HALSION HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04246093"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04246093",
+                "uri": "https://opencorporates.com/companies/gb/04246093"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91c6c67e4ebf340dcaaf5",
+                "uri": "http://register.openownership.org/entities/59b91c6c67e4ebf340dcaaf5"
+            }
+        ],
+        "foundingDate": "2001-07-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Homestead Farm Stone Street, Petham, Canterbury, Kent, CT4 5PP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03173418_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03173418_bods.json
@@ -1,1 +1,145 @@
-[{"statementID": "openownership-register-5254847065238927188", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MIDLAND QUARRY PRODUCTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03173418"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03173418", "uri": "https://opencorporates.com/companies/gb/03173418"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9920967e4ebf340eeeec7", "uri": "http://register.openownership.org/entities/59b9920967e4ebf340eeeec7"}], "foundingDate": "1996-03-15", "addresses": [{"type": "registered", "address": "Hanson House, 14 Castle Hill, Maidenhead, Berkshire, SL6 4JJ", "country": "GB"}]}, {"statementID": "openownership-register-16590258760203749581", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5254847065238927188"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4771594749251348785"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4771594749251348785", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HANSON QUARRY PRODUCTS EUROPE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00300002"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00300002", "uri": "https://opencorporates.com/companies/gb/00300002"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9723b67e4ebf34065321e", "uri": "http://register.openownership.org/entities/59b9723b67e4ebf34065321e"}], "foundingDate": "1935-04-23", "addresses": [{"type": "registered", "address": "Hanson House, 14 Castle Hill, Maidenhead, SL6 4JJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5254847065238927188",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MIDLAND QUARRY PRODUCTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03173418"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03173418",
+                "uri": "https://opencorporates.com/companies/gb/03173418"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9920967e4ebf340eeeec7",
+                "uri": "http://register.openownership.org/entities/59b9920967e4ebf340eeeec7"
+            }
+        ],
+        "foundingDate": "1996-03-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hanson House, 14 Castle Hill, Maidenhead, Berkshire, SL6 4JJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16590258760203749581",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5254847065238927188"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4771594749251348785"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4771594749251348785",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HANSON QUARRY PRODUCTS EUROPE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00300002"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00300002",
+                "uri": "https://opencorporates.com/companies/gb/00300002"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9723b67e4ebf34065321e",
+                "uri": "http://register.openownership.org/entities/59b9723b67e4ebf34065321e"
+            }
+        ],
+        "foundingDate": "1935-04-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hanson House, 14 Castle Hill, Maidenhead, SL6 4JJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03182827_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03182827_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-8985132140041005903", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "THE HAMPTON TRUST (HAMPSHIRE & THE ISLE OF WIGHT)", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03182827"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03182827", "uri": "https://opencorporates.com/companies/gb/03182827"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c507ae67e4ebf3406c3fc3", "uri": "http://register.openownership.org/entities/59c507ae67e4ebf3406c3fc3"}], "foundingDate": "1996-03-29", "addresses": [{"type": "registered", "address": "The Chubut Suite Ashurst Lodge, Ashurst, Southampton, Hampshire, SO40 7AA", "country": "GB"}]}, {"statementID": "openownership-register-2134820078371707448", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-29", "subject": {"describedByEntityStatement": "openownership-register-8985132140041005903"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-8985132140041005903",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "THE HAMPTON TRUST (HAMPSHIRE & THE ISLE OF WIGHT)",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03182827"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03182827",
+                "uri": "https://opencorporates.com/companies/gb/03182827"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c507ae67e4ebf3406c3fc3",
+                "uri": "http://register.openownership.org/entities/59c507ae67e4ebf3406c3fc3"
+            }
+        ],
+        "foundingDate": "1996-03-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Chubut Suite Ashurst Lodge, Ashurst, Southampton, Hampshire, SO40 7AA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2134820078371707448",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8985132140041005903"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03196518_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03196518_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-11415704624600844692", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "IDEAL FOR ALL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03196518"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03196518", "uri": "https://opencorporates.com/companies/gb/03196518"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c508c167e4ebf3406eb33c", "uri": "http://register.openownership.org/entities/59c508c167e4ebf3406eb33c"}], "foundingDate": "1996-05-09", "addresses": [{"type": "registered", "address": "100 Oldbury Road, Smethwick, West Midlands, B66 1JE", "country": "GB"}]}, {"statementID": "openownership-register-6730162519618051726", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-21", "subject": {"describedByEntityStatement": "openownership-register-11415704624600844692"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-11415704624600844692",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "IDEAL FOR ALL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03196518"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03196518",
+                "uri": "https://opencorporates.com/companies/gb/03196518"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c508c167e4ebf3406eb33c",
+                "uri": "http://register.openownership.org/entities/59c508c167e4ebf3406eb33c"
+            }
+        ],
+        "foundingDate": "1996-05-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 Oldbury Road, Smethwick, West Midlands, B66 1JE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6730162519618051726",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-21",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11415704624600844692"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03197219_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03197219_bods.json
@@ -1,1 +1,107 @@
-[{"statementID": "openownership-register-7592698799531825925", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HEALTH FOR ALL (LEEDS) LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03197219"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03197219", "uri": "https://opencorporates.com/companies/gb/03197219"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9be9867e4ebf34094f310", "uri": "http://register.openownership.org/entities/59b9be9867e4ebf34094f310"}], "foundingDate": "1996-05-13", "addresses": [{"type": "registered", "address": "Tenants Hall Enterprise Centre Acre Close, Middleton, Leeds, West Yorkshire, LS10 4HX", "country": "GB"}]}, {"statementID": "openownership-register-13600491114666731136", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-13", "subject": {"describedByEntityStatement": "openownership-register-7592698799531825925"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4071786549374870074"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2017-05-13"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-trust", "startDate": "2017-05-13"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2017-05-13"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4071786549374870074", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Patricia Mary Mcgeever"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03197219/persons-with-significant-control/individual/7rDdcHsvtRfFHMlqWI582e-Zv7I"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9be9867e4ebf34094f320", "uri": "http://register.openownership.org/entities/59b9be9867e4ebf34094f320"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1952-12-01", "addresses": [{"address": "Tenants Hall Enterprise Centre, Acre Close, Middleton, Leeds, West Yorkshire, LS10 4HX"}]}]
+[
+    {
+        "statementID": "openownership-register-7592698799531825925",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HEALTH FOR ALL (LEEDS) LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03197219"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03197219",
+                "uri": "https://opencorporates.com/companies/gb/03197219"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9be9867e4ebf34094f310",
+                "uri": "http://register.openownership.org/entities/59b9be9867e4ebf34094f310"
+            }
+        ],
+        "foundingDate": "1996-05-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Tenants Hall Enterprise Centre Acre Close, Middleton, Leeds, West Yorkshire, LS10 4HX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13600491114666731136",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-13",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7592698799531825925"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4071786549374870074"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2017-05-13"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-trust",
+                "startDate": "2017-05-13"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2017-05-13"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4071786549374870074",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Patricia Mary Mcgeever"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03197219/persons-with-significant-control/individual/7rDdcHsvtRfFHMlqWI582e-Zv7I"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9be9867e4ebf34094f320",
+                "uri": "http://register.openownership.org/entities/59b9be9867e4ebf34094f320"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1952-12-01",
+        "addresses": [
+            {
+                "address": "Tenants Hall Enterprise Centre, Acre Close, Middleton, Leeds, West Yorkshire, LS10 4HX"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03229632_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03229632_bods.json
@@ -1,1 +1,223 @@
-[{"statementID": "openownership-register-1624052711081282453", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLARKE WILLMOTT & CLARKE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03229632"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03229632", "uri": "https://opencorporates.com/companies/gb/03229632"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91f8167e4ebf340e666c8", "uri": "http://register.openownership.org/entities/59b91f8167e4ebf340e666c8"}], "foundingDate": "1996-07-25", "addresses": [{"type": "registered", "address": "1 Georges Square, Bath Street, Bristol, BS1 6BA", "country": "GB"}]}, {"statementID": "openownership-register-11996603357060147188", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1624052711081282453"}, "interestedParty": {"describedByEntityStatement": "openownership-register-12987120890184377819"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12987120890184377819", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLARKE WILLMOTT LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344818"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC344818", "uri": "https://opencorporates.com/companies/gb/OC344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344818"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91f8267e4ebf340e667cf", "uri": "http://register.openownership.org/entities/59b91f8267e4ebf340e667cf"}], "foundingDate": "2009-04-08", "addresses": [{"type": "registered", "address": "138 Edmund Street, Birmingham, West Midlands, B3 2ES", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1624052711081282453",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLARKE WILLMOTT & CLARKE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03229632"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03229632",
+                "uri": "https://opencorporates.com/companies/gb/03229632"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91f8167e4ebf340e666c8",
+                "uri": "http://register.openownership.org/entities/59b91f8167e4ebf340e666c8"
+            }
+        ],
+        "foundingDate": "1996-07-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Georges Square, Bath Street, Bristol, BS1 6BA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11996603357060147188",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1624052711081282453"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-12987120890184377819"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12987120890184377819",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLARKE WILLMOTT LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344818"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC344818",
+                "uri": "https://opencorporates.com/companies/gb/OC344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344818"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91f8267e4ebf340e667cf",
+                "uri": "http://register.openownership.org/entities/59b91f8267e4ebf340e667cf"
+            }
+        ],
+        "foundingDate": "2009-04-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "138 Edmund Street, Birmingham, West Midlands, B3 2ES",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03241012_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03241012_bods.json
@@ -1,1 +1,155 @@
-[{"statementID": "openownership-register-6690057153673074304", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CORONA ENERGY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03241012"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03241012"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03241012"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03241012"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03241012", "uri": "https://opencorporates.com/companies/gb/03241012"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3241012"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9376767e4ebf34052317a", "uri": "http://register.openownership.org/entities/59b9376767e4ebf34052317a"}], "foundingDate": "1996-08-22", "addresses": [{"type": "registered", "address": "Building 2 Level 2, Croxley Park, Watford, WD18 8YA", "country": "GB"}]}, {"statementID": "openownership-register-16765064702331978681", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-6690057153673074304"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3160298743876599474"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3160298743876599474", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MACQUARIE CORONA ENERGY HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04752472"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04752472"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04752472"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04752472", "uri": "https://opencorporates.com/companies/gb/04752472"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4752472"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9376867e4ebf340523579", "uri": "http://register.openownership.org/entities/59b9376867e4ebf340523579"}], "foundingDate": "2003-05-02", "addresses": [{"type": "registered", "address": "Building 2 Level 2, Croxley Park, Watford, WD18 8YA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6690057153673074304",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CORONA ENERGY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03241012"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03241012"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03241012"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03241012"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03241012",
+                "uri": "https://opencorporates.com/companies/gb/03241012"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3241012"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9376767e4ebf34052317a",
+                "uri": "http://register.openownership.org/entities/59b9376767e4ebf34052317a"
+            }
+        ],
+        "foundingDate": "1996-08-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Building 2 Level 2, Croxley Park, Watford, WD18 8YA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16765064702331978681",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6690057153673074304"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3160298743876599474"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3160298743876599474",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MACQUARIE CORONA ENERGY HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04752472"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04752472"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04752472"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04752472",
+                "uri": "https://opencorporates.com/companies/gb/04752472"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4752472"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9376867e4ebf340523579",
+                "uri": "http://register.openownership.org/entities/59b9376867e4ebf340523579"
+            }
+        ],
+        "foundingDate": "2003-05-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Building 2 Level 2, Croxley Park, Watford, WD18 8YA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03272255_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03272255_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-11500858689330938990", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MAISON MOTI LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03272255"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03272255", "uri": "https://opencorporates.com/companies/gb/03272255"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165c9", "uri": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165c9"}], "foundingDate": "1996-10-31", "addresses": [{"type": "registered", "address": "8a Southbury Road, Enfield, Middlesex, EN1 1YT", "country": "GB"}]}, {"statementID": "openownership-register-5233981918681538131", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11500858689330938990"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17508141767805817725"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17508141767805817725", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Maya Mahtani"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03272255/persons-with-significant-control/individual/RasyAdB3Qww8KPJCAWw60gR4WoM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165d4", "uri": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165d4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1946-07-01", "addresses": [{"address": "8a Southbury Road, Enfield, Middlesex, EN1 1YT"}]}]
+[
+    {
+        "statementID": "openownership-register-11500858689330938990",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MAISON MOTI LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03272255"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03272255",
+                "uri": "https://opencorporates.com/companies/gb/03272255"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165c9",
+                "uri": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165c9"
+            }
+        ],
+        "foundingDate": "1996-10-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "8a Southbury Road, Enfield, Middlesex, EN1 1YT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5233981918681538131",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11500858689330938990"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17508141767805817725"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17508141767805817725",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Maya Mahtani"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03272255/persons-with-significant-control/individual/RasyAdB3Qww8KPJCAWw60gR4WoM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165d4",
+                "uri": "http://register.openownership.org/entities/59b9d31f67e4ebf340e165d4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1946-07-01",
+        "addresses": [
+            {
+                "address": "8a Southbury Road, Enfield, Middlesex, EN1 1YT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03352929_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03352929_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-7901087383116306508", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BATES OFFICE SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03352929"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03352929"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03352929"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03352929", "uri": "https://opencorporates.com/companies/gb/03352929"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94c7767e4ebf340b07206", "uri": "http://register.openownership.org/entities/59b94c7767e4ebf340b07206"}], "foundingDate": "1997-04-15", "addresses": [{"type": "registered", "address": "Units A1 - A4 Knights Park Industrial Estate, Knight Road, Rochester, Kent, ME2 2LS", "country": "GB"}]}, {"statementID": "openownership-register-18309272024501056269", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7901087383116306508"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4177628026158978398"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4177628026158978398", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Michael Edmonds"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03352929/persons-with-significant-control/individual/D1rFO-xK0z79CCPLRW6RVReNVfY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9638867e4ebf3401b99de", "uri": "http://register.openownership.org/entities/59b9638867e4ebf3401b99de"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-03-01", "addresses": [{"address": "Units A1- A4, Knights Park Industrial Estate, Knight Road, Rochester, Kent, ME2 2LS", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7901087383116306508",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BATES OFFICE SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03352929"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03352929"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03352929"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03352929",
+                "uri": "https://opencorporates.com/companies/gb/03352929"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94c7767e4ebf340b07206",
+                "uri": "http://register.openownership.org/entities/59b94c7767e4ebf340b07206"
+            }
+        ],
+        "foundingDate": "1997-04-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Units A1 - A4 Knights Park Industrial Estate, Knight Road, Rochester, Kent, ME2 2LS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18309272024501056269",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7901087383116306508"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4177628026158978398"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4177628026158978398",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michael Edmonds"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03352929/persons-with-significant-control/individual/D1rFO-xK0z79CCPLRW6RVReNVfY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9638867e4ebf3401b99de",
+                "uri": "http://register.openownership.org/entities/59b9638867e4ebf3401b99de"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-03-01",
+        "addresses": [
+            {
+                "address": "Units A1- A4, Knights Park Industrial Estate, Knight Road, Rochester, Kent, ME2 2LS",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03376202_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03376202_bods.json
@@ -1,1 +1,144 @@
-[{"statementID": "openownership-register-7252303563156541964", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OPENVIEW SECURITY SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03376202"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03376202", "uri": "https://opencorporates.com/companies/gb/03376202"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c52067e4ebf340ae4fe7", "uri": "http://register.openownership.org/entities/59b9c52067e4ebf340ae4fe7"}], "foundingDate": "1997-05-27", "addresses": [{"type": "registered", "address": "Openview House, Chesham Close, Romford, Essex, RM7 7PJ", "country": "GB"}]}, {"statementID": "openownership-register-11778413202223133664", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-05", "subject": {"describedByEntityStatement": "openownership-register-7252303563156541964"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2864384025096860820"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2864384025096860820", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "OPENVIEW GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05114513"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05114513", "uri": "https://opencorporates.com/companies/gb/05114513"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9529067e4ebf340cbbeae", "uri": "http://register.openownership.org/entities/59b9529067e4ebf340cbbeae"}], "foundingDate": "2004-04-28", "addresses": [{"type": "registered", "address": "Openview House, Chesham Close, Romford, RM7 7PJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7252303563156541964",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OPENVIEW SECURITY SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03376202"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03376202",
+                "uri": "https://opencorporates.com/companies/gb/03376202"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c52067e4ebf340ae4fe7",
+                "uri": "http://register.openownership.org/entities/59b9c52067e4ebf340ae4fe7"
+            }
+        ],
+        "foundingDate": "1997-05-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Openview House, Chesham Close, Romford, Essex, RM7 7PJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11778413202223133664",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7252303563156541964"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2864384025096860820"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2864384025096860820",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "OPENVIEW GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05114513"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05114513",
+                "uri": "https://opencorporates.com/companies/gb/05114513"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9529067e4ebf340cbbeae",
+                "uri": "http://register.openownership.org/entities/59b9529067e4ebf340cbbeae"
+            }
+        ],
+        "foundingDate": "2004-04-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Openview House, Chesham Close, Romford, RM7 7PJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03447054_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03447054_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-2610451556061771721", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CENTRAL MANAGEMENT CATALOGUE AGENCY (UK) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03447054"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03447054"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03447054", "uri": "https://opencorporates.com/companies/gb/03447054"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9305a67e4ebf340311189", "uri": "http://register.openownership.org/entities/59b9305a67e4ebf340311189"}], "foundingDate": "1997-10-09", "addresses": [{"type": "registered", "address": "Ross House, The Square, Stow On The Wold, Gloucestershire, GL54 1AF", "country": "GB"}]}, {"statementID": "openownership-register-4578222434247472279", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2610451556061771721"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16635427798723544678"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16635427798723544678", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Crawford"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09788093/persons-with-significant-control/individual/h67Vr0b0bP1pKIaotCqIidrQ5Iw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9490767e4ebf340a1d0b6", "uri": "http://register.openownership.org/entities/59b9490767e4ebf340a1d0b6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-08-01", "addresses": [{"address": "Murrells End Barn, Redmarley, Gloucestershire, GL19 3LR"}]}]
+[
+    {
+        "statementID": "openownership-register-2610451556061771721",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CENTRAL MANAGEMENT CATALOGUE AGENCY (UK) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03447054"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03447054"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03447054",
+                "uri": "https://opencorporates.com/companies/gb/03447054"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9305a67e4ebf340311189",
+                "uri": "http://register.openownership.org/entities/59b9305a67e4ebf340311189"
+            }
+        ],
+        "foundingDate": "1997-10-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ross House, The Square, Stow On The Wold, Gloucestershire, GL54 1AF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4578222434247472279",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2610451556061771721"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16635427798723544678"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16635427798723544678",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Crawford"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09788093/persons-with-significant-control/individual/h67Vr0b0bP1pKIaotCqIidrQ5Iw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9490767e4ebf340a1d0b6",
+                "uri": "http://register.openownership.org/entities/59b9490767e4ebf340a1d0b6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-08-01",
+        "addresses": [
+            {
+                "address": "Murrells End Barn, Redmarley, Gloucestershire, GL19 3LR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03548067_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03548067_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-2274101196731361995", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MILLSTREAM PENTHOUSE SYSTEMS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03548067"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03548067", "uri": "https://opencorporates.com/companies/gb/03548067"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5055867e4ebf34066f101", "uri": "http://register.openownership.org/entities/59c5055867e4ebf34066f101"}], "foundingDate": "1998-04-17", "addresses": [{"type": "registered", "address": "Unit 6 Beverley Trading Estate, 190 Garth Road, Morden, Surrey, SM4 4LU", "country": "GB"}]}, {"statementID": "openownership-register-1569901663720677010", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-05", "subject": {"describedByEntityStatement": "openownership-register-2274101196731361995"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-2274101196731361995",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MILLSTREAM PENTHOUSE SYSTEMS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03548067"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03548067",
+                "uri": "https://opencorporates.com/companies/gb/03548067"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5055867e4ebf34066f101",
+                "uri": "http://register.openownership.org/entities/59c5055867e4ebf34066f101"
+            }
+        ],
+        "foundingDate": "1998-04-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 6 Beverley Trading Estate, 190 Garth Road, Morden, Surrey, SM4 4LU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1569901663720677010",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2274101196731361995"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03638958_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03638958_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-1640776561283399699", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CARETECH UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03638958"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03638958", "uri": "https://opencorporates.com/companies/gb/03638958"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ef567e4ebf340bbfb36", "uri": "http://register.openownership.org/entities/59b94ef567e4ebf340bbfb36"}], "foundingDate": "1998-09-22", "addresses": [{"type": "registered", "address": "1386 London Road, Leigh On Sea, Essex, SS9 2UJ", "country": "GB"}]}, {"statementID": "openownership-register-6209263976525477150", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-1640776561283399699"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1499180722979564036"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-07-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1499180722979564036", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Antony Philip Mears"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04061627/persons-with-significant-control/individual/9oq7IdAFNbmhEWv69abyv_MJ7OM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ef467e4ebf340bbf392", "uri": "http://register.openownership.org/entities/59b94ef467e4ebf340bbf392"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-02-01", "addresses": [{"address": "1386 London Road, Leigh On Sea, Essex, SS9 2UJ"}]}]
+[
+    {
+        "statementID": "openownership-register-1640776561283399699",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CARETECH UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03638958"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03638958",
+                "uri": "https://opencorporates.com/companies/gb/03638958"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ef567e4ebf340bbfb36",
+                "uri": "http://register.openownership.org/entities/59b94ef567e4ebf340bbfb36"
+            }
+        ],
+        "foundingDate": "1998-09-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1386 London Road, Leigh On Sea, Essex, SS9 2UJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6209263976525477150",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1640776561283399699"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1499180722979564036"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1499180722979564036",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Antony Philip Mears"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04061627/persons-with-significant-control/individual/9oq7IdAFNbmhEWv69abyv_MJ7OM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ef467e4ebf340bbf392",
+                "uri": "http://register.openownership.org/entities/59b94ef467e4ebf340bbf392"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-02-01",
+        "addresses": [
+            {
+                "address": "1386 London Road, Leigh On Sea, Essex, SS9 2UJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03641345_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03641345_bods.json
@@ -1,1 +1,326 @@
-[{"statementID": "openownership-register-1955869517880905989", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PROGRESSIVE CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03641345"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03641345"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03641345", "uri": "https://opencorporates.com/companies/gb/03641345"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9bbb69dfc3fae1887c35b", "uri": "http://register.openownership.org/entities/5ab9bbb69dfc3fae1887c35b"}], "foundingDate": "1998-09-30", "addresses": [{"type": "registered", "address": "51 Attercliffe Common, Sheffield, S9 2AE", "country": "GB"}]}, {"statementID": "openownership-register-11811902949044071713", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1955869517880905989"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6533909013695848103"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-08-18"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-08-18"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2017-08-18"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3213735878325894300", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1955869517880905989"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15475482067022578647"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-10-02"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-8980309791504757866", "statementType": "ownershipOrControlStatement", "statementDate": "2017-08-18", "subject": {"describedByEntityStatement": "openownership-register-1955869517880905989"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14439750207829839814"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-08-18"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15475482067022578647", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Shabir Mohammad Ali"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03641345/persons-with-significant-control/individual/1BehmDHSjyxR9XLj6Jmg0GX530I"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba110a9dfc3fae18628abf", "uri": "http://register.openownership.org/entities/5aba110a9dfc3fae18628abf"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-03-01", "addresses": [{"address": "51, Attercliffe Common, Sheffield, S9 2AE"}]}, {"statementID": "openownership-register-14439750207829839814", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PROGRESSIVE CARE UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05878916", "uri": "https://opencorporates.com/companies/gb/05878916"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05878916"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9db4367e4ebf340ff02bd", "uri": "http://register.openownership.org/entities/59b9db4367e4ebf340ff02bd"}], "foundingDate": "2006-07-17", "addresses": [{"type": "registered", "address": "51 Attercliffe Common, Sheffield, S9 2AE", "country": "GB"}]}, {"statementID": "openownership-register-6533909013695848103", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PROGRESSIVE CARE (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06401090"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06401090", "uri": "https://opencorporates.com/companies/gb/06401090"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab94d659dfc3fae18799961", "uri": "http://register.openownership.org/entities/5ab94d659dfc3fae18799961"}], "foundingDate": "2007-10-16", "addresses": [{"type": "registered", "address": "51 Attercliffe Common, Sheffield, South Yorkshire, S9 2AE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1955869517880905989",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PROGRESSIVE CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03641345"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03641345"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03641345",
+                "uri": "https://opencorporates.com/companies/gb/03641345"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9bbb69dfc3fae1887c35b",
+                "uri": "http://register.openownership.org/entities/5ab9bbb69dfc3fae1887c35b"
+            }
+        ],
+        "foundingDate": "1998-09-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "51 Attercliffe Common, Sheffield, S9 2AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11811902949044071713",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1955869517880905989"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6533909013695848103"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-08-18"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-08-18"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2017-08-18"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3213735878325894300",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1955869517880905989"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15475482067022578647"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-10-02"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8980309791504757866",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-08-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1955869517880905989"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14439750207829839814"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-08-18"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15475482067022578647",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Shabir Mohammad Ali"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03641345/persons-with-significant-control/individual/1BehmDHSjyxR9XLj6Jmg0GX530I"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba110a9dfc3fae18628abf",
+                "uri": "http://register.openownership.org/entities/5aba110a9dfc3fae18628abf"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-03-01",
+        "addresses": [
+            {
+                "address": "51, Attercliffe Common, Sheffield, S9 2AE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14439750207829839814",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PROGRESSIVE CARE UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05878916",
+                "uri": "https://opencorporates.com/companies/gb/05878916"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05878916"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9db4367e4ebf340ff02bd",
+                "uri": "http://register.openownership.org/entities/59b9db4367e4ebf340ff02bd"
+            }
+        ],
+        "foundingDate": "2006-07-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "51 Attercliffe Common, Sheffield, S9 2AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6533909013695848103",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PROGRESSIVE CARE (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06401090"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06401090",
+                "uri": "https://opencorporates.com/companies/gb/06401090"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab94d659dfc3fae18799961",
+                "uri": "http://register.openownership.org/entities/5ab94d659dfc3fae18799961"
+            }
+        ],
+        "foundingDate": "2007-10-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "51 Attercliffe Common, Sheffield, South Yorkshire, S9 2AE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03659610_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03659610_bods.json
@@ -1,1 +1,135 @@
-[{"statementID": "openownership-register-4581269409314436596", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLEARWATER TECHNOLOGY LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659610"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659610"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03659610", "uri": "https://opencorporates.com/companies/gb/03659610"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9312567e4ebf340337ed6", "uri": "http://register.openownership.org/entities/59b9312567e4ebf340337ed6"}], "foundingDate": "1998-10-30", "addresses": [{"type": "registered", "address": "20 Grosvenor Place, London, SW1X 7HN", "country": "GB"}]}, {"statementID": "openownership-register-9025129037065950981", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4581269409314436596"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2415162765912871713"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2415162765912871713", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CLEARWATER GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02494701"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02494701"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02494701"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02494701", "uri": "https://opencorporates.com/companies/gb/02494701"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9579867e4ebf340e38eea", "uri": "http://register.openownership.org/entities/59b9579867e4ebf340e38eea"}], "foundingDate": "1990-04-23", "addresses": [{"type": "registered", "address": "20 Grosvenor Place, London, SW1X 7HN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4581269409314436596",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLEARWATER TECHNOLOGY LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659610"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659610"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03659610",
+                "uri": "https://opencorporates.com/companies/gb/03659610"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9312567e4ebf340337ed6",
+                "uri": "http://register.openownership.org/entities/59b9312567e4ebf340337ed6"
+            }
+        ],
+        "foundingDate": "1998-10-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20 Grosvenor Place, London, SW1X 7HN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9025129037065950981",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4581269409314436596"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2415162765912871713"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2415162765912871713",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CLEARWATER GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02494701"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02494701"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02494701"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02494701",
+                "uri": "https://opencorporates.com/companies/gb/02494701"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9579867e4ebf340e38eea",
+                "uri": "http://register.openownership.org/entities/59b9579867e4ebf340e38eea"
+            }
+        ],
+        "foundingDate": "1990-04-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20 Grosvenor Place, London, SW1X 7HN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03659970_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03659970_bods.json
@@ -1,1 +1,129 @@
-[{"statementID": "openownership-register-8783580056872101466", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RAMBOLL UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659970"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659970"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659970"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03659970", "uri": "https://opencorporates.com/companies/gb/03659970"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03659970"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95b1067e4ebf340f33cc7", "uri": "http://register.openownership.org/entities/59b95b1067e4ebf340f33cc7"}], "foundingDate": "1998-11-02", "addresses": [{"type": "registered", "address": "240 Blackfriars Road, London, SE1 8NW", "country": "GB"}]}, {"statementID": "openownership-register-10593639738840845611", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8783580056872101466"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2838465755418390690"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2838465755418390690", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RAMBOLL UK HOLDING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06322436"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06322436"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06322436"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06322436", "uri": "https://opencorporates.com/companies/gb/06322436"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94a3d67e4ebf340a77409", "uri": "http://register.openownership.org/entities/59b94a3d67e4ebf340a77409"}], "foundingDate": "2007-07-24", "addresses": [{"type": "registered", "address": "240 Blackfriars Road, London, SE1 8NW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8783580056872101466",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RAMBOLL UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659970"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659970"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659970"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03659970",
+                "uri": "https://opencorporates.com/companies/gb/03659970"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03659970"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95b1067e4ebf340f33cc7",
+                "uri": "http://register.openownership.org/entities/59b95b1067e4ebf340f33cc7"
+            }
+        ],
+        "foundingDate": "1998-11-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "240 Blackfriars Road, London, SE1 8NW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10593639738840845611",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8783580056872101466"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2838465755418390690"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2838465755418390690",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RAMBOLL UK HOLDING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06322436"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06322436"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06322436"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06322436",
+                "uri": "https://opencorporates.com/companies/gb/06322436"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94a3d67e4ebf340a77409",
+                "uri": "http://register.openownership.org/entities/59b94a3d67e4ebf340a77409"
+            }
+        ],
+        "foundingDate": "2007-07-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "240 Blackfriars Road, London, SE1 8NW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03665035_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03665035_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-13815645958652370245", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FENTEX LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03665035"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03665035", "uri": "https://opencorporates.com/companies/gb/03665035"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4fa9567e4ebf340509335", "uri": "http://register.openownership.org/entities/59c4fa9567e4ebf340509335"}], "foundingDate": "1998-11-10", "addresses": [{"type": "registered", "address": "Fentex Ltd Station Road, Warboys, Huntingdon, Cambridgeshire, PE28 2TH", "country": "GB"}]}, {"statementID": "openownership-register-4142841655720034577", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-10", "subject": {"describedByEntityStatement": "openownership-register-13815645958652370245"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-13815645958652370245",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FENTEX LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03665035"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03665035",
+                "uri": "https://opencorporates.com/companies/gb/03665035"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4fa9567e4ebf340509335",
+                "uri": "http://register.openownership.org/entities/59c4fa9567e4ebf340509335"
+            }
+        ],
+        "foundingDate": "1998-11-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Fentex Ltd Station Road, Warboys, Huntingdon, Cambridgeshire, PE28 2TH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4142841655720034577",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13815645958652370245"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03752300_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03752300_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-14949840820258348193", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MAXIMUS PEOPLE SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03752300"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03752300", "uri": "https://opencorporates.com/companies/gb/03752300"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b24867e4ebf340651564", "uri": "http://register.openownership.org/entities/59b9b24867e4ebf340651564"}], "foundingDate": "1999-04-14", "addresses": [{"type": "registered", "address": "18c Meridian Business Park Meridian East, Meridian Business Park, Leicester, LE19 1WZ", "country": "GB"}]}, {"statementID": "openownership-register-12359685648747064402", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14949840820258348193"}, "interestedParty": {"describedByEntityStatement": "openownership-register-697313330144885604"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-697313330144885604", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MAXIMUS HHS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06588344", "uri": "https://opencorporates.com/companies/gb/06588344"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e", "uri": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e"}], "foundingDate": "2008-05-08", "addresses": [{"type": "registered", "address": "18c Meridian East, Meridian Business Park, Leicester, LE19 1WZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14949840820258348193",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MAXIMUS PEOPLE SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03752300"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03752300",
+                "uri": "https://opencorporates.com/companies/gb/03752300"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b24867e4ebf340651564",
+                "uri": "http://register.openownership.org/entities/59b9b24867e4ebf340651564"
+            }
+        ],
+        "foundingDate": "1999-04-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "18c Meridian Business Park Meridian East, Meridian Business Park, Leicester, LE19 1WZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12359685648747064402",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14949840820258348193"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-697313330144885604"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-697313330144885604",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MAXIMUS HHS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06588344",
+                "uri": "https://opencorporates.com/companies/gb/06588344"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e",
+                "uri": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e"
+            }
+        ],
+        "foundingDate": "2008-05-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "18c Meridian East, Meridian Business Park, Leicester, LE19 1WZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03790634_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03790634_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-11020806590781128723", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COWENS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03790634"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03790634", "uri": "https://opencorporates.com/companies/gb/03790634"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c51", "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c51"}], "foundingDate": "1999-06-16", "addresses": [{"type": "registered", "address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ", "country": "GB"}]}, {"statementID": "openownership-register-9568121889798116605", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11020806590781128723"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16557042314540925832"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13333234680025411969", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11020806590781128723"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11865263739469491696"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16557042314540925832", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrea Gail Coulthard"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03790634/persons-with-significant-control/individual/QHrVzuL4kwozIpQSMoNp3AQDcGY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c79", "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c79"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-08-01", "addresses": [{"address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ"}]}, {"statementID": "openownership-register-11865263739469491696", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jonathan Robert Coulthard"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03790634/persons-with-significant-control/individual/laJTk0BJZg1j-4dEo--tglkfSJ8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c65", "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c65"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-09-01", "addresses": [{"address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ"}]}]
+[
+    {
+        "statementID": "openownership-register-11020806590781128723",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COWENS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03790634"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03790634",
+                "uri": "https://opencorporates.com/companies/gb/03790634"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c51",
+                "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c51"
+            }
+        ],
+        "foundingDate": "1999-06-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9568121889798116605",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11020806590781128723"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16557042314540925832"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13333234680025411969",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11020806590781128723"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11865263739469491696"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16557042314540925832",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrea Gail Coulthard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03790634/persons-with-significant-control/individual/QHrVzuL4kwozIpQSMoNp3AQDcGY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c79",
+                "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c79"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-08-01",
+        "addresses": [
+            {
+                "address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11865263739469491696",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jonathan Robert Coulthard"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03790634/persons-with-significant-control/individual/laJTk0BJZg1j-4dEo--tglkfSJ8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c65",
+                "uri": "http://register.openownership.org/entities/59b9c93167e4ebf340bc6c65"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-09-01",
+        "addresses": [
+            {
+                "address": "Ellers Mill, Dalston, Carlisle, Cumbria, CA5 7QJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03805449_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03805449_bods.json
@@ -1,1 +1,193 @@
-[{"statementID": "openownership-register-5508083453530794649", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LANDSCAPE PROJECTS LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03805449"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03805449", "uri": "https://opencorporates.com/companies/gb/03805449"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e33f5", "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e33f5"}], "foundingDate": "1999-07-12", "addresses": [{"type": "registered", "address": "48 - 52, Penny Lane Mossley Hill, Liverpool, L18 1DG", "country": "GB"}]}, {"statementID": "openownership-register-6709709270116634913", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5508083453530794649"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9774051022688656914"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3346740601250868361", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5508083453530794649"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17879565272170350253"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9774051022688656914", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Neil Swanson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03805449/persons-with-significant-control/individual/hzbYuyZpWwbtJ54ODt1lDovTn1E"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e3406", "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e3406"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-06-01", "addresses": [{"address": "50, Beaconsfield Road, Woolton, Liverpool, Merseyside, L25 6EL", "country": "GB"}]}, {"statementID": "openownership-register-17879565272170350253", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Lynne Swanson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03805449/persons-with-significant-control/individual/noOg6HzMpf_oDywXZzDcSMrnYQM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e340e", "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e340e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-03-01", "addresses": [{"address": "50, Beaconsfield Road, Woolton, Liverpool, Merseyside, L25 6EL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5508083453530794649",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LANDSCAPE PROJECTS LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03805449"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03805449",
+                "uri": "https://opencorporates.com/companies/gb/03805449"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e33f5",
+                "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e33f5"
+            }
+        ],
+        "foundingDate": "1999-07-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "48 - 52, Penny Lane Mossley Hill, Liverpool, L18 1DG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6709709270116634913",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5508083453530794649"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9774051022688656914"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3346740601250868361",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5508083453530794649"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17879565272170350253"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9774051022688656914",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Neil Swanson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03805449/persons-with-significant-control/individual/hzbYuyZpWwbtJ54ODt1lDovTn1E"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e3406",
+                "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e3406"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-06-01",
+        "addresses": [
+            {
+                "address": "50, Beaconsfield Road, Woolton, Liverpool, Merseyside, L25 6EL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17879565272170350253",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Lynne Swanson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03805449/persons-with-significant-control/individual/noOg6HzMpf_oDywXZzDcSMrnYQM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9295767e4ebf3400e340e",
+                "uri": "http://register.openownership.org/entities/59b9295767e4ebf3400e340e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-03-01",
+        "addresses": [
+            {
+                "address": "50, Beaconsfield Road, Woolton, Liverpool, Merseyside, L25 6EL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03885095_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03885095_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-16353519166223267700", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SOUTHERN FIRE ALARMS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03885095"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03885095", "uri": "https://opencorporates.com/companies/gb/03885095"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6aa5", "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6aa5"}], "foundingDate": "1999-11-29", "addresses": [{"type": "registered", "address": "4 Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX", "country": "GB"}]}, {"statementID": "openownership-register-13351048825999701987", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16353519166223267700"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3363748658549975225"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15515233463795394968", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16353519166223267700"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10282072094599797264"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3363748658549975225", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Graham John Reynolds"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03885095/persons-with-significant-control/individual/Yy7GUV0CyhhgxOKd_Fwm3gRlMIs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ab8", "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ab8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1947-06-01", "addresses": [{"address": "4, Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX"}]}, {"statementID": "openownership-register-10282072094599797264", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Oliver Reynolds"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03885095/persons-with-significant-control/individual/tWOzZImSwCrD8aD5zntJHhbKDNw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ac0", "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ac0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1977-02-01", "addresses": [{"address": "4, Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX"}]}]
+[
+    {
+        "statementID": "openownership-register-16353519166223267700",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SOUTHERN FIRE ALARMS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03885095"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03885095",
+                "uri": "https://opencorporates.com/companies/gb/03885095"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6aa5",
+                "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6aa5"
+            }
+        ],
+        "foundingDate": "1999-11-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4 Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13351048825999701987",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16353519166223267700"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3363748658549975225"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15515233463795394968",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16353519166223267700"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10282072094599797264"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3363748658549975225",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Graham John Reynolds"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03885095/persons-with-significant-control/individual/Yy7GUV0CyhhgxOKd_Fwm3gRlMIs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ab8",
+                "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ab8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1947-06-01",
+        "addresses": [
+            {
+                "address": "4, Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10282072094599797264",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Oliver Reynolds"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03885095/persons-with-significant-control/individual/tWOzZImSwCrD8aD5zntJHhbKDNw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ac0",
+                "uri": "http://register.openownership.org/entities/59b96a3767e4ebf3403c6ac0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1977-02-01",
+        "addresses": [
+            {
+                "address": "4, Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03908728_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03908728_bods.json
@@ -1,1 +1,237 @@
-[{"statementID": "openownership-register-10905979071518055980", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "T.S.G. BUILDING SERVICES PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03908728"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03908728", "uri": "https://opencorporates.com/companies/gb/03908728"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d100", "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d100"}], "foundingDate": "2000-01-18", "addresses": [{"type": "registered", "address": "Tsg House Cranborne Industrial Estate, Cranborne Road, Potters Bar, Hertfordshire, EN6 3JN", "country": "GB"}]}, {"statementID": "openownership-register-4332605181481554552", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10905979071518055980"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3531146079689556705"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-11275552375144783340", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10905979071518055980"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1114762923354323553"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-05-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14573449135538614451", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-10905979071518055980"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11847197896591694688"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-05-08"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1114762923354323553", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Benjamin Peter Thrussell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03908728/persons-with-significant-control/individual/fQB79aBnwhtR3n1CWj1lkGggIFs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d15a", "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d15a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-03-01", "addresses": [{"address": "11, Great North Road, Brookmans Park, Hatfield, Hertfordshire, AL9 6LB"}]}, {"statementID": "openownership-register-11847197896591694688", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Caroline Anne Thrussell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03908728/persons-with-significant-control/individual/rTB1aiSPKtFERoNveESzq5FBM0w"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d106", "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d106"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-06-01", "addresses": [{"address": "110, Brookmans Avenue, Brookmans Park, Hatfield, Hertfordshire, AL9 7QQ"}]}, {"statementID": "openownership-register-3531146079689556705", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Adam James Thrussell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09727451/persons-with-significant-control/individual/x6u_K9tr3cn8NOzo8ND14TUnOck"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b933da67e4ebf340414770", "uri": "http://register.openownership.org/entities/59b933da67e4ebf340414770"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1979-01-01", "addresses": [{"address": "Tsg House, Cranborne Industrial Estate, Cranborne Road, Potters Bar, Hertfordshire, EN6 3JN"}]}]
+[
+    {
+        "statementID": "openownership-register-10905979071518055980",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "T.S.G. BUILDING SERVICES PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03908728"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03908728",
+                "uri": "https://opencorporates.com/companies/gb/03908728"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d100",
+                "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d100"
+            }
+        ],
+        "foundingDate": "2000-01-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Tsg House Cranborne Industrial Estate, Cranborne Road, Potters Bar, Hertfordshire, EN6 3JN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4332605181481554552",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10905979071518055980"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3531146079689556705"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11275552375144783340",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10905979071518055980"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1114762923354323553"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-05-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14573449135538614451",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10905979071518055980"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11847197896591694688"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-05-08"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1114762923354323553",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Benjamin Peter Thrussell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03908728/persons-with-significant-control/individual/fQB79aBnwhtR3n1CWj1lkGggIFs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d15a",
+                "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d15a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-03-01",
+        "addresses": [
+            {
+                "address": "11, Great North Road, Brookmans Park, Hatfield, Hertfordshire, AL9 6LB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11847197896591694688",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Caroline Anne Thrussell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03908728/persons-with-significant-control/individual/rTB1aiSPKtFERoNveESzq5FBM0w"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97b6167e4ebf34091d106",
+                "uri": "http://register.openownership.org/entities/59b97b6167e4ebf34091d106"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-06-01",
+        "addresses": [
+            {
+                "address": "110, Brookmans Avenue, Brookmans Park, Hatfield, Hertfordshire, AL9 7QQ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3531146079689556705",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Adam James Thrussell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09727451/persons-with-significant-control/individual/x6u_K9tr3cn8NOzo8ND14TUnOck"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b933da67e4ebf340414770",
+                "uri": "http://register.openownership.org/entities/59b933da67e4ebf340414770"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1979-01-01",
+        "addresses": [
+            {
+                "address": "Tsg House, Cranborne Industrial Estate, Cranborne Road, Potters Bar, Hertfordshire, EN6 3JN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03942925_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03942925_bods.json
@@ -1,1 +1,102 @@
-[{"statementID": "openownership-register-8243492848679759113", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BIG CREATIVE TRAINING LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03942925"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03942925"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03942925", "uri": "https://opencorporates.com/companies/gb/03942925"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99e3867e4ebf3401a3617", "uri": "http://register.openownership.org/entities/59b99e3867e4ebf3401a3617"}], "foundingDate": "2000-03-08", "addresses": [{"type": "registered", "address": "Big Creative Training Uplands House, Uplands Business Park C, Blackhorse Lane, London, E17 5QJ", "country": "GB"}]}, {"statementID": "openownership-register-230276596822173977", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8243492848679759113"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4947339341046960087"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4947339341046960087", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alexis Sam Michaelides"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03942925/persons-with-significant-control/individual/gqACRnEtN1Ot3NEhlbTd-x-V2Fs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99e3867e4ebf3401a362e", "uri": "http://register.openownership.org/entities/59b99e3867e4ebf3401a362e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-08-01", "addresses": [{"address": "Big Creative Training, Uplands Business Park C, Blackhorse Lane, London, E17 5QJ"}]}]
+[
+    {
+        "statementID": "openownership-register-8243492848679759113",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BIG CREATIVE TRAINING LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03942925"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03942925"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03942925",
+                "uri": "https://opencorporates.com/companies/gb/03942925"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99e3867e4ebf3401a3617",
+                "uri": "http://register.openownership.org/entities/59b99e3867e4ebf3401a3617"
+            }
+        ],
+        "foundingDate": "2000-03-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Big Creative Training Uplands House, Uplands Business Park C, Blackhorse Lane, London, E17 5QJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-230276596822173977",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8243492848679759113"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4947339341046960087"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4947339341046960087",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alexis Sam Michaelides"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03942925/persons-with-significant-control/individual/gqACRnEtN1Ot3NEhlbTd-x-V2Fs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99e3867e4ebf3401a362e",
+                "uri": "http://register.openownership.org/entities/59b99e3867e4ebf3401a362e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-08-01",
+        "addresses": [
+            {
+                "address": "Big Creative Training, Uplands Business Park C, Blackhorse Lane, London, E17 5QJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03975999_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_03975999_bods.json
@@ -1,1 +1,210 @@
-[{"statementID": "openownership-register-9245710072899034814", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CAVENDISH NUCLEAR LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03975999"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03975999", "uri": "https://opencorporates.com/companies/gb/03975999"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9a4aa9dfc3fae184d861c", "uri": "http://register.openownership.org/entities/5ab9a4aa9dfc3fae184d861c"}], "foundingDate": "2000-04-18", "addresses": [{"type": "registered", "address": "33 Wigmore Street, London, W1U 1QX", "country": "GB"}]}, {"statementID": "openownership-register-17988293771024258448", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9245710072899034814"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1904046917508252260"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1904046917508252260", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BABCOCK SERVICES GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03939840"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03939840", "uri": "https://opencorporates.com/companies/gb/03939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3939840"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95d3e67e4ebf340fe1cc0", "uri": "http://register.openownership.org/entities/59b95d3e67e4ebf340fe1cc0"}], "foundingDate": "2000-03-06", "addresses": [{"type": "registered", "address": "33 Wigmore Street, London, W1U 1QX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9245710072899034814",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CAVENDISH NUCLEAR LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03975999"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03975999",
+                "uri": "https://opencorporates.com/companies/gb/03975999"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9a4aa9dfc3fae184d861c",
+                "uri": "http://register.openownership.org/entities/5ab9a4aa9dfc3fae184d861c"
+            }
+        ],
+        "foundingDate": "2000-04-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33 Wigmore Street, London, W1U 1QX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17988293771024258448",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9245710072899034814"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1904046917508252260"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1904046917508252260",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BABCOCK SERVICES GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03939840"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03939840",
+                "uri": "https://opencorporates.com/companies/gb/03939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3939840"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95d3e67e4ebf340fe1cc0",
+                "uri": "http://register.openownership.org/entities/59b95d3e67e4ebf340fe1cc0"
+            }
+        ],
+        "foundingDate": "2000-03-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33 Wigmore Street, London, W1U 1QX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04021353_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04021353_bods.json
@@ -1,1 +1,70 @@
-[{"statementID": "openownership-register-2924847232968682077", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DAY CUMMINS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04021353"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04021353"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04021353", "uri": "https://opencorporates.com/companies/gb/04021353"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4021353"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94a1c67e4ebf340a6f157", "uri": "http://register.openownership.org/entities/59b94a1c67e4ebf340a6f157"}], "foundingDate": "2000-06-26", "addresses": [{"type": "registered", "address": "Unit 4a, Lakeland Business Park,, Lamplugh Road Cockermouth, Cumbria, CA13 0QT", "country": "GB"}]}, {"statementID": "openownership-register-9149977335444141623", "statementType": "ownershipOrControlStatement", "statementDate": "2017-06-07", "subject": {"describedByEntityStatement": "openownership-register-2924847232968682077"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-2924847232968682077",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DAY CUMMINS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04021353"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04021353"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04021353",
+                "uri": "https://opencorporates.com/companies/gb/04021353"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4021353"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94a1c67e4ebf340a6f157",
+                "uri": "http://register.openownership.org/entities/59b94a1c67e4ebf340a6f157"
+            }
+        ],
+        "foundingDate": "2000-06-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 4a, Lakeland Business Park,, Lamplugh Road Cockermouth, Cumbria, CA13 0QT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9149977335444141623",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-06-07",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2924847232968682077"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04021960_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04021960_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-16288052506054013675", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CALDERDALE SEWER SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04021960"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04021960", "uri": "https://opencorporates.com/companies/gb/04021960"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaec", "uri": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaec"}], "foundingDate": "2000-06-27", "addresses": [{"type": "registered", "address": "Unit 7, Emstead Works Old Lane, Ovenden Halifax, West Yorkshire, HX3 5QN", "country": "GB"}]}, {"statementID": "openownership-register-14662511054954924459", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-06", "subject": {"describedByEntityStatement": "openownership-register-16288052506054013675"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11185887498820912747"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11185887498820912747", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Craig Shaw"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04021960/persons-with-significant-control/individual/Famh2j2uVkO7WsxaTMTp6nAcZCQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaf5", "uri": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaf5"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-11-01", "addresses": [{"address": "Unit 7, Emstead Works Old Lane, Ovenden Halifax, West Yorkshire, HX3 5QN"}]}]
+[
+    {
+        "statementID": "openownership-register-16288052506054013675",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CALDERDALE SEWER SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04021960"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04021960",
+                "uri": "https://opencorporates.com/companies/gb/04021960"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaec",
+                "uri": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaec"
+            }
+        ],
+        "foundingDate": "2000-06-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 7, Emstead Works Old Lane, Ovenden Halifax, West Yorkshire, HX3 5QN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14662511054954924459",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16288052506054013675"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11185887498820912747"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11185887498820912747",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Craig Shaw"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04021960/persons-with-significant-control/individual/Famh2j2uVkO7WsxaTMTp6nAcZCQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaf5",
+                "uri": "http://register.openownership.org/entities/59b9d64267e4ebf340ecbaf5"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "Unit 7, Emstead Works Old Lane, Ovenden Halifax, West Yorkshire, HX3 5QN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04026569_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04026569_bods.json
@@ -1,1 +1,164 @@
-[{"statementID": "openownership-register-7499487245147669453", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TARMAC BUILDING PRODUCTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04026569"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04026569", "uri": "https://opencorporates.com/companies/gb/04026569"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba749a9dfc3fae18fcd0f7", "uri": "http://register.openownership.org/entities/5aba749a9dfc3fae18fcd0f7"}], "foundingDate": "2000-07-04", "addresses": [{"type": "registered", "address": "Interchange 10 Railway Drive, Wolverhampton, WV1 1LH", "country": "GB"}]}, {"statementID": "openownership-register-14726354412921217029", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7499487245147669453"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4344339031287253246"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4344339031287253246", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TARMAC HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07533961"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07533961", "uri": "https://opencorporates.com/companies/gb/07533961"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb", "uri": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb"}], "foundingDate": "2011-02-17", "addresses": [{"type": "registered", "address": "Portland House, Bickenhill Lane, Solihull, Birmingham, B37 7BQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7499487245147669453",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TARMAC BUILDING PRODUCTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04026569"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04026569",
+                "uri": "https://opencorporates.com/companies/gb/04026569"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba749a9dfc3fae18fcd0f7",
+                "uri": "http://register.openownership.org/entities/5aba749a9dfc3fae18fcd0f7"
+            }
+        ],
+        "foundingDate": "2000-07-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Interchange 10 Railway Drive, Wolverhampton, WV1 1LH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14726354412921217029",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7499487245147669453"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4344339031287253246"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4344339031287253246",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TARMAC HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07533961"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07533961",
+                "uri": "https://opencorporates.com/companies/gb/07533961"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb",
+                "uri": "http://register.openownership.org/entities/59b9632767e4ebf34019c6bb"
+            }
+        ],
+        "foundingDate": "2011-02-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Portland House, Bickenhill Lane, Solihull, Birmingham, B37 7BQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04050190_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04050190_bods.json
@@ -1,1 +1,154 @@
-[{"statementID": "openownership-register-2805858492117957952", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VITAL ENERGI UTILITIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04050190"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04050190", "uri": "https://opencorporates.com/companies/gb/04050190"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04050190"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9305867e4ebf3403101d0", "uri": "http://register.openownership.org/entities/59b9305867e4ebf3403101d0"}], "foundingDate": "2000-08-09", "addresses": [{"type": "registered", "address": "Century House, Roman Road, Blackburn, Lancashire, BB1 2LD", "country": "GB"}]}, {"statementID": "openownership-register-5331302465631596978", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2805858492117957952"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7169844254993810014"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7169844254993810014", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VITAL HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06395526"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06395526", "uri": "https://opencorporates.com/companies/gb/06395526"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9305867e4ebf340310664", "uri": "http://register.openownership.org/entities/59b9305867e4ebf340310664"}], "foundingDate": "2007-10-10", "addresses": [{"type": "registered", "address": "Century House, Roman Road, Blackburn, Lancashire, BB1 2LD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2805858492117957952",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VITAL ENERGI UTILITIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04050190"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04050190",
+                "uri": "https://opencorporates.com/companies/gb/04050190"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04050190"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9305867e4ebf3403101d0",
+                "uri": "http://register.openownership.org/entities/59b9305867e4ebf3403101d0"
+            }
+        ],
+        "foundingDate": "2000-08-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Century House, Roman Road, Blackburn, Lancashire, BB1 2LD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5331302465631596978",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2805858492117957952"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7169844254993810014"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7169844254993810014",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VITAL HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06395526"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06395526",
+                "uri": "https://opencorporates.com/companies/gb/06395526"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9305867e4ebf340310664",
+                "uri": "http://register.openownership.org/entities/59b9305867e4ebf340310664"
+            }
+        ],
+        "foundingDate": "2007-10-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Century House, Roman Road, Blackburn, Lancashire, BB1 2LD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04085767_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04085767_bods.json
@@ -1,1 +1,165 @@
-[{"statementID": "openownership-register-5669514348931504728", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COMENSURA LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04085767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04085767"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04085767", "uri": "https://opencorporates.com/companies/gb/04085767"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4085767"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94afd67e4ebf340a9d2c7", "uri": "http://register.openownership.org/entities/59b94afd67e4ebf340a9d2c7"}], "foundingDate": "2000-10-09", "addresses": [{"type": "registered", "address": "800 The Boulevard, Capability Green, Luton, Bedfordshire, LU1 3BA", "country": "GB"}]}, {"statementID": "openownership-register-2114679396020570071", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5669514348931504728"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9357185206627844111"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9357185206627844111", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "IMPELLAM HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00490212", "uri": "https://opencorporates.com/companies/gb/00490212"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00490212"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93ee967e4ebf340745c33", "uri": "http://register.openownership.org/entities/59b93ee967e4ebf340745c33"}], "foundingDate": "1951-01-05", "addresses": [{"type": "registered", "address": "800 The Boulevard, Capability Green, Luton, Bedfordshire, LU1 3BA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5669514348931504728",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COMENSURA LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04085767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04085767"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04085767",
+                "uri": "https://opencorporates.com/companies/gb/04085767"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4085767"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94afd67e4ebf340a9d2c7",
+                "uri": "http://register.openownership.org/entities/59b94afd67e4ebf340a9d2c7"
+            }
+        ],
+        "foundingDate": "2000-10-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "800 The Boulevard, Capability Green, Luton, Bedfordshire, LU1 3BA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2114679396020570071",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5669514348931504728"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9357185206627844111"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9357185206627844111",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "IMPELLAM HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00490212",
+                "uri": "https://opencorporates.com/companies/gb/00490212"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00490212"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93ee967e4ebf340745c33",
+                "uri": "http://register.openownership.org/entities/59b93ee967e4ebf340745c33"
+            }
+        ],
+        "foundingDate": "1951-01-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "800 The Boulevard, Capability Green, Luton, Bedfordshire, LU1 3BA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04109393_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04109393_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-1105541806213951116", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HANDICARE ACCESSIBILITY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04109393"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04109393", "uri": "https://opencorporates.com/companies/gb/04109393"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4109393"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95ff967e4ebf3400a9729", "uri": "http://register.openownership.org/entities/59b95ff967e4ebf3400a9729"}], "foundingDate": "2000-11-16", "addresses": [{"type": "registered", "address": "82 First Avenue, Pensnett Estate, Kingswinford, West Midlands, DY6 7FJ", "country": "GB"}]}, {"statementID": "openownership-register-3217872563502517023", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1105541806213951116"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15294557494787105821"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15294557494787105821", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MINIVATOR GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05194271"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05194271"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05194271", "uri": "https://opencorporates.com/companies/gb/05194271"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5194271"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95ffa67e4ebf3400a9b15", "uri": "http://register.openownership.org/entities/59b95ffa67e4ebf3400a9b15"}], "foundingDate": "2004-07-30", "addresses": [{"type": "registered", "address": "82 First Avenue, Pensnett Trading Estate, Kingswinford, West Midlands, DY6 7FJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1105541806213951116",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HANDICARE ACCESSIBILITY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04109393"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04109393",
+                "uri": "https://opencorporates.com/companies/gb/04109393"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4109393"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95ff967e4ebf3400a9729",
+                "uri": "http://register.openownership.org/entities/59b95ff967e4ebf3400a9729"
+            }
+        ],
+        "foundingDate": "2000-11-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "82 First Avenue, Pensnett Estate, Kingswinford, West Midlands, DY6 7FJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3217872563502517023",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1105541806213951116"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15294557494787105821"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15294557494787105821",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MINIVATOR GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05194271"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05194271"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05194271",
+                "uri": "https://opencorporates.com/companies/gb/05194271"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5194271"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95ffa67e4ebf3400a9b15",
+                "uri": "http://register.openownership.org/entities/59b95ffa67e4ebf3400a9b15"
+            }
+        ],
+        "foundingDate": "2004-07-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "82 First Avenue, Pensnett Trading Estate, Kingswinford, West Midlands, DY6 7FJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04126127_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04126127_bods.json
@@ -1,1 +1,343 @@
-[{"statementID": "openownership-register-8283328982740122423", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LIFEWAYS COMMUNITY CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04126127"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04126127"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04126127", "uri": "https://opencorporates.com/companies/gb/04126127"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b939ac67e4ebf3405c2244", "uri": "http://register.openownership.org/entities/59b939ac67e4ebf3405c2244"}], "foundingDate": "2000-12-15", "addresses": [{"type": "registered", "address": "56 Southwark Bridge Road, London, SE1 0AS", "country": "GB"}]}, {"statementID": "openownership-register-6326920737012382382", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-15", "subject": {"describedByEntityStatement": "openownership-register-8283328982740122423"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17709164874164273333"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-15"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-15"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17709164874164273333", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LIFEWAYS FINANCE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06295365"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06295365", "uri": "https://opencorporates.com/companies/gb/06295365"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9274167e4ebf3400545bd", "uri": "http://register.openownership.org/entities/59b9274167e4ebf3400545bd"}], "foundingDate": "2007-06-27", "addresses": [{"type": "registered", "address": "56 Southwark Bridge Road, London, SE1 0AS", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8283328982740122423",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LIFEWAYS COMMUNITY CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04126127"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04126127"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04126127",
+                "uri": "https://opencorporates.com/companies/gb/04126127"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b939ac67e4ebf3405c2244",
+                "uri": "http://register.openownership.org/entities/59b939ac67e4ebf3405c2244"
+            }
+        ],
+        "foundingDate": "2000-12-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "56 Southwark Bridge Road, London, SE1 0AS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6326920737012382382",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-15",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8283328982740122423"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17709164874164273333"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-15"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-15"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17709164874164273333",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LIFEWAYS FINANCE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06295365"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06295365",
+                "uri": "https://opencorporates.com/companies/gb/06295365"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9274167e4ebf3400545bd",
+                "uri": "http://register.openownership.org/entities/59b9274167e4ebf3400545bd"
+            }
+        ],
+        "foundingDate": "2007-06-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "56 Southwark Bridge Road, London, SE1 0AS",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04157398_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04157398_bods.json
@@ -1,1 +1,157 @@
-[{"statementID": "openownership-register-16165421124416399532", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FAROL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04157398"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04157398", "uri": "https://opencorporates.com/companies/gb/04157398"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e68", "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e68"}], "foundingDate": "2001-02-09", "addresses": [{"type": "registered", "address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ", "country": "GB"}]}, {"statementID": "openownership-register-13241226181961983094", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16165421124416399532"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10458614285407401595"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13155832261867414961", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16165421124416399532"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3193760967479771778"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10458614285407401595", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Benjamin Thomas Vellacott"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04157398/persons-with-significant-control/individual/R5aILlJMxyOp4Vsz8zRDnpthNPQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e74", "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e74"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-04-01", "addresses": [{"address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ"}]}, {"statementID": "openownership-register-3193760967479771778", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Matthew Edward Vellacott"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04157398/persons-with-significant-control/individual/uZDaf4QTBytfbSmwdNnPjrDlDBQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e85", "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e85"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-04-01", "addresses": [{"address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ"}]}]
+[
+    {
+        "statementID": "openownership-register-16165421124416399532",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FAROL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04157398"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04157398",
+                "uri": "https://opencorporates.com/companies/gb/04157398"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e68",
+                "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e68"
+            }
+        ],
+        "foundingDate": "2001-02-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13241226181961983094",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16165421124416399532"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10458614285407401595"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13155832261867414961",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16165421124416399532"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3193760967479771778"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10458614285407401595",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Benjamin Thomas Vellacott"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04157398/persons-with-significant-control/individual/R5aILlJMxyOp4Vsz8zRDnpthNPQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e74",
+                "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e74"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-04-01",
+        "addresses": [
+            {
+                "address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3193760967479771778",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Matthew Edward Vellacott"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04157398/persons-with-significant-control/individual/uZDaf4QTBytfbSmwdNnPjrDlDBQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e85",
+                "uri": "http://register.openownership.org/entities/59b98d2d67e4ebf340de0e85"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-04-01",
+        "addresses": [
+            {
+                "address": "Rycote Lane Farm, Milton Common, Thame, Oxon, OX9 2NZ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04195096_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04195096_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-16312985639736907827", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BLUE OCEAN SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04195096"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04195096", "uri": "https://opencorporates.com/companies/gb/04195096"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0193", "uri": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0193"}], "foundingDate": "2001-04-05", "addresses": [{"type": "registered", "address": "339 Stanstead Road, London, SE6 4UE", "country": "GB"}]}, {"statementID": "openownership-register-14802161560897370979", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-05", "subject": {"describedByEntityStatement": "openownership-register-16312985639736907827"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3246716202358048354"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-05"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3246716202358048354", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Frances Dugbo"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04195096/persons-with-significant-control/individual/KquDpINzyNTrvoNivdMRVptYQHc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0198", "uri": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0198"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-01-01", "addresses": [{"address": "82, Further Green Road, London, SE6 1JQ"}]}]
+[
+    {
+        "statementID": "openownership-register-16312985639736907827",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BLUE OCEAN SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04195096"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04195096",
+                "uri": "https://opencorporates.com/companies/gb/04195096"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0193",
+                "uri": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0193"
+            }
+        ],
+        "foundingDate": "2001-04-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "339 Stanstead Road, London, SE6 4UE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14802161560897370979",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16312985639736907827"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3246716202358048354"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-05"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3246716202358048354",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Frances Dugbo"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04195096/persons-with-significant-control/individual/KquDpINzyNTrvoNivdMRVptYQHc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0198",
+                "uri": "http://register.openownership.org/entities/59b9b08a67e4ebf3405e0198"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-01-01",
+        "addresses": [
+            {
+                "address": "82, Further Green Road, London, SE6 1JQ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04212532_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04212532_bods.json
@@ -1,1 +1,99 @@
-[{"statementID": "openownership-register-14490932616123999990", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GROUNDWORK LONDON", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04212532"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04212532", "uri": "https://opencorporates.com/companies/gb/04212532"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b5e67e4ebf34017a807", "uri": "http://register.openownership.org/entities/59b92b5e67e4ebf34017a807"}], "foundingDate": "2001-05-08", "addresses": [{"type": "registered", "address": "18-21 Morley Street, London, SE1 7QZ", "country": "GB"}]}, {"statementID": "openownership-register-12503422794590639216", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-08", "subject": {"describedByEntityStatement": "openownership-register-14490932616123999990"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-14490932616123999990",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GROUNDWORK LONDON",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04212532"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04212532",
+                "uri": "https://opencorporates.com/companies/gb/04212532"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b5e67e4ebf34017a807",
+                "uri": "http://register.openownership.org/entities/59b92b5e67e4ebf34017a807"
+            }
+        ],
+        "foundingDate": "2001-05-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "18-21 Morley Street, London, SE1 7QZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12503422794590639216",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-08",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14490932616123999990"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04250960_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04250960_bods.json
@@ -1,1 +1,280 @@
-[{"statementID": "openownership-register-15234733795224262714", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VOYAGE CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04250960", "uri": "https://opencorporates.com/companies/gb/04250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4250960"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04250960"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b9e67e4ebf34018c552", "uri": "http://register.openownership.org/entities/59b92b9e67e4ebf34018c552"}], "foundingDate": "2001-07-12", "addresses": [{"type": "registered", "address": "Voyage Care Wall Island, Birmingham Road, Lichfield, Staffordshire, WS14 0QP", "country": "GB"}]}, {"statementID": "openownership-register-9611821942029307430", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15234733795224262714"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10341994780189986885"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10341994780189986885", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VOYAGE HEALTHCARE GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04218481"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04218481"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04218481", "uri": "https://opencorporates.com/companies/gb/04218481"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "4218481"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ae0567e4ebf34054513e", "uri": "http://register.openownership.org/entities/59b9ae0567e4ebf34054513e"}], "foundingDate": "2001-05-17", "addresses": [{"type": "registered", "address": "Voyage Care Wall Island, Birmingham Road, Lichfield, Staffordshire, WS14 0QP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15234733795224262714",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VOYAGE CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04250960",
+                "uri": "https://opencorporates.com/companies/gb/04250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4250960"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04250960"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b9e67e4ebf34018c552",
+                "uri": "http://register.openownership.org/entities/59b92b9e67e4ebf34018c552"
+            }
+        ],
+        "foundingDate": "2001-07-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Voyage Care Wall Island, Birmingham Road, Lichfield, Staffordshire, WS14 0QP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9611821942029307430",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15234733795224262714"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10341994780189986885"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10341994780189986885",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VOYAGE HEALTHCARE GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04218481"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04218481"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04218481",
+                "uri": "https://opencorporates.com/companies/gb/04218481"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "4218481"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ae0567e4ebf34054513e",
+                "uri": "http://register.openownership.org/entities/59b9ae0567e4ebf34054513e"
+            }
+        ],
+        "foundingDate": "2001-05-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Voyage Care Wall Island, Birmingham Road, Lichfield, Staffordshire, WS14 0QP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04301005_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04301005_bods.json
@@ -1,1 +1,135 @@
-[{"statementID": "openownership-register-3235075997279589329", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DRIVE DEVILBISS HEALTHCARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04301005", "uri": "https://opencorporates.com/companies/gb/04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04301005"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94e2a67e4ebf340b86153", "uri": "http://register.openownership.org/entities/59b94e2a67e4ebf340b86153"}], "foundingDate": "2001-10-08", "addresses": [{"type": "registered", "address": "Drive Devilbiss Healthcare Limited Heathfield Lane, Birkenshaw, West Yorkshire, BD11 2HW", "country": "GB"}]}, {"statementID": "openownership-register-6519084531769773859", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3235075997279589329"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14434586989398223582"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14434586989398223582", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RB CCP HOLDINGS, LLC", "incorporatedInJurisdiction": {"name": "United States of America", "code": "US"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04301005/persons-with-significant-control/corporate-entity/s-dkQwDVUnqIJhaoladghElQEOo"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/us_de/5263486", "uri": "https://opencorporates.com/companies/us_de/5263486"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b16a3c19dfc3fae18e906de", "uri": "http://register.openownership.org/entities/5b16a3c19dfc3fae18e906de"}], "foundingDate": "2012-12-20"}]
+[
+    {
+        "statementID": "openownership-register-3235075997279589329",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DRIVE DEVILBISS HEALTHCARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04301005",
+                "uri": "https://opencorporates.com/companies/gb/04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04301005"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94e2a67e4ebf340b86153",
+                "uri": "http://register.openownership.org/entities/59b94e2a67e4ebf340b86153"
+            }
+        ],
+        "foundingDate": "2001-10-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Drive Devilbiss Healthcare Limited Heathfield Lane, Birkenshaw, West Yorkshire, BD11 2HW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6519084531769773859",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3235075997279589329"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14434586989398223582"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14434586989398223582",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RB CCP HOLDINGS, LLC",
+        "incorporatedInJurisdiction": {
+            "name": "United States of America",
+            "code": "US"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04301005/persons-with-significant-control/corporate-entity/s-dkQwDVUnqIJhaoladghElQEOo"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/us_de/5263486",
+                "uri": "https://opencorporates.com/companies/us_de/5263486"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b16a3c19dfc3fae18e906de",
+                "uri": "http://register.openownership.org/entities/5b16a3c19dfc3fae18e906de"
+            }
+        ],
+        "foundingDate": "2012-12-20"
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04349535_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04349535_bods.json
@@ -1,1 +1,218 @@
-[{"statementID": "openownership-register-4883980201289775132", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MORGAN HUNT UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04349535"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04349535", "uri": "https://opencorporates.com/companies/gb/04349535"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9754b67e4ebf340736b83", "uri": "http://register.openownership.org/entities/59b9754b67e4ebf340736b83"}], "foundingDate": "2002-01-09", "addresses": [{"type": "registered", "address": "125 London Wall, London, EC2Y 5AS", "country": "GB"}]}, {"statementID": "openownership-register-18240882187028652538", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4883980201289775132"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16522768703618523656"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-10301650894324870209", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4883980201289775132"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17427577182399940582"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-16522768703618523656", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Rupert Patrick Fordham"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04349535/persons-with-significant-control/individual/UxasdnfzwBxc-9JQIGHaiNTkkTA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9754b67e4ebf340736b8d", "uri": "http://register.openownership.org/entities/59b9754b67e4ebf340736b8d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-08-01", "addresses": [{"address": "Wappenham Manor, Greenside, Wappenham, Towcester, NN12 8SH", "country": "GB"}]}, {"statementID": "openownership-register-17427577182399940582", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MORGAN HUNT HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06512897"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06512897", "uri": "https://opencorporates.com/companies/gb/06512897"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6512897"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6512897"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6512897"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6512897"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9929067e4ebf340f0db34", "uri": "http://register.openownership.org/entities/59b9929067e4ebf340f0db34"}], "foundingDate": "2008-02-25", "addresses": [{"type": "registered", "address": "125 London Wall, 9th Floor, London, EC2Y 5AS", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4883980201289775132",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MORGAN HUNT UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04349535"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04349535",
+                "uri": "https://opencorporates.com/companies/gb/04349535"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9754b67e4ebf340736b83",
+                "uri": "http://register.openownership.org/entities/59b9754b67e4ebf340736b83"
+            }
+        ],
+        "foundingDate": "2002-01-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "125 London Wall, London, EC2Y 5AS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18240882187028652538",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4883980201289775132"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16522768703618523656"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10301650894324870209",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4883980201289775132"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17427577182399940582"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16522768703618523656",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Rupert Patrick Fordham"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04349535/persons-with-significant-control/individual/UxasdnfzwBxc-9JQIGHaiNTkkTA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9754b67e4ebf340736b8d",
+                "uri": "http://register.openownership.org/entities/59b9754b67e4ebf340736b8d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-08-01",
+        "addresses": [
+            {
+                "address": "Wappenham Manor, Greenside, Wappenham, Towcester, NN12 8SH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17427577182399940582",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MORGAN HUNT HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06512897"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06512897",
+                "uri": "https://opencorporates.com/companies/gb/06512897"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6512897"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6512897"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6512897"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6512897"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9929067e4ebf340f0db34",
+                "uri": "http://register.openownership.org/entities/59b9929067e4ebf340f0db34"
+            }
+        ],
+        "foundingDate": "2008-02-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "125 London Wall, 9th Floor, London, EC2Y 5AS",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04353201_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04353201_bods.json
@@ -1,1 +1,140 @@
-[{"statementID": "openownership-register-13083766951533015319", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CABLESHEER (ASBESTOS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04353201"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04353201", "uri": "https://opencorporates.com/companies/gb/04353201"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9799c67e4ebf340891c88", "uri": "http://register.openownership.org/entities/59b9799c67e4ebf340891c88"}], "foundingDate": "2002-01-15", "addresses": [{"type": "registered", "address": "Cablesheer House, Murray Road, Orpington, Kent, BR5 3QY", "country": "GB"}]}, {"statementID": "openownership-register-14174935316145026411", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13083766951533015319"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3876304545196421496"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3876304545196421496", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CABLESHEER GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08167226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08167226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08167226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08167226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08167226"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08167226", "uri": "https://opencorporates.com/companies/gb/08167226"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015f225", "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015f225"}], "foundingDate": "2012-08-03", "addresses": [{"type": "registered", "address": "Cablesheer House, Murray Road, Orpington, Kent, BR5 3QY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13083766951533015319",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CABLESHEER (ASBESTOS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04353201"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04353201",
+                "uri": "https://opencorporates.com/companies/gb/04353201"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9799c67e4ebf340891c88",
+                "uri": "http://register.openownership.org/entities/59b9799c67e4ebf340891c88"
+            }
+        ],
+        "foundingDate": "2002-01-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cablesheer House, Murray Road, Orpington, Kent, BR5 3QY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14174935316145026411",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13083766951533015319"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3876304545196421496"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3876304545196421496",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CABLESHEER GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08167226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08167226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08167226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08167226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08167226"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08167226",
+                "uri": "https://opencorporates.com/companies/gb/08167226"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015f225",
+                "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015f225"
+            }
+        ],
+        "foundingDate": "2012-08-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Cablesheer House, Murray Road, Orpington, Kent, BR5 3QY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04369949_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04369949_bods.json
@@ -1,1 +1,129 @@
-[{"statementID": "openownership-register-2813517994751353491", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HEALTH MANAGEMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04369949"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04369949"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04369949"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04369949"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04369949", "uri": "https://opencorporates.com/companies/gb/04369949"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9795767e4ebf34087b1e3", "uri": "http://register.openownership.org/entities/59b9795767e4ebf34087b1e3"}], "foundingDate": "2002-02-08", "addresses": [{"type": "registered", "address": "Ash House, The Broyle, Ringmer, East Sussex, BN8 5NN", "country": "GB"}]}, {"statementID": "openownership-register-6609140734413655877", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2813517994751353491"}, "interestedParty": {"describedByEntityStatement": "openownership-register-697313330144885604"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-697313330144885604", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MAXIMUS HHS HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06588344"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06588344", "uri": "https://opencorporates.com/companies/gb/06588344"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e", "uri": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e"}], "foundingDate": "2008-05-08", "addresses": [{"type": "registered", "address": "18c Meridian East, Meridian Business Park, Leicester, LE19 1WZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2813517994751353491",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HEALTH MANAGEMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04369949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04369949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04369949"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04369949"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04369949",
+                "uri": "https://opencorporates.com/companies/gb/04369949"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9795767e4ebf34087b1e3",
+                "uri": "http://register.openownership.org/entities/59b9795767e4ebf34087b1e3"
+            }
+        ],
+        "foundingDate": "2002-02-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ash House, The Broyle, Ringmer, East Sussex, BN8 5NN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6609140734413655877",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2813517994751353491"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-697313330144885604"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-697313330144885604",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MAXIMUS HHS HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06588344"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06588344",
+                "uri": "https://opencorporates.com/companies/gb/06588344"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e",
+                "uri": "http://register.openownership.org/entities/59b9795867e4ebf34087b68e"
+            }
+        ],
+        "foundingDate": "2008-05-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "18c Meridian East, Meridian Business Park, Leicester, LE19 1WZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04373379_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04373379_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-14753487720686084721", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HI-SPEC FACILITIES SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04373379"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04373379", "uri": "https://opencorporates.com/companies/gb/04373379"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b982ad67e4ebf340b54068", "uri": "http://register.openownership.org/entities/59b982ad67e4ebf340b54068"}], "foundingDate": "2002-02-13", "addresses": [{"type": "registered", "address": "20 Schooner Court, Crossways Business Park, Dartford, Kent, DA2 6NW", "country": "GB"}]}, {"statementID": "openownership-register-900378280108297776", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14753487720686084721"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12749578496820464378"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12749578496820464378", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Colin Alexander Stirling"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03732022/persons-with-significant-control/individual/77ZSP79UGsBefVlN3OQQJNNP__o"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9548267e4ebf340d4a96e", "uri": "http://register.openownership.org/entities/59b9548267e4ebf340d4a96e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-12-01", "addresses": [{"address": "20, Schooner Court, Crossways Business Park, Dartford, Kent, DA2 6NW"}]}]
+[
+    {
+        "statementID": "openownership-register-14753487720686084721",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HI-SPEC FACILITIES SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04373379"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04373379",
+                "uri": "https://opencorporates.com/companies/gb/04373379"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b982ad67e4ebf340b54068",
+                "uri": "http://register.openownership.org/entities/59b982ad67e4ebf340b54068"
+            }
+        ],
+        "foundingDate": "2002-02-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "20 Schooner Court, Crossways Business Park, Dartford, Kent, DA2 6NW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-900378280108297776",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14753487720686084721"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12749578496820464378"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12749578496820464378",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Colin Alexander Stirling"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03732022/persons-with-significant-control/individual/77ZSP79UGsBefVlN3OQQJNNP__o"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9548267e4ebf340d4a96e",
+                "uri": "http://register.openownership.org/entities/59b9548267e4ebf340d4a96e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-12-01",
+        "addresses": [
+            {
+                "address": "20, Schooner Court, Crossways Business Park, Dartford, Kent, DA2 6NW"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04446433_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04446433_bods.json
@@ -1,1 +1,172 @@
-[{"statementID": "openownership-register-498416962137482799", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STACEY PROCESSING LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04446433"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04446433", "uri": "https://opencorporates.com/companies/gb/04446433"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76dfe", "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76dfe"}], "foundingDate": "2002-05-23", "addresses": [{"type": "registered", "address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE", "country": "GB"}]}, {"statementID": "openownership-register-7672875385980707370", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-498416962137482799"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6362148083328241716"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6888381044636912998", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-498416962137482799"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8560868708204652253"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-12-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6362148083328241716", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tony Stacey"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04446433/persons-with-significant-control/individual/VmJUAQAfH7bKxF33jFlIS0R4oKM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76e05", "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76e05"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-04-01", "addresses": [{"address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE", "country": "GB"}]}, {"statementID": "openownership-register-8560868708204652253", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robin Stacey"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04446433/persons-with-significant-control/individual/aMiba-6Q0sFxGV68YdNJ7h_43G0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76ef9", "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76ef9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-12-01", "addresses": [{"address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-498416962137482799",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STACEY PROCESSING LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04446433"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04446433",
+                "uri": "https://opencorporates.com/companies/gb/04446433"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76dfe",
+                "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76dfe"
+            }
+        ],
+        "foundingDate": "2002-05-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7672875385980707370",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-498416962137482799"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6362148083328241716"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6888381044636912998",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-498416962137482799"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8560868708204652253"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-12-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6362148083328241716",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tony Stacey"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04446433/persons-with-significant-control/individual/VmJUAQAfH7bKxF33jFlIS0R4oKM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76e05",
+                "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76e05"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-04-01",
+        "addresses": [
+            {
+                "address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8560868708204652253",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robin Stacey"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04446433/persons-with-significant-control/individual/aMiba-6Q0sFxGV68YdNJ7h_43G0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76ef9",
+                "uri": "http://register.openownership.org/entities/59b9c7c567e4ebf340b76ef9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-12-01",
+        "addresses": [
+            {
+                "address": "Ryder Point Works, Wirksworth, Matlock, Derbyshire, DE4 4HE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04449855_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04449855_bods.json
@@ -1,1 +1,205 @@
-[{"statementID": "openownership-register-7067231111681983810", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BUSINESS IMAGE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04449855"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04449855", "uri": "https://opencorporates.com/companies/gb/04449855"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431dc", "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431dc"}], "foundingDate": "2002-05-29", "addresses": [{"type": "registered", "address": "400 Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ", "country": "GB"}]}, {"statementID": "openownership-register-2082720424914068660", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7067231111681983810"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16597192664736987740"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-206619431979206173", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7067231111681983810"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1256714317439894303"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12545324923196916731", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7067231111681983810"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5116469418681109907"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16597192664736987740", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Derek Robert Rogers"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04449855/persons-with-significant-control/individual/FiUjNNBLBhlTxlizl6z_AiE-NFU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431ea", "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431ea"}], "birthDate": "1959-10-01", "addresses": [{"address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"}]}, {"statementID": "openownership-register-1256714317439894303", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tracey Rogers"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04449855/persons-with-significant-control/individual/N1dHmztSVRtJP80HaINYDCd4PAI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431f1", "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431f1"}], "birthDate": "1963-12-01", "addresses": [{"address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"}]}, {"statementID": "openownership-register-5116469418681109907", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "William Harold Price"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04449855/persons-with-significant-control/individual/xXEBmlfPFBI_CwYNXHyO8UfhhbM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431e4", "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431e4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-10-01", "addresses": [{"address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"}]}]
+[
+    {
+        "statementID": "openownership-register-7067231111681983810",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BUSINESS IMAGE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04449855"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04449855",
+                "uri": "https://opencorporates.com/companies/gb/04449855"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431dc",
+                "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431dc"
+            }
+        ],
+        "foundingDate": "2002-05-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "400 Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2082720424914068660",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7067231111681983810"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16597192664736987740"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-206619431979206173",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7067231111681983810"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1256714317439894303"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12545324923196916731",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7067231111681983810"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5116469418681109907"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16597192664736987740",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Derek Robert Rogers"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04449855/persons-with-significant-control/individual/FiUjNNBLBhlTxlizl6z_AiE-NFU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431ea",
+                "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431ea"
+            }
+        ],
+        "birthDate": "1959-10-01",
+        "addresses": [
+            {
+                "address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1256714317439894303",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tracey Rogers"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04449855/persons-with-significant-control/individual/N1dHmztSVRtJP80HaINYDCd4PAI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431f1",
+                "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431f1"
+            }
+        ],
+        "birthDate": "1963-12-01",
+        "addresses": [
+            {
+                "address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5116469418681109907",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "William Harold Price"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04449855/persons-with-significant-control/individual/xXEBmlfPFBI_CwYNXHyO8UfhhbM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431e4",
+                "uri": "http://register.openownership.org/entities/59b9cb4c67e4ebf340c431e4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-10-01",
+        "addresses": [
+            {
+                "address": "400, Dashwood Lang Road, Weybridge, Surrey, KT15 2HJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04451141_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04451141_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-18413647067251116495", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GATENBYSANDERSON LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04451141"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04451141", "uri": "https://opencorporates.com/companies/gb/04451141"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d2eb67e4ebf340e0a0f0", "uri": "http://register.openownership.org/entities/59b9d2eb67e4ebf340e0a0f0"}], "foundingDate": "2002-05-30", "addresses": [{"type": "registered", "address": "14 King Street, Leeds, West Yorkshire, LS1 2HL", "country": "GB"}]}, {"statementID": "openownership-register-14656694653861855813", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-18413647067251116495"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13443252585011151571"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13443252585011151571", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Gatenbysanderson Midco Limited", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09083901"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09083901", "uri": "https://opencorporates.com/companies/gb/09083901"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d30067e4ebf340e0e7ea", "uri": "http://register.openownership.org/entities/59b9d30067e4ebf340e0e7ea"}], "foundingDate": "2014-06-12", "addresses": [{"type": "registered", "address": "14, King Street, Leeds, LS1 2HL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-18413647067251116495",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GATENBYSANDERSON LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04451141"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04451141",
+                "uri": "https://opencorporates.com/companies/gb/04451141"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d2eb67e4ebf340e0a0f0",
+                "uri": "http://register.openownership.org/entities/59b9d2eb67e4ebf340e0a0f0"
+            }
+        ],
+        "foundingDate": "2002-05-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "14 King Street, Leeds, West Yorkshire, LS1 2HL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14656694653861855813",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-18413647067251116495"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13443252585011151571"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13443252585011151571",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Gatenbysanderson Midco Limited",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09083901"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09083901",
+                "uri": "https://opencorporates.com/companies/gb/09083901"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d30067e4ebf340e0e7ea",
+                "uri": "http://register.openownership.org/entities/59b9d30067e4ebf340e0e7ea"
+            }
+        ],
+        "foundingDate": "2014-06-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "14, King Street, Leeds, LS1 2HL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04482582_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04482582_bods.json
@@ -1,1 +1,312 @@
-[{"statementID": "openownership-register-738303516728094405", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PEACH ORATOR LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04482582"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04482582", "uri": "https://opencorporates.com/companies/gb/04482582"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c05", "uri": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c05"}], "foundingDate": "2002-07-10", "addresses": [{"type": "registered", "address": "1st Floor 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT", "country": "GB"}]}, {"statementID": "openownership-register-13859083974222681382", "statementType": "ownershipOrControlStatement", "statementDate": "2018-09-25", "subject": {"describedByEntityStatement": "openownership-register-738303516728094405"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14802358999607263338"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-25"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-25"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-09-25"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2018-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16105609473995115802", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-738303516728094405"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6694797928266740251"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06", "endDate": "2018-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-932258644712455562", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-738303516728094405"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17080745410281611667"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06", "endDate": "2018-09-25"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06", "endDate": "2018-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14802358999607263338", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ROUGEMONT CAPITAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11237541"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11237541", "uri": "https://opencorporates.com/companies/gb/11237541"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "11237541"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9726e9dfc3fae18d2b363", "uri": "http://register.openownership.org/entities/5ab9726e9dfc3fae18d2b363"}], "foundingDate": "2018-03-06", "addresses": [{"type": "registered", "address": "Yew House Private Road, Rodborough Common, Stroud, GL5 5BT", "country": "GB"}]}, {"statementID": "openownership-register-6694797928266740251", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Sarah Dianne Brooks"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04482582/persons-with-significant-control/individual/BbmxDB7WmY9iEFqypBgt2Sh8e5M"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d6c367e4ebf340ee0d7c", "uri": "http://register.openownership.org/entities/59b9d6c367e4ebf340ee0d7c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1969-08-01", "addresses": [{"address": "1st Floor, 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT"}]}, {"statementID": "openownership-register-17080745410281611667", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Stephen Bates"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04482582/persons-with-significant-control/individual/sk33JNMJ4--ulXP3VabkLuAxoIE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c0e", "uri": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c0e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-03-01", "addresses": [{"address": "1st Floor, 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT"}]}]
+[
+    {
+        "statementID": "openownership-register-738303516728094405",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PEACH ORATOR LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04482582"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04482582",
+                "uri": "https://opencorporates.com/companies/gb/04482582"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c05",
+                "uri": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c05"
+            }
+        ],
+        "foundingDate": "2002-07-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1st Floor 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13859083974222681382",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-09-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-738303516728094405"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14802358999607263338"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-25"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-25"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-09-25"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2018-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16105609473995115802",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-738303516728094405"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6694797928266740251"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-932258644712455562",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-738303516728094405"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17080745410281611667"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14802358999607263338",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ROUGEMONT CAPITAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11237541"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11237541",
+                "uri": "https://opencorporates.com/companies/gb/11237541"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11237541"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9726e9dfc3fae18d2b363",
+                "uri": "http://register.openownership.org/entities/5ab9726e9dfc3fae18d2b363"
+            }
+        ],
+        "foundingDate": "2018-03-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Yew House Private Road, Rodborough Common, Stroud, GL5 5BT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6694797928266740251",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Sarah Dianne Brooks"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04482582/persons-with-significant-control/individual/BbmxDB7WmY9iEFqypBgt2Sh8e5M"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d6c367e4ebf340ee0d7c",
+                "uri": "http://register.openownership.org/entities/59b9d6c367e4ebf340ee0d7c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1969-08-01",
+        "addresses": [
+            {
+                "address": "1st Floor, 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17080745410281611667",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Stephen Bates"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04482582/persons-with-significant-control/individual/sk33JNMJ4--ulXP3VabkLuAxoIE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c0e",
+                "uri": "http://register.openownership.org/entities/59b9d5d867e4ebf340eb7c0e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-03-01",
+        "addresses": [
+            {
+                "address": "1st Floor, 106a Rotherham Road, Smithies, Barnsley, South Yorkshire, S71 1UT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04487125_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04487125_bods.json
@@ -1,1 +1,185 @@
-[{"statementID": "openownership-register-1656269297772372121", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "THOMAS LISTER LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04487125"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04487125", "uri": "https://opencorporates.com/companies/gb/04487125"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9245467e4ebf340f943f0", "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f943f0"}], "foundingDate": "2002-07-16", "addresses": [{"type": "registered", "address": "11 The Courtyard, Buntsford Gate, Bromsgrove, Worcestershire, B60 3DJ", "country": "GB"}]}, {"statementID": "openownership-register-3169321219718929282", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1656269297772372121"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17736711504365200633"}, "interests": [{"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-11233237945514360626", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1656269297772372121"}, "interestedParty": {"describedByPersonStatement": "openownership-register-712442969542196945"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-17736711504365200633", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Chris Bernard Thomas"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04487125/persons-with-significant-control/individual/FzB-LJ8WUlpnraWgoWGcirO1MLo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9245467e4ebf340f94413", "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f94413"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-12-01", "addresses": [{"address": "Harwood, Laylocks Lane, Broadheath Common, Worcester, WR2 6RL"}]}, {"statementID": "openownership-register-712442969542196945", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Rachel Julie Lister"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04487125/persons-with-significant-control/individual/XQTSMtYClEIpiT1Ka2Nfa87Sz7A"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9245467e4ebf340f94418", "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f94418"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-09-01", "addresses": [{"address": "65, Suffok Way, Fernhill Heath, Worcester, WR3 7RJ"}]}]
+[
+    {
+        "statementID": "openownership-register-1656269297772372121",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "THOMAS LISTER LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04487125"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04487125",
+                "uri": "https://opencorporates.com/companies/gb/04487125"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9245467e4ebf340f943f0",
+                "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f943f0"
+            }
+        ],
+        "foundingDate": "2002-07-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "11 The Courtyard, Buntsford Gate, Bromsgrove, Worcestershire, B60 3DJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3169321219718929282",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1656269297772372121"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17736711504365200633"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11233237945514360626",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1656269297772372121"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-712442969542196945"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17736711504365200633",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Chris Bernard Thomas"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04487125/persons-with-significant-control/individual/FzB-LJ8WUlpnraWgoWGcirO1MLo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9245467e4ebf340f94413",
+                "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f94413"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-12-01",
+        "addresses": [
+            {
+                "address": "Harwood, Laylocks Lane, Broadheath Common, Worcester, WR2 6RL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-712442969542196945",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Rachel Julie Lister"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04487125/persons-with-significant-control/individual/XQTSMtYClEIpiT1Ka2Nfa87Sz7A"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9245467e4ebf340f94418",
+                "uri": "http://register.openownership.org/entities/59b9245467e4ebf340f94418"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-09-01",
+        "addresses": [
+            {
+                "address": "65, Suffok Way, Fernhill Heath, Worcester, WR3 7RJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04528646_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04528646_bods.json
@@ -1,1 +1,283 @@
-[{"statementID": "openownership-register-13024017356931274563", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RAINBOW TAXIS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04528646"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04528646", "uri": "https://opencorporates.com/companies/gb/04528646"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0e3", "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0e3"}], "foundingDate": "2002-09-06", "addresses": [{"type": "registered", "address": "11 Portland Road, Edgbaston, Birmingham, B16 9HN", "country": "GB"}]}, {"statementID": "openownership-register-17847374136902747452", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13024017356931274563"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6006999921298708735"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16103328539751308087", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13024017356931274563"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12808188525597250664"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8387412500349384788", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13024017356931274563"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14160486491802695150"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6006999921298708735", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Riaz Mohammed Raja"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04528646/persons-with-significant-control/individual/G4iWFMivSKyIGqHHC1bR7lHHYjE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0f3", "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0f3"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1951-01-01", "addresses": [{"address": "82 Jeffcock Road, Wolverhampton, West Midlands, WV3 7AA"}]}, {"statementID": "openownership-register-12808188525597250664", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mohammed Zulfiqir"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04528646/persons-with-significant-control/individual/h8r3nTMGp8-TNwXLCy3Nf403CT8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad105", "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad105"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-09-01", "addresses": [{"address": "7 Belgrade Road, Fordhouses, Wolverhampton, West Midlands, WV10 6SX"}]}, {"statementID": "openownership-register-14160486491802695150", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mahmood Hussain"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04528646/persons-with-significant-control/individual/uFW6hl-BgwWfv9FIL1W1ly5fY3g"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad10a", "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad10a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-03-01", "addresses": [{"address": "27 Skipton Green, Wolverhampton, West Midlands, WV6 0TY"}]}]
+[
+    {
+        "statementID": "openownership-register-13024017356931274563",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RAINBOW TAXIS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04528646"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04528646",
+                "uri": "https://opencorporates.com/companies/gb/04528646"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0e3",
+                "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0e3"
+            }
+        ],
+        "foundingDate": "2002-09-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "11 Portland Road, Edgbaston, Birmingham, B16 9HN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17847374136902747452",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13024017356931274563"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6006999921298708735"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16103328539751308087",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13024017356931274563"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12808188525597250664"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8387412500349384788",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13024017356931274563"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14160486491802695150"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6006999921298708735",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Riaz Mohammed Raja"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04528646/persons-with-significant-control/individual/G4iWFMivSKyIGqHHC1bR7lHHYjE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0f3",
+                "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad0f3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1951-01-01",
+        "addresses": [
+            {
+                "address": "82 Jeffcock Road, Wolverhampton, West Midlands, WV3 7AA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12808188525597250664",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mohammed Zulfiqir"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04528646/persons-with-significant-control/individual/h8r3nTMGp8-TNwXLCy3Nf403CT8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad105",
+                "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad105"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-09-01",
+        "addresses": [
+            {
+                "address": "7 Belgrade Road, Fordhouses, Wolverhampton, West Midlands, WV10 6SX"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14160486491802695150",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mahmood Hussain"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04528646/persons-with-significant-control/individual/uFW6hl-BgwWfv9FIL1W1ly5fY3g"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94eb567e4ebf340bad10a",
+                "uri": "http://register.openownership.org/entities/59b94eb567e4ebf340bad10a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-03-01",
+        "addresses": [
+            {
+                "address": "27 Skipton Green, Wolverhampton, West Midlands, WV6 0TY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04540287_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04540287_bods.json
@@ -1,1 +1,205 @@
-[{"statementID": "openownership-register-5031748331655580748", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ERIC WRIGHT FM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04540287"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04540287", "uri": "https://opencorporates.com/companies/gb/04540287"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9408a67e4ebf3407bd095", "uri": "http://register.openownership.org/entities/59b9408a67e4ebf3407bd095"}], "foundingDate": "2002-09-19", "addresses": [{"type": "registered", "address": "Sceptre House, Sceptre Way, Bamber Bridge, Preston, Lancashire, PR5 6AW", "country": "GB"}]}, {"statementID": "openownership-register-7895628161608487848", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5031748331655580748"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1118248152329809669"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1118248152329809669", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ERIC WRIGHT GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02841234"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02841234", "uri": "https://opencorporates.com/companies/gb/02841234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2841234"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92d2167e4ebf3402059ba", "uri": "http://register.openownership.org/entities/59b92d2167e4ebf3402059ba"}], "foundingDate": "1993-08-02", "addresses": [{"type": "registered", "address": "Sceptre House, Sceptre Way, Bamber Bridge Preston, Lancashire, PR5 6AW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5031748331655580748",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ERIC WRIGHT FM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04540287"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04540287",
+                "uri": "https://opencorporates.com/companies/gb/04540287"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9408a67e4ebf3407bd095",
+                "uri": "http://register.openownership.org/entities/59b9408a67e4ebf3407bd095"
+            }
+        ],
+        "foundingDate": "2002-09-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Sceptre House, Sceptre Way, Bamber Bridge, Preston, Lancashire, PR5 6AW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7895628161608487848",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5031748331655580748"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1118248152329809669"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1118248152329809669",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ERIC WRIGHT GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02841234"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02841234",
+                "uri": "https://opencorporates.com/companies/gb/02841234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2841234"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92d2167e4ebf3402059ba",
+                "uri": "http://register.openownership.org/entities/59b92d2167e4ebf3402059ba"
+            }
+        ],
+        "foundingDate": "1993-08-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Sceptre House, Sceptre Way, Bamber Bridge Preston, Lancashire, PR5 6AW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04555159_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04555159_bods.json
@@ -1,1 +1,199 @@
-[{"statementID": "openownership-register-16105583366135349979", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "2BM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04555159"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04555159", "uri": "https://opencorporates.com/companies/gb/04555159"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b041", "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b041"}], "foundingDate": "2002-10-07", "addresses": [{"type": "registered", "address": "Eldon Business Park, Eldon Road, Chilwell, Nottinghamshire, NG9 6DZ", "country": "GB"}]}, {"statementID": "openownership-register-13969700892224340735", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16105583366135349979"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7029932781795295673"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-06-07"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-06-07"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1633767645776229223", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16105583366135349979"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6738759741123295546"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7029932781795295673", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jason Alan Preston"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04555159/persons-with-significant-control/individual/Hrvn0oXMGsfIzrUT6nLCXmsAzEQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b04d", "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b04d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-12-01", "addresses": [{"address": "9 Main Street, Long Whatton, Loughborough, Leicestershire, LE12 5DF"}]}, {"statementID": "openownership-register-6738759741123295546", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark Anthony King"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04555159/persons-with-significant-control/individual/mAYAbGI95SIatIGuauo4fTgNWUk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b064", "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b064"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-12-01", "addresses": [{"address": "Textile View, 73 Derby Road, Bramcote, Nottingham, Nottinghamshire, NG9 3GW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16105583366135349979",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "2BM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04555159"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04555159",
+                "uri": "https://opencorporates.com/companies/gb/04555159"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b041",
+                "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b041"
+            }
+        ],
+        "foundingDate": "2002-10-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Eldon Business Park, Eldon Road, Chilwell, Nottinghamshire, NG9 6DZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13969700892224340735",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16105583366135349979"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7029932781795295673"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-06-07"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-06-07"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1633767645776229223",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16105583366135349979"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6738759741123295546"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7029932781795295673",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jason Alan Preston"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04555159/persons-with-significant-control/individual/Hrvn0oXMGsfIzrUT6nLCXmsAzEQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b04d",
+                "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b04d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-12-01",
+        "addresses": [
+            {
+                "address": "9 Main Street, Long Whatton, Loughborough, Leicestershire, LE12 5DF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6738759741123295546",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark Anthony King"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04555159/persons-with-significant-control/individual/mAYAbGI95SIatIGuauo4fTgNWUk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b064",
+                "uri": "http://register.openownership.org/entities/59b94ae767e4ebf340a9b064"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-12-01",
+        "addresses": [
+            {
+                "address": "Textile View, 73 Derby Road, Bramcote, Nottingham, Nottinghamshire, NG9 3GW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04611669_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04611669_bods.json
@@ -1,1 +1,283 @@
-[{"statementID": "openownership-register-16241579334190053026", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EVIDENCE TALKS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04611669"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04611669", "uri": "https://opencorporates.com/companies/gb/04611669"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c72", "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c72"}], "foundingDate": "2002-12-09", "addresses": [{"type": "registered", "address": "36 Timothys Bridge Road, Stratford Enterprise Park, Stratford-Upon-Avon, CV37 9NW", "country": "GB"}]}, {"statementID": "openownership-register-16201968405166875798", "statementType": "ownershipOrControlStatement", "statementDate": "2019-05-24", "subject": {"describedByEntityStatement": "openownership-register-16241579334190053026"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9476061932095845496"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-05-24"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-05-24"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-05-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6545938241573392759", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16241579334190053026"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4249778976685066668"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-05-24"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-05-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-5530764187238352018", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16241579334190053026"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10090148735107916614"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-05-24"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2019-05-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4249778976685066668", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Elizabeth Helen Sheldon"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04611669/persons-with-significant-control/individual/AOzuG21f399NNc0HrSYtNCM_zHo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c7d", "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c7d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-06-01", "addresses": [{"address": "Willen House, Tongwell Street, Fox Milne, Milton Keynes, Buckinghamshire, MK15 0YS"}]}, {"statementID": "openownership-register-10090148735107916614", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew David Sheldon"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04611669/persons-with-significant-control/individual/cxYoIJQg5Bo14E34ziD_g-rQVOk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c9c", "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c9c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-01-01", "addresses": [{"address": "Willen House, Tongwell Street, Fox Milne, Milton Keynes, Buckinghamshire, MK15 0YS"}]}, {"statementID": "openownership-register-9476061932095845496", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CCL EVIDENCE TALKS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "12004843"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/12004843", "uri": "https://opencorporates.com/companies/gb/12004843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "12004843"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ce707cb9dfc3fae182d09d7", "uri": "http://register.openownership.org/entities/5ce707cb9dfc3fae182d09d7"}], "foundingDate": "2019-05-20", "addresses": [{"type": "registered", "address": "36 Cygnet Court, Timothy's Bridge Street, Stratford Upon Avon, CV37 9NW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16241579334190053026",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EVIDENCE TALKS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04611669"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04611669",
+                "uri": "https://opencorporates.com/companies/gb/04611669"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c72",
+                "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c72"
+            }
+        ],
+        "foundingDate": "2002-12-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "36 Timothys Bridge Road, Stratford Enterprise Park, Stratford-Upon-Avon, CV37 9NW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16201968405166875798",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-05-24",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16241579334190053026"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9476061932095845496"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-05-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-05-24"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-05-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6545938241573392759",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16241579334190053026"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4249778976685066668"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-05-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-05-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5530764187238352018",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16241579334190053026"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10090148735107916614"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-05-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2019-05-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4249778976685066668",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Elizabeth Helen Sheldon"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04611669/persons-with-significant-control/individual/AOzuG21f399NNc0HrSYtNCM_zHo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c7d",
+                "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c7d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-06-01",
+        "addresses": [
+            {
+                "address": "Willen House, Tongwell Street, Fox Milne, Milton Keynes, Buckinghamshire, MK15 0YS"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10090148735107916614",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew David Sheldon"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04611669/persons-with-significant-control/individual/cxYoIJQg5Bo14E34ziD_g-rQVOk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c9c",
+                "uri": "http://register.openownership.org/entities/59b96ac567e4ebf3403f4c9c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-01-01",
+        "addresses": [
+            {
+                "address": "Willen House, Tongwell Street, Fox Milne, Milton Keynes, Buckinghamshire, MK15 0YS"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9476061932095845496",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CCL EVIDENCE TALKS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12004843"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/12004843",
+                "uri": "https://opencorporates.com/companies/gb/12004843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12004843"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ce707cb9dfc3fae182d09d7",
+                "uri": "http://register.openownership.org/entities/5ce707cb9dfc3fae182d09d7"
+            }
+        ],
+        "foundingDate": "2019-05-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "36 Cygnet Court, Timothy's Bridge Street, Stratford Upon Avon, CV37 9NW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04616077_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04616077_bods.json
@@ -1,1 +1,115 @@
-[{"statementID": "openownership-register-12935491266432967750", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "J H CONTRACT SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04616077"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04616077", "uri": "https://opencorporates.com/companies/gb/04616077"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96c1867e4ebf3404603e3", "uri": "http://register.openownership.org/entities/59b96c1867e4ebf3404603e3"}], "foundingDate": "2002-12-12", "addresses": [{"type": "registered", "address": "2 Mountsdie, Stanmore, Middlesex, HA7 2DT", "country": "GB"}]}, {"statementID": "openownership-register-17908919856826953297", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12935491266432967750"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13687027330277610945"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13687027330277610945", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter John Hand"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04616077/persons-with-significant-control/individual/-9KkvKs4kikfSjIH2_0lQd3VFMg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96c1867e4ebf3404603f3", "uri": "http://register.openownership.org/entities/59b96c1867e4ebf3404603f3"}], "nationalities": [{"name": "Ireland", "code": "IE"}], "birthDate": "1941-10-01", "addresses": [{"address": "30 St Ronans Crescent, Woodford Green, Essex, IG8 9DG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12935491266432967750",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "J H CONTRACT SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04616077"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04616077",
+                "uri": "https://opencorporates.com/companies/gb/04616077"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96c1867e4ebf3404603e3",
+                "uri": "http://register.openownership.org/entities/59b96c1867e4ebf3404603e3"
+            }
+        ],
+        "foundingDate": "2002-12-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2 Mountsdie, Stanmore, Middlesex, HA7 2DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17908919856826953297",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12935491266432967750"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13687027330277610945"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13687027330277610945",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter John Hand"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04616077/persons-with-significant-control/individual/-9KkvKs4kikfSjIH2_0lQd3VFMg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96c1867e4ebf3404603f3",
+                "uri": "http://register.openownership.org/entities/59b96c1867e4ebf3404603f3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Ireland",
+                "code": "IE"
+            }
+        ],
+        "birthDate": "1941-10-01",
+        "addresses": [
+            {
+                "address": "30 St Ronans Crescent, Woodford Green, Essex, IG8 9DG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04653580_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04653580_bods.json
@@ -1,1 +1,233 @@
-[{"statementID": "openownership-register-7250669306693762252", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RIDER LEVETT BUCKNALL UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04653580", "uri": "https://opencorporates.com/companies/gb/04653580"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa", "uri": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa"}], "foundingDate": "2003-01-31", "addresses": [{"type": "registered", "address": "15 Colmore Row, Birmingham, West Midlands, B3 2BH", "country": "GB"}]}, {"statementID": "openownership-register-2227417909411851246", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7250669306693762252"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14625823436902465893"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent-as-trust", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent-as-trust", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16240284868291248626", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7250669306693762252"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9505691467153504908"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent-as-trust", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent-as-trust", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14625823436902465893", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Maureen Caroline Quayle"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04653580/persons-with-significant-control/individual/LiqdRosBeICYDpk8_AiTU0t-5pg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2fd", "uri": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2fd"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-03-01", "addresses": [{"address": "St Mary's, The Parade, Castletown, IM9 1LG", "country": "IM"}]}, {"statementID": "openownership-register-9505691467153504908", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark St John Schofield"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04653580/persons-with-significant-control/individual/P5Y6EmhqlsbQdz8nb8UMjNlT894"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2f4", "uri": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2f4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-07-01", "addresses": [{"address": "St Mary's, The Parade, Castletown, IM9 1LG", "country": "IM"}]}]
+[
+    {
+        "statementID": "openownership-register-7250669306693762252",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RIDER LEVETT BUCKNALL UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04653580",
+                "uri": "https://opencorporates.com/companies/gb/04653580"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa",
+                "uri": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa"
+            }
+        ],
+        "foundingDate": "2003-01-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "15 Colmore Row, Birmingham, West Midlands, B3 2BH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2227417909411851246",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7250669306693762252"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14625823436902465893"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent-as-trust",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-as-trust",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16240284868291248626",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7250669306693762252"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9505691467153504908"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent-as-trust",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-as-trust",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14625823436902465893",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Maureen Caroline Quayle"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04653580/persons-with-significant-control/individual/LiqdRosBeICYDpk8_AiTU0t-5pg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2fd",
+                "uri": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2fd"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-03-01",
+        "addresses": [
+            {
+                "address": "St Mary's, The Parade, Castletown, IM9 1LG",
+                "country": "IM"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9505691467153504908",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark St John Schofield"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04653580/persons-with-significant-control/individual/P5Y6EmhqlsbQdz8nb8UMjNlT894"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2f4",
+                "uri": "http://register.openownership.org/entities/59b9a47b67e4ebf34031c2f4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-07-01",
+        "addresses": [
+            {
+                "address": "St Mary's, The Parade, Castletown, IM9 1LG",
+                "country": "IM"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04661899_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04661899_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-6751103240688991145", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HOWARTH LITCHFIELD PARTNERSHIP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04661899"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04661899", "uri": "https://opencorporates.com/companies/gb/04661899"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c39867e4ebf340a806e9", "uri": "http://register.openownership.org/entities/59b9c39867e4ebf340a806e9"}], "foundingDate": "2003-02-11", "addresses": [{"type": "registered", "address": "Liddon House, Belmont Business Park, Durham, DH1 1TW", "country": "GB"}]}, {"statementID": "openownership-register-5323638766379208622", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-27", "subject": {"describedByEntityStatement": "openownership-register-6751103240688991145"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7688137968392232081"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10534044823223077341", "statementType": "ownershipOrControlStatement", "statementDate": "2018-10-15", "subject": {"describedByEntityStatement": "openownership-register-6751103240688991145"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16004065303098775030"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2018-10-15"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7688137968392232081", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HLP (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05488309"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05488309"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05488309", "uri": "https://opencorporates.com/companies/gb/05488309"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c39967e4ebf340a80a28", "uri": "http://register.openownership.org/entities/59b9c39967e4ebf340a80a28"}], "foundingDate": "2005-06-22", "addresses": [{"type": "registered", "address": "Liddon House, Belmont Business Park, Durham, DH1 1TW", "country": "GB"}]}, {"statementID": "openownership-register-16004065303098775030", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Keith David Handy"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04661899/persons-with-significant-control/individual/bzjeFR58T7hYoS4iCwEOwzOLuCg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bf447699dfc3fae18b656b6", "uri": "http://register.openownership.org/entities/5bf447699dfc3fae18b656b6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1975-01-01", "addresses": [{"address": "3, Gerards Gill, Browney, Durham, DH7 8LH"}]}]
+[
+    {
+        "statementID": "openownership-register-6751103240688991145",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HOWARTH LITCHFIELD PARTNERSHIP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04661899"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04661899",
+                "uri": "https://opencorporates.com/companies/gb/04661899"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c39867e4ebf340a806e9",
+                "uri": "http://register.openownership.org/entities/59b9c39867e4ebf340a806e9"
+            }
+        ],
+        "foundingDate": "2003-02-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Liddon House, Belmont Business Park, Durham, DH1 1TW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5323638766379208622",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6751103240688991145"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7688137968392232081"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10534044823223077341",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-10-15",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6751103240688991145"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16004065303098775030"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2018-10-15"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7688137968392232081",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HLP (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05488309"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05488309"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05488309",
+                "uri": "https://opencorporates.com/companies/gb/05488309"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c39967e4ebf340a80a28",
+                "uri": "http://register.openownership.org/entities/59b9c39967e4ebf340a80a28"
+            }
+        ],
+        "foundingDate": "2005-06-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Liddon House, Belmont Business Park, Durham, DH1 1TW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16004065303098775030",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Keith David Handy"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04661899/persons-with-significant-control/individual/bzjeFR58T7hYoS4iCwEOwzOLuCg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bf447699dfc3fae18b656b6",
+                "uri": "http://register.openownership.org/entities/5bf447699dfc3fae18b656b6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1975-01-01",
+        "addresses": [
+            {
+                "address": "3, Gerards Gill, Browney, Durham, DH7 8LH"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04676102_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04676102_bods.json
@@ -1,1 +1,399 @@
-[{"statementID": "openownership-register-7236770428475206774", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JOHN DWYER BAKERY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04676102"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04676102", "uri": "https://opencorporates.com/companies/gb/04676102"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed68d5", "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed68d5"}], "foundingDate": "2003-02-24", "addresses": [{"type": "registered", "address": "Hamilton House, 39 Kings Road, Haslemere, Surrey, GU27 2QA", "country": "GB"}]}, {"statementID": "openownership-register-4060140272397928790", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7236770428475206774"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16697054819582420684"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-07-27"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-07-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2018-07-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6108859646119194920", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7236770428475206774"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12220520609380556691"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-07-27"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-07-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2018-07-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5338754111281233422", "statementType": "ownershipOrControlStatement", "statementDate": "2018-07-27", "subject": {"describedByEntityStatement": "openownership-register-7236770428475206774"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9983370805489621456"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-07-27"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-07-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-trust", "startDate": "2018-07-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16697054819582420684", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jacqueline Dwyer"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04676102/persons-with-significant-control/individual/DgLao697O-xyDPl8Gszlrln0XzI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed68e1", "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed68e1"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-08-01", "addresses": [{"address": "10-11 Prospect Park, Valley Drive, Swift Valley, Rugby, Warwickshire, CV21 1TF"}]}, {"statementID": "openownership-register-12220520609380556691", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Russell Dwyer"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04676102/persons-with-significant-control/individual/pGq3ZKMNiyAY1AZZXu1qeGG5zws"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed6ae8", "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed6ae8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-10-01", "addresses": [{"address": "10 & 11 Prospect Park, Valley Drive, Rugby, Warwickshire, CV21 1TF"}]}, {"statementID": "openownership-register-9983370805489621456", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BRIDGWATER BROS.HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00893784", "uri": "https://opencorporates.com/companies/gb/00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "893784"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00893784"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9252067e4ebf340fca880", "uri": "http://register.openownership.org/entities/59b9252067e4ebf340fca880"}], "foundingDate": "1966-12-09", "addresses": [{"type": "registered", "address": "Hamilton House, 39 Kings Road, Haslemere, Surrey, GU27 2QA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7236770428475206774",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JOHN DWYER BAKERY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04676102"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04676102",
+                "uri": "https://opencorporates.com/companies/gb/04676102"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed68d5",
+                "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed68d5"
+            }
+        ],
+        "foundingDate": "2003-02-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hamilton House, 39 Kings Road, Haslemere, Surrey, GU27 2QA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4060140272397928790",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7236770428475206774"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16697054819582420684"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6108859646119194920",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7236770428475206774"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12220520609380556691"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2018-07-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5338754111281233422",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-07-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7236770428475206774"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9983370805489621456"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-trust",
+                "startDate": "2018-07-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16697054819582420684",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jacqueline Dwyer"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04676102/persons-with-significant-control/individual/DgLao697O-xyDPl8Gszlrln0XzI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed68e1",
+                "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed68e1"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-08-01",
+        "addresses": [
+            {
+                "address": "10-11 Prospect Park, Valley Drive, Swift Valley, Rugby, Warwickshire, CV21 1TF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12220520609380556691",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Russell Dwyer"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04676102/persons-with-significant-control/individual/pGq3ZKMNiyAY1AZZXu1qeGG5zws"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9919167e4ebf340ed6ae8",
+                "uri": "http://register.openownership.org/entities/59b9919167e4ebf340ed6ae8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-10-01",
+        "addresses": [
+            {
+                "address": "10 & 11 Prospect Park, Valley Drive, Rugby, Warwickshire, CV21 1TF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9983370805489621456",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BRIDGWATER BROS.HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00893784",
+                "uri": "https://opencorporates.com/companies/gb/00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00893784"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9252067e4ebf340fca880",
+                "uri": "http://register.openownership.org/entities/59b9252067e4ebf340fca880"
+            }
+        ],
+        "foundingDate": "1966-12-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hamilton House, 39 Kings Road, Haslemere, Surrey, GU27 2QA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04739226_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04739226_bods.json
@@ -1,1 +1,70 @@
-[{"statementID": "openownership-register-4850115169539891535", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GENTOO HOMES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04739226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04739226"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04739226", "uri": "https://opencorporates.com/companies/gb/04739226"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04739226"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b174ad69dfc3fae18a35096", "uri": "http://register.openownership.org/entities/5b174ad69dfc3fae18a35096"}], "foundingDate": "2003-04-18", "addresses": [{"type": "registered", "address": "2 Emperor House, 2 Emperor Way, Sunderland, Tyne & Wear, SR3 3XR", "country": "GB"}]}, {"statementID": "openownership-register-2185222803174105739", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-18", "subject": {"describedByEntityStatement": "openownership-register-4850115169539891535"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-4850115169539891535",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GENTOO HOMES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04739226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04739226"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04739226",
+                "uri": "https://opencorporates.com/companies/gb/04739226"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04739226"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b174ad69dfc3fae18a35096",
+                "uri": "http://register.openownership.org/entities/5b174ad69dfc3fae18a35096"
+            }
+        ],
+        "foundingDate": "2003-04-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2 Emperor House, 2 Emperor Way, Sunderland, Tyne & Wear, SR3 3XR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2185222803174105739",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4850115169539891535"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04757246_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04757246_bods.json
@@ -1,1 +1,192 @@
-[{"statementID": "openownership-register-2033312860994492500", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JUNIPER TRAINING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04757246"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04757246", "uri": "https://opencorporates.com/companies/gb/04757246"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993aae", "uri": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993aae"}], "foundingDate": "2003-05-08", "addresses": [{"type": "registered", "address": "5 Element Court, Hilton Cross Business Park, Wolverhampton, West Midlands, WV10 7QZ", "country": "GB"}]}, {"statementID": "openownership-register-6879000144569934045", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-08", "subject": {"describedByEntityStatement": "openownership-register-2033312860994492500"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18379957083582564617"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-05-08", "endDate": "2020-03-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-1697913956238675262", "statementType": "ownershipOrControlStatement", "statementDate": "2020-03-10", "subject": {"describedByEntityStatement": "openownership-register-2033312860994492500"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16134101060923046834"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2020-03-10"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2020-03-10"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2020-03-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-18379957083582564617", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Richard John Holt"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04757246/persons-with-significant-control/individual/WSPeuzWSuo2qX35PJsU9crDq_wI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993ab9", "uri": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993ab9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-05-01", "addresses": [{"address": "5, Element Court, Hilton Cross Business Park, Wolverhampton, West Midlands, WV10 7QZ"}]}, {"statementID": "openownership-register-16134101060923046834", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JUNIPER TRAINING HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "12481811"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/12481811", "uri": "https://opencorporates.com/companies/gb/12481811"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "12481811"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5e7a4ea266c21ef3534ffe52", "uri": "http://register.openownership.org/entities/5e7a4ea266c21ef3534ffe52"}], "foundingDate": "2020-02-25", "addresses": [{"type": "registered", "address": "5 Element Court Hilton Cross Business Park, Featherstone, Wolverhampton, WV10 7QZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2033312860994492500",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JUNIPER TRAINING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04757246"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04757246",
+                "uri": "https://opencorporates.com/companies/gb/04757246"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993aae",
+                "uri": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993aae"
+            }
+        ],
+        "foundingDate": "2003-05-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Element Court, Hilton Cross Business Park, Wolverhampton, West Midlands, WV10 7QZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6879000144569934045",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-08",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2033312860994492500"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18379957083582564617"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-05-08",
+                "endDate": "2020-03-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1697913956238675262",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2020-03-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2033312860994492500"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16134101060923046834"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2020-03-10"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2020-03-10"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2020-03-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-18379957083582564617",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Richard John Holt"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04757246/persons-with-significant-control/individual/WSPeuzWSuo2qX35PJsU9crDq_wI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993ab9",
+                "uri": "http://register.openownership.org/entities/59b9bfbc67e4ebf340993ab9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-05-01",
+        "addresses": [
+            {
+                "address": "5, Element Court, Hilton Cross Business Park, Wolverhampton, West Midlands, WV10 7QZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16134101060923046834",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JUNIPER TRAINING HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12481811"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/12481811",
+                "uri": "https://opencorporates.com/companies/gb/12481811"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "12481811"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5e7a4ea266c21ef3534ffe52",
+                "uri": "http://register.openownership.org/entities/5e7a4ea266c21ef3534ffe52"
+            }
+        ],
+        "foundingDate": "2020-02-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Element Court Hilton Cross Business Park, Featherstone, Wolverhampton, WV10 7QZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04777788_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04777788_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-392256547938632774", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HEADWAY DEVON", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04777788"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04777788", "uri": "https://opencorporates.com/companies/gb/04777788"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4f9e567e4ebf3404f241b", "uri": "http://register.openownership.org/entities/59c4f9e567e4ebf3404f241b"}], "foundingDate": "2003-05-27", "addresses": [{"type": "registered", "address": "Xcentre, Commercial Road, Exeter, EX2 4AD", "country": "GB"}]}, {"statementID": "openownership-register-7881965062768889439", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-09", "subject": {"describedByEntityStatement": "openownership-register-392256547938632774"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-392256547938632774",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HEADWAY DEVON",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04777788"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04777788",
+                "uri": "https://opencorporates.com/companies/gb/04777788"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4f9e567e4ebf3404f241b",
+                "uri": "http://register.openownership.org/entities/59c4f9e567e4ebf3404f241b"
+            }
+        ],
+        "foundingDate": "2003-05-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Xcentre, Commercial Road, Exeter, EX2 4AD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7881965062768889439",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-09",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-392256547938632774"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04905838_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04905838_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-11522380413919455218", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PATHWAY FIRST LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04905838"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04905838", "uri": "https://opencorporates.com/companies/gb/04905838"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94bad67e4ebf340ac8ec8", "uri": "http://register.openownership.org/entities/59b94bad67e4ebf340ac8ec8"}], "foundingDate": "2003-09-19", "addresses": [{"type": "registered", "address": "Amington House 95 Amington Road, Tyseley, Birmingham, West Midlands, B25 8EP", "country": "GB"}]}, {"statementID": "openownership-register-1134157174195442349", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-19", "subject": {"describedByEntityStatement": "openownership-register-11522380413919455218"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7192356546780595001"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-09-19"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7192356546780595001", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Safaraz Ali"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06655381/persons-with-significant-control/individual/Ilpwn8ktwBbcq_R1N6VFAdyj-kY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9459c67e4ebf340907af4", "uri": "http://register.openownership.org/entities/59b9459c67e4ebf340907af4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-11-01", "addresses": [{"address": "Amington House, 95 Amington Road, Tyseley, Birmingham, West Midlands, B25 8EP"}]}]
+[
+    {
+        "statementID": "openownership-register-11522380413919455218",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PATHWAY FIRST LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04905838"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04905838",
+                "uri": "https://opencorporates.com/companies/gb/04905838"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94bad67e4ebf340ac8ec8",
+                "uri": "http://register.openownership.org/entities/59b94bad67e4ebf340ac8ec8"
+            }
+        ],
+        "foundingDate": "2003-09-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Amington House 95 Amington Road, Tyseley, Birmingham, West Midlands, B25 8EP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1134157174195442349",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11522380413919455218"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7192356546780595001"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-19"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7192356546780595001",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Safaraz Ali"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06655381/persons-with-significant-control/individual/Ilpwn8ktwBbcq_R1N6VFAdyj-kY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9459c67e4ebf340907af4",
+                "uri": "http://register.openownership.org/entities/59b9459c67e4ebf340907af4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-11-01",
+        "addresses": [
+            {
+                "address": "Amington House, 95 Amington Road, Tyseley, Birmingham, West Midlands, B25 8EP"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04910537_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04910537_bods.json
@@ -1,1 +1,196 @@
-[{"statementID": "openownership-register-14006434136348290095", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MACDONALD MARTIN LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04910537"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04910537", "uri": "https://opencorporates.com/companies/gb/04910537"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532a1", "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532a1"}], "foundingDate": "2003-09-24", "addresses": [{"type": "registered", "address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE", "country": "GB"}]}, {"statementID": "openownership-register-8968207902937077835", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14006434136348290095"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1775856314782633913"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6485462911249221281", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14006434136348290095"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6441403638642479812"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1775856314782633913", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew Trafford"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04910537/persons-with-significant-control/individual/V_E-8v6S7YFUG2TJZIZdV3oQXRw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532bc", "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532bc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-11-01", "addresses": [{"address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE"}]}, {"statementID": "openownership-register-6441403638642479812", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jacqueline Trafford"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04910537/persons-with-significant-control/individual/XfeIGnYOYSv1FEW-QRxYA8Axaho"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532af", "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532af"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-10-01", "addresses": [{"address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE"}]}]
+[
+    {
+        "statementID": "openownership-register-14006434136348290095",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MACDONALD MARTIN LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04910537"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04910537",
+                "uri": "https://opencorporates.com/companies/gb/04910537"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532a1",
+                "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532a1"
+            }
+        ],
+        "foundingDate": "2003-09-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8968207902937077835",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14006434136348290095"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1775856314782633913"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6485462911249221281",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14006434136348290095"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6441403638642479812"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1775856314782633913",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew Trafford"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04910537/persons-with-significant-control/individual/V_E-8v6S7YFUG2TJZIZdV3oQXRw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532bc",
+                "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532bc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-11-01",
+        "addresses": [
+            {
+                "address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6441403638642479812",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jacqueline Trafford"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04910537/persons-with-significant-control/individual/XfeIGnYOYSv1FEW-QRxYA8Axaho"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9469667e4ebf3409532af",
+                "uri": "http://register.openownership.org/entities/59b9469667e4ebf3409532af"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-10-01",
+        "addresses": [
+            {
+                "address": "3a Wellmere Road, Leechmere Industrial Estate, Sunderland, Tyne And Wear, SR2 9TE"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04990626_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04990626_bods.json
@@ -1,1 +1,192 @@
-[{"statementID": "openownership-register-15183386085179108565", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SECURE IT ENVIRONMENTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04990626"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04990626", "uri": "https://opencorporates.com/companies/gb/04990626"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96e4267e4ebf34050c306", "uri": "http://register.openownership.org/entities/59b96e4267e4ebf34050c306"}], "foundingDate": "2003-12-10", "addresses": [{"type": "registered", "address": "9 Shortmead Street, Biggleswade, Bedfordshire, SG18 0AT", "country": "GB"}]}, {"statementID": "openownership-register-14822028591489621133", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15183386085179108565"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10592101859661345378"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8467107373811341276", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15183386085179108565"}, "interestedParty": {"describedByPersonStatement": "openownership-register-887659868753397462"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10592101859661345378", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jo-Anne Elizabeth Garvie"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04990626/persons-with-significant-control/individual/DSClz2PHu4E5EcMb5T5kfxS3d-I"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96e4267e4ebf34050c327", "uri": "http://register.openownership.org/entities/59b96e4267e4ebf34050c327"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-03-01", "addresses": [{"address": "Valentine House, George Lane, Buckton, Cambridgeshire, PE19 5XL"}]}, {"statementID": "openownership-register-887659868753397462", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Christopher Kim Wellfair"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09175065/persons-with-significant-control/individual/7CdEuajvpG6JYZNcUrDWkMuMY9E"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9304d67e4ebf34030d071", "uri": "http://register.openownership.org/entities/59b9304d67e4ebf34030d071"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-12-01", "addresses": [{"address": "3 Meadow Way, Churchdown, Gloucester, GL3 2AU", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15183386085179108565",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SECURE IT ENVIRONMENTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04990626"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04990626",
+                "uri": "https://opencorporates.com/companies/gb/04990626"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96e4267e4ebf34050c306",
+                "uri": "http://register.openownership.org/entities/59b96e4267e4ebf34050c306"
+            }
+        ],
+        "foundingDate": "2003-12-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "9 Shortmead Street, Biggleswade, Bedfordshire, SG18 0AT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14822028591489621133",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15183386085179108565"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10592101859661345378"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8467107373811341276",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15183386085179108565"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-887659868753397462"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10592101859661345378",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jo-Anne Elizabeth Garvie"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04990626/persons-with-significant-control/individual/DSClz2PHu4E5EcMb5T5kfxS3d-I"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96e4267e4ebf34050c327",
+                "uri": "http://register.openownership.org/entities/59b96e4267e4ebf34050c327"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-03-01",
+        "addresses": [
+            {
+                "address": "Valentine House, George Lane, Buckton, Cambridgeshire, PE19 5XL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-887659868753397462",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Christopher Kim Wellfair"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09175065/persons-with-significant-control/individual/7CdEuajvpG6JYZNcUrDWkMuMY9E"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9304d67e4ebf34030d071",
+                "uri": "http://register.openownership.org/entities/59b9304d67e4ebf34030d071"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-12-01",
+        "addresses": [
+            {
+                "address": "3 Meadow Way, Churchdown, Gloucester, GL3 2AU",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04992349_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_04992349_bods.json
@@ -1,1 +1,194 @@
-[{"statementID": "openownership-register-5447882300364170980", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PRISM UK MEDICAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04992349", "uri": "https://opencorporates.com/companies/gb/04992349"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04992349"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92a1267e4ebf340117fb2", "uri": "http://register.openownership.org/entities/59b92a1267e4ebf340117fb2"}], "foundingDate": "2003-12-11", "addresses": [{"type": "registered", "address": "Unit 4 Jubilee Business Park Jubilee Way, Grange Moor, Wakefield, West Yorkshire, WF4 4TD", "country": "GB"}]}, {"statementID": "openownership-register-9130974075128880989", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5447882300364170980"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14397169588843944568"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14397169588843944568", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PRISM MEDICAL HEALTHCARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08840024", "uri": "https://opencorporates.com/companies/gb/08840024"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08840024"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93a1367e4ebf3405e3d64", "uri": "http://register.openownership.org/entities/59b93a1367e4ebf3405e3d64"}], "foundingDate": "2014-01-10", "addresses": [{"type": "registered", "address": "Unit 4 Jubilee Business Park, Jubilee Way, Grange Moor, West Yorkshire, WF4 4TD", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5447882300364170980",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PRISM UK MEDICAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04992349",
+                "uri": "https://opencorporates.com/companies/gb/04992349"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04992349"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92a1267e4ebf340117fb2",
+                "uri": "http://register.openownership.org/entities/59b92a1267e4ebf340117fb2"
+            }
+        ],
+        "foundingDate": "2003-12-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 4 Jubilee Business Park Jubilee Way, Grange Moor, Wakefield, West Yorkshire, WF4 4TD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9130974075128880989",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5447882300364170980"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14397169588843944568"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14397169588843944568",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PRISM MEDICAL HEALTHCARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08840024",
+                "uri": "https://opencorporates.com/companies/gb/08840024"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08840024"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93a1367e4ebf3405e3d64",
+                "uri": "http://register.openownership.org/entities/59b93a1367e4ebf3405e3d64"
+            }
+        ],
+        "foundingDate": "2014-01-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 4 Jubilee Business Park, Jubilee Way, Grange Moor, West Yorkshire, WF4 4TD",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05074255_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05074255_bods.json
@@ -1,1 +1,268 @@
-[{"statementID": "openownership-register-4681355752078933603", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EBENI LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05074255"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05074255", "uri": "https://opencorporates.com/companies/gb/05074255"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a911", "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a911"}], "foundingDate": "2004-03-16", "addresses": [{"type": "registered", "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP", "country": "GB"}]}, {"statementID": "openownership-register-7118406110540948009", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4681355752078933603"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10872724831684301528"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15213226373010678301", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4681355752078933603"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1202066062550920661"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-195698067330936892", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4681355752078933603"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10870118883823868684"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10872724831684301528", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jason Edward Denness"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05074255/persons-with-significant-control/individual/8-cSb4dnPiPbaAey22mfCQCZqLw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a920", "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a920"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-06-01", "addresses": [{"address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"}]}, {"statementID": "openownership-register-1202066062550920661", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Joanne Latham"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05074255/persons-with-significant-control/individual/QB25QPImZGBsZ3TVVIfLYYx_p8s"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a929", "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a929"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1975-10-01", "addresses": [{"address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"}]}, {"statementID": "openownership-register-10870118883823868684", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alan James Simpson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05074255/persons-with-significant-control/individual/jyS1sLPMloVE-eGklhkcml-GNPs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a932", "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a932"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-06-01", "addresses": [{"address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"}]}]
+[
+    {
+        "statementID": "openownership-register-4681355752078933603",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EBENI LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05074255"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05074255",
+                "uri": "https://opencorporates.com/companies/gb/05074255"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a911",
+                "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a911"
+            }
+        ],
+        "foundingDate": "2004-03-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7118406110540948009",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4681355752078933603"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10872724831684301528"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15213226373010678301",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4681355752078933603"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1202066062550920661"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-195698067330936892",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4681355752078933603"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10870118883823868684"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10872724831684301528",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jason Edward Denness"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05074255/persons-with-significant-control/individual/8-cSb4dnPiPbaAey22mfCQCZqLw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a920",
+                "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a920"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-06-01",
+        "addresses": [
+            {
+                "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1202066062550920661",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Joanne Latham"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05074255/persons-with-significant-control/individual/QB25QPImZGBsZ3TVVIfLYYx_p8s"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a929",
+                "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a929"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1975-10-01",
+        "addresses": [
+            {
+                "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10870118883823868684",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alan James Simpson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05074255/persons-with-significant-control/individual/jyS1sLPMloVE-eGklhkcml-GNPs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a08667e4ebf34022a932",
+                "uri": "http://register.openownership.org/entities/59b9a08667e4ebf34022a932"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-06-01",
+        "addresses": [
+            {
+                "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05108219_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05108219_bods.json
@@ -1,1 +1,369 @@
-[{"statementID": "openownership-register-13992192668712856865", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PARK HOUSE SCHOOL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05108219"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05108219", "uri": "https://opencorporates.com/companies/gb/05108219"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec377", "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec377"}], "foundingDate": "2004-04-21", "addresses": [{"type": "registered", "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA", "country": "GB"}]}, {"statementID": "openownership-register-9077973138623896381", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-13992192668712856865"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4040055124460167578"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-04-24T09:24:16Z"}}, {"statementID": "openownership-register-14768031830337086495", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-13992192668712856865"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5174716245231902170"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13139125718903910228", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-13992192668712856865"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13803609884404883512"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10820958997969838627", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13992192668712856865"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9090401157196166152"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12040538063552184546", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13992192668712856865"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10845202940558826719"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4040055124460167578", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Beth Abigayle Marie Rich"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05108219/persons-with-significant-control/individual/HSs-VttDsF8uwXSp-NfybziuS2w"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b1710b49dfc3fae1808e37f", "uri": "http://register.openownership.org/entities/5b1710b49dfc3fae1808e37f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1984-03-01", "addresses": [{"address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"}]}, {"statementID": "openownership-register-5174716245231902170", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tom Raymond Crossland"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05108219/persons-with-significant-control/individual/aIETPSKqnGUQZ13EgCGSGoe-mh4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b1710b29dfc3fae1808dd92", "uri": "http://register.openownership.org/entities/5b1710b29dfc3fae1808dd92"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1981-03-01", "addresses": [{"address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"}]}, {"statementID": "openownership-register-13803609884404883512", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tacita Annette Crossland"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05108219/persons-with-significant-control/individual/kGhwi-Nh3oBkKmPR7rLJ-hg6eKA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b1710af9dfc3fae1808d6e0", "uri": "http://register.openownership.org/entities/5b1710af9dfc3fae1808d6e0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1973-06-01", "addresses": [{"address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"}]}, {"statementID": "openownership-register-9090401157196166152", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jane Crossland"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05108219/persons-with-significant-control/individual/mZoBbuEcCQ4ie_627_AH8rStvnQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec396", "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec396"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-06-01", "addresses": [{"address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"}]}, {"statementID": "openownership-register-10845202940558826719", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alan Crossland"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05108219/persons-with-significant-control/individual/yHgYFarZBgMS-YzRR_zRu-IXjYs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec3ab", "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec3ab"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1941-12-01", "addresses": [{"address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"}]}]
+[
+    {
+        "statementID": "openownership-register-13992192668712856865",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PARK HOUSE SCHOOL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05108219"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05108219",
+                "uri": "https://opencorporates.com/companies/gb/05108219"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec377",
+                "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec377"
+            }
+        ],
+        "foundingDate": "2004-04-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9077973138623896381",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13992192668712856865"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4040055124460167578"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-04-24T09:24:16Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14768031830337086495",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13992192668712856865"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5174716245231902170"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13139125718903910228",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13992192668712856865"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13803609884404883512"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10820958997969838627",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13992192668712856865"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9090401157196166152"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12040538063552184546",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13992192668712856865"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10845202940558826719"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4040055124460167578",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Beth Abigayle Marie Rich"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05108219/persons-with-significant-control/individual/HSs-VttDsF8uwXSp-NfybziuS2w"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b1710b49dfc3fae1808e37f",
+                "uri": "http://register.openownership.org/entities/5b1710b49dfc3fae1808e37f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1984-03-01",
+        "addresses": [
+            {
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5174716245231902170",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tom Raymond Crossland"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05108219/persons-with-significant-control/individual/aIETPSKqnGUQZ13EgCGSGoe-mh4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b1710b29dfc3fae1808dd92",
+                "uri": "http://register.openownership.org/entities/5b1710b29dfc3fae1808dd92"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1981-03-01",
+        "addresses": [
+            {
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13803609884404883512",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tacita Annette Crossland"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05108219/persons-with-significant-control/individual/kGhwi-Nh3oBkKmPR7rLJ-hg6eKA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b1710af9dfc3fae1808d6e0",
+                "uri": "http://register.openownership.org/entities/5b1710af9dfc3fae1808d6e0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1973-06-01",
+        "addresses": [
+            {
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9090401157196166152",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jane Crossland"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05108219/persons-with-significant-control/individual/mZoBbuEcCQ4ie_627_AH8rStvnQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec396",
+                "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec396"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-06-01",
+        "addresses": [
+            {
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10845202940558826719",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alan Crossland"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05108219/persons-with-significant-control/individual/yHgYFarZBgMS-YzRR_zRu-IXjYs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec3ab",
+                "uri": "http://register.openownership.org/entities/59b9b4b767e4ebf3406ec3ab"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1941-12-01",
+        "addresses": [
+            {
+                "address": "Park House School, Park House, Thorney, Peterborough, Cambridgeshire, PE6 0SA"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05190234_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05190234_bods.json
@@ -1,1 +1,199 @@
-[{"statementID": "openownership-register-15101858643215523235", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Inhealth Limited", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05190234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05190234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05190234"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05190234"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05190234", "uri": "https://opencorporates.com/companies/gb/05190234"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab93d5d9dfc3fae1853444d", "uri": "http://register.openownership.org/entities/5ab93d5d9dfc3fae1853444d"}], "foundingDate": "2004-07-27", "addresses": [{"type": "registered", "address": "Beechwood Hall, Kingsmead Road, High Wycombe, HP11 1JL", "country": "GB"}]}, {"statementID": "openownership-register-10400225818558630516", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15101858643215523235"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17318597971975023629"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17318597971975023629", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INHEALTH GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04620480"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04620480", "uri": "https://opencorporates.com/companies/gb/04620480"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96e4967e4ebf34050ecee", "uri": "http://register.openownership.org/entities/59b96e4967e4ebf34050ecee"}], "foundingDate": "2002-12-18", "addresses": [{"type": "registered", "address": "Beechwood Hall, Kingsmead Road, High Wycombe, Buckinghamshire, HP11 1JL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15101858643215523235",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Inhealth Limited",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05190234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05190234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05190234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05190234"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05190234",
+                "uri": "https://opencorporates.com/companies/gb/05190234"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab93d5d9dfc3fae1853444d",
+                "uri": "http://register.openownership.org/entities/5ab93d5d9dfc3fae1853444d"
+            }
+        ],
+        "foundingDate": "2004-07-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Beechwood Hall, Kingsmead Road, High Wycombe, HP11 1JL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10400225818558630516",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15101858643215523235"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17318597971975023629"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17318597971975023629",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INHEALTH GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04620480"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04620480",
+                "uri": "https://opencorporates.com/companies/gb/04620480"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96e4967e4ebf34050ecee",
+                "uri": "http://register.openownership.org/entities/59b96e4967e4ebf34050ecee"
+            }
+        ],
+        "foundingDate": "2002-12-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Beechwood Hall, Kingsmead Road, High Wycombe, Buckinghamshire, HP11 1JL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05302612_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05302612_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-5460790090990774026", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WORKSPACE TECHNOLOGY LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05302612"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05302612", "uri": "https://opencorporates.com/companies/gb/05302612"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9682c67e4ebf34031c216", "uri": "http://register.openownership.org/entities/59b9682c67e4ebf34031c216"}], "foundingDate": "2004-12-02", "addresses": [{"type": "registered", "address": "Unit 10 Reddicap Trading Estate, Sutton Coldfield, West Midlands, B75 7BU", "country": "GB"}]}, {"statementID": "openownership-register-498584146274069085", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-02", "subject": {"describedByEntityStatement": "openownership-register-5460790090990774026"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12170234332373431749"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-12-02"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-12-02"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-12170234332373431749", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Roy David Griffiths"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05302612/persons-with-significant-control/individual/tboIkog9lqgTyTr_7XA4PC0KQLg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9682c67e4ebf34031c228", "uri": "http://register.openownership.org/entities/59b9682c67e4ebf34031c228"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-08-01", "addresses": [{"address": "Unit 10, Reddicap Trading Estate, Sutton Coldfield, West Midlands, B75 7BU"}]}]
+[
+    {
+        "statementID": "openownership-register-5460790090990774026",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WORKSPACE TECHNOLOGY LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05302612"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05302612",
+                "uri": "https://opencorporates.com/companies/gb/05302612"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9682c67e4ebf34031c216",
+                "uri": "http://register.openownership.org/entities/59b9682c67e4ebf34031c216"
+            }
+        ],
+        "foundingDate": "2004-12-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 10 Reddicap Trading Estate, Sutton Coldfield, West Midlands, B75 7BU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-498584146274069085",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-02",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5460790090990774026"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12170234332373431749"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-12-02"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-12-02"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12170234332373431749",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Roy David Griffiths"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05302612/persons-with-significant-control/individual/tboIkog9lqgTyTr_7XA4PC0KQLg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9682c67e4ebf34031c228",
+                "uri": "http://register.openownership.org/entities/59b9682c67e4ebf34031c228"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-08-01",
+        "addresses": [
+            {
+                "address": "Unit 10, Reddicap Trading Estate, Sutton Coldfield, West Midlands, B75 7BU"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05326869_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05326869_bods.json
@@ -1,1 +1,139 @@
-[{"statementID": "openownership-register-7842035833851869585", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BLUE SKY FOSTERING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05326869"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05326869", "uri": "https://opencorporates.com/companies/gb/05326869"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4fefa67e4ebf340597785", "uri": "http://register.openownership.org/entities/59c4fefa67e4ebf340597785"}], "foundingDate": "2005-01-07", "addresses": [{"type": "registered", "address": "4 Jardine House, Harrovian Business Village Bessborough Road, Harrow, Middlesex, HA1 3EX", "country": "GB"}]}, {"statementID": "openownership-register-8749330224031110253", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-07", "subject": {"describedByEntityStatement": "openownership-register-7842035833851869585"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6140174103831590722"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-07"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-07"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-07"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6140174103831590722", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BSN SOCIAL CARE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09092445", "uri": "https://opencorporates.com/companies/gb/09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e", "uri": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e"}], "foundingDate": "2014-06-19", "addresses": [{"type": "registered", "address": "4 Jardine House Harrovian Business Village, Bessborough Road, Harrow, HA1 3EX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7842035833851869585",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BLUE SKY FOSTERING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05326869"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05326869",
+                "uri": "https://opencorporates.com/companies/gb/05326869"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4fefa67e4ebf340597785",
+                "uri": "http://register.openownership.org/entities/59c4fefa67e4ebf340597785"
+            }
+        ],
+        "foundingDate": "2005-01-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4 Jardine House, Harrovian Business Village Bessborough Road, Harrow, Middlesex, HA1 3EX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8749330224031110253",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-07",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7842035833851869585"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6140174103831590722"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-07"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-07"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-07"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6140174103831590722",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BSN SOCIAL CARE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09092445",
+                "uri": "https://opencorporates.com/companies/gb/09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e",
+                "uri": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e"
+            }
+        ],
+        "foundingDate": "2014-06-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4 Jardine House Harrovian Business Village, Bessborough Road, Harrow, HA1 3EX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05418977_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05418977_bods.json
@@ -1,1 +1,192 @@
-[{"statementID": "openownership-register-15366167382357723889", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HERRINGTON CONSULTING LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05418977"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05418977", "uri": "https://opencorporates.com/companies/gb/05418977"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bc8", "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bc8"}], "foundingDate": "2005-04-08", "addresses": [{"type": "registered", "address": "158 High Street, Herne Bay, Kent, CT6 5NP", "country": "GB"}]}, {"statementID": "openownership-register-15659962355255506881", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15366167382357723889"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7381889902475004823"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13280702738110996607", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15366167382357723889"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3432854774935753679"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7381889902475004823", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Simon Herrington"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05418977/persons-with-significant-control/individual/P__CcxT4QRF0wloZlm-XsnvScIE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bdc", "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bdc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-02-01", "addresses": [{"address": "6, Elham Valley Road, Barham, Canterbury, CT4 6DQ"}]}, {"statementID": "openownership-register-3432854774935753679", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Simon Anthony Maiden-Brooks"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05418977/persons-with-significant-control/individual/YojWkGS892JlPZQmcrNmxbhX98c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bda", "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bda"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1978-03-01", "addresses": [{"address": "6, Elham Valley Road, Barham, Canterbury, CT4 6DQ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15366167382357723889",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HERRINGTON CONSULTING LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05418977"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05418977",
+                "uri": "https://opencorporates.com/companies/gb/05418977"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bc8",
+                "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bc8"
+            }
+        ],
+        "foundingDate": "2005-04-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "158 High Street, Herne Bay, Kent, CT6 5NP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15659962355255506881",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15366167382357723889"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7381889902475004823"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13280702738110996607",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15366167382357723889"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3432854774935753679"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7381889902475004823",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Simon Herrington"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05418977/persons-with-significant-control/individual/P__CcxT4QRF0wloZlm-XsnvScIE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bdc",
+                "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bdc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-02-01",
+        "addresses": [
+            {
+                "address": "6, Elham Valley Road, Barham, Canterbury, CT4 6DQ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3432854774935753679",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Simon Anthony Maiden-Brooks"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05418977/persons-with-significant-control/individual/YojWkGS892JlPZQmcrNmxbhX98c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bda",
+                "uri": "http://register.openownership.org/entities/59b9d60967e4ebf340ec0bda"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1978-03-01",
+        "addresses": [
+            {
+                "address": "6, Elham Valley Road, Barham, Canterbury, CT4 6DQ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05509733_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05509733_bods.json
@@ -1,1 +1,104 @@
-[{"statementID": "openownership-register-3258880133823919752", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PROVENTURE CONSULTING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05509733"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05509733", "uri": "https://opencorporates.com/companies/gb/05509733"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9273967e4ebf34005177e", "uri": "http://register.openownership.org/entities/59b9273967e4ebf34005177e"}], "foundingDate": "2005-07-15", "addresses": [{"type": "registered", "address": "Blackfriars House, Parsonage, Manchester, M3 2JA", "country": "GB"}]}, {"statementID": "openownership-register-4719260220353858347", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3258880133823919752"}, "interestedParty": {"describedByPersonStatement": "openownership-register-356725435670256055"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-356725435670256055", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Stephen Anthony Cooley"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05509733/persons-with-significant-control/individual/CUK2jP5w_xZFQL7AVxvyoEckXP4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9273967e4ebf34005178e", "uri": "http://register.openownership.org/entities/59b9273967e4ebf34005178e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-01-01", "addresses": [{"address": "Village Farmhouse, Main Street, Askham Richard, York, YO23 3PT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-3258880133823919752",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PROVENTURE CONSULTING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05509733"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05509733",
+                "uri": "https://opencorporates.com/companies/gb/05509733"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9273967e4ebf34005177e",
+                "uri": "http://register.openownership.org/entities/59b9273967e4ebf34005177e"
+            }
+        ],
+        "foundingDate": "2005-07-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Blackfriars House, Parsonage, Manchester, M3 2JA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4719260220353858347",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3258880133823919752"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-356725435670256055"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-356725435670256055",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Stephen Anthony Cooley"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05509733/persons-with-significant-control/individual/CUK2jP5w_xZFQL7AVxvyoEckXP4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9273967e4ebf34005178e",
+                "uri": "http://register.openownership.org/entities/59b9273967e4ebf34005178e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-01-01",
+        "addresses": [
+            {
+                "address": "Village Farmhouse, Main Street, Askham Richard, York, YO23 3PT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05510758_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05510758_bods.json
@@ -1,1 +1,1605 @@
-[{"statementID": "openownership-register-1820076799963233079", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BANNER GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05510758"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05510758"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05510758"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05510758", "uri": "https://opencorporates.com/companies/gb/05510758"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05510758"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee12", "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee12"}], "foundingDate": "2005-07-18", "addresses": [{"type": "registered", "address": "K House, Sheffield Business Park, Europa Link, Sheffield, S9 1XU", "country": "GB"}]}, {"statementID": "openownership-register-17829939612884066837", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1820076799963233079"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3722734699986348582"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14656002078852184030", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1820076799963233079"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3068926442300694163"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-10081729829104525204", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1820076799963233079"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6399471097175949483"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9488899758103536544", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-1820076799963233079"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1073939460253575989"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3722734699986348582", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ENDLESS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC316569"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC316569", "uri": "https://opencorporates.com/companies/gb/OC316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc316569"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91c2d67e4ebf340dbe3e6", "uri": "http://register.openownership.org/entities/59b91c2d67e4ebf340dbe3e6"}], "foundingDate": "2005-12-07", "addresses": [{"type": "registered", "address": "3 Whitehall Quay, Leeds, West Yorkshire, LS1 4BF", "country": "GB"}]}, {"statementID": "openownership-register-6399471097175949483", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ENDLESS II (GP) LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO304712"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SO304712", "uri": "https://opencorporates.com/companies/gb/SO304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So304712"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e2e67e4ebf34025def5", "uri": "http://register.openownership.org/entities/59b92e2e67e4ebf34025def5"}], "foundingDate": "2013-12-16", "addresses": [{"type": "registered", "address": "50 Lothian Road, Festival Square, Edinburgh, EH3 9WJ", "country": "GB"}]}, {"statementID": "openownership-register-3068926442300694163", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EVO GROUP SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06257099", "uri": "https://opencorporates.com/companies/gb/06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06257099"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b0267e4ebf34015f3cd", "uri": "http://register.openownership.org/entities/59b92b0267e4ebf34015f3cd"}], "foundingDate": "2007-05-23", "addresses": [{"type": "registered", "address": "K House, Sheffield Business Park, Europa  Link, Sheffield, S9 1XU", "country": "GB"}]}, {"statementID": "openownership-register-1073939460253575989", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Endless Iii General Partner Llp", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SO303405"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SO303405", "uri": "https://opencorporates.com/companies/gb/SO303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "So303405"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92e2e67e4ebf34025dd8e", "uri": "http://register.openownership.org/entities/59b92e2e67e4ebf34025dd8e"}], "foundingDate": "2011-06-21", "addresses": [{"type": "registered", "address": "50, Lothian Road, Edinburgh, EH3 9WJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-1820076799963233079",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BANNER GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05510758"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05510758"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05510758"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05510758",
+                "uri": "https://opencorporates.com/companies/gb/05510758"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05510758"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee12",
+                "uri": "http://register.openownership.org/entities/59b92b0167e4ebf34015ee12"
+            }
+        ],
+        "foundingDate": "2005-07-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "K House, Sheffield Business Park, Europa Link, Sheffield, S9 1XU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17829939612884066837",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1820076799963233079"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3722734699986348582"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14656002078852184030",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1820076799963233079"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3068926442300694163"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10081729829104525204",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1820076799963233079"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6399471097175949483"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9488899758103536544",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1820076799963233079"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1073939460253575989"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3722734699986348582",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ENDLESS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC316569"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC316569",
+                "uri": "https://opencorporates.com/companies/gb/OC316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc316569"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91c2d67e4ebf340dbe3e6",
+                "uri": "http://register.openownership.org/entities/59b91c2d67e4ebf340dbe3e6"
+            }
+        ],
+        "foundingDate": "2005-12-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3 Whitehall Quay, Leeds, West Yorkshire, LS1 4BF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6399471097175949483",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ENDLESS II (GP) LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO304712"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SO304712",
+                "uri": "https://opencorporates.com/companies/gb/SO304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So304712"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e2e67e4ebf34025def5",
+                "uri": "http://register.openownership.org/entities/59b92e2e67e4ebf34025def5"
+            }
+        ],
+        "foundingDate": "2013-12-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "50 Lothian Road, Festival Square, Edinburgh, EH3 9WJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3068926442300694163",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EVO GROUP SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06257099",
+                "uri": "https://opencorporates.com/companies/gb/06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06257099"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b0267e4ebf34015f3cd",
+                "uri": "http://register.openownership.org/entities/59b92b0267e4ebf34015f3cd"
+            }
+        ],
+        "foundingDate": "2007-05-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "K House, Sheffield Business Park, Europa  Link, Sheffield, S9 1XU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1073939460253575989",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Endless Iii General Partner Llp",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SO303405"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SO303405",
+                "uri": "https://opencorporates.com/companies/gb/SO303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "So303405"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92e2e67e4ebf34025dd8e",
+                "uri": "http://register.openownership.org/entities/59b92e2e67e4ebf34025dd8e"
+            }
+        ],
+        "foundingDate": "2011-06-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "50, Lothian Road, Edinburgh, EH3 9WJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05577806_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05577806_bods.json
@@ -1,1 +1,139 @@
-[{"statementID": "openownership-register-4413437610415782795", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NEXUS FOSTERING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05577806"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05577806", "uri": "https://opencorporates.com/companies/gb/05577806"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4f74d67e4ebf34049fa3d", "uri": "http://register.openownership.org/entities/59c4f74d67e4ebf34049fa3d"}], "foundingDate": "2005-09-29", "addresses": [{"type": "registered", "address": "4 Jardine House, Harrovian Business Village Bessborough Road, Harrow, Middlesex, HA1 3EX", "country": "GB"}]}, {"statementID": "openownership-register-4541335789004652537", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-29", "subject": {"describedByEntityStatement": "openownership-register-4413437610415782795"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6140174103831590722"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-29"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-29"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-09-29"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6140174103831590722", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BSN SOCIAL CARE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09092445", "uri": "https://opencorporates.com/companies/gb/09092445"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09092445"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e", "uri": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e"}], "foundingDate": "2014-06-19", "addresses": [{"type": "registered", "address": "4 Jardine House Harrovian Business Village, Bessborough Road, Harrow, HA1 3EX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4413437610415782795",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NEXUS FOSTERING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05577806"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05577806",
+                "uri": "https://opencorporates.com/companies/gb/05577806"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4f74d67e4ebf34049fa3d",
+                "uri": "http://register.openownership.org/entities/59c4f74d67e4ebf34049fa3d"
+            }
+        ],
+        "foundingDate": "2005-09-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4 Jardine House, Harrovian Business Village Bessborough Road, Harrow, Middlesex, HA1 3EX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4541335789004652537",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-29",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4413437610415782795"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6140174103831590722"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-29"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-29"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-09-29"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6140174103831590722",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BSN SOCIAL CARE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09092445",
+                "uri": "https://opencorporates.com/companies/gb/09092445"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09092445"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e",
+                "uri": "http://register.openownership.org/entities/5ab9c9df9dfc3fae18afa19e"
+            }
+        ],
+        "foundingDate": "2014-06-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "4 Jardine House Harrovian Business Village, Bessborough Road, Harrow, HA1 3EX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05594095_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05594095_bods.json
@@ -1,1 +1,144 @@
-[{"statementID": "openownership-register-6895601544353152836", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RIDER LEVETT BUCKNALL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05594095"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05594095", "uri": "https://opencorporates.com/companies/gb/05594095"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b952cf67e4ebf340cced52", "uri": "http://register.openownership.org/entities/59b952cf67e4ebf340cced52"}], "foundingDate": "2005-10-17", "addresses": [{"type": "registered", "address": "One Eleven, Edmund Street, Birmingham, West Midlands, B3 2HJ", "country": "GB"}]}, {"statementID": "openownership-register-2091324655630885197", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-6895601544353152836"}, "interestedParty": {"describedByEntityStatement": "openownership-register-7250669306693762252"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7250669306693762252", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RIDER LEVETT BUCKNALL UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04653580"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04653580", "uri": "https://opencorporates.com/companies/gb/04653580"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa", "uri": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa"}], "foundingDate": "2003-01-31", "addresses": [{"type": "registered", "address": "15 Colmore Row, Birmingham, West Midlands, B3 2BH", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-6895601544353152836",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RIDER LEVETT BUCKNALL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05594095"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05594095",
+                "uri": "https://opencorporates.com/companies/gb/05594095"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b952cf67e4ebf340cced52",
+                "uri": "http://register.openownership.org/entities/59b952cf67e4ebf340cced52"
+            }
+        ],
+        "foundingDate": "2005-10-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Eleven, Edmund Street, Birmingham, West Midlands, B3 2HJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2091324655630885197",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6895601544353152836"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-7250669306693762252"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7250669306693762252",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RIDER LEVETT BUCKNALL UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04653580"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04653580",
+                "uri": "https://opencorporates.com/companies/gb/04653580"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa",
+                "uri": "http://register.openownership.org/entities/59b9339a67e4ebf340400baa"
+            }
+        ],
+        "foundingDate": "2003-01-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "15 Colmore Row, Birmingham, West Midlands, B3 2BH",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05613767_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05613767_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-11488261060142652714", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "P.R.P. & SON DEVELOPMENTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05613767"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05613767", "uri": "https://opencorporates.com/companies/gb/05613767"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9785267e4ebf34082693f", "uri": "http://register.openownership.org/entities/59b9785267e4ebf34082693f"}], "foundingDate": "2005-11-07", "addresses": [{"type": "registered", "address": "15 Palmers Avenue, Grays, Essex, RM17 5TX", "country": "GB"}]}, {"statementID": "openownership-register-3038805515985707653", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-07", "subject": {"describedByEntityStatement": "openownership-register-11488261060142652714"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13746621820104433964"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-11-07"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13746621820104433964", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter Raymond Pledger"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05613767/persons-with-significant-control/individual/3nQLlYqDEUQsXhHHcCCIanFyZkI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9785267e4ebf34082694b", "uri": "http://register.openownership.org/entities/59b9785267e4ebf34082694b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-03-01", "addresses": [{"address": "15, Palmers Avenue, Grays, Essex, RM17 5TX"}]}]
+[
+    {
+        "statementID": "openownership-register-11488261060142652714",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "P.R.P. & SON DEVELOPMENTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05613767"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05613767",
+                "uri": "https://opencorporates.com/companies/gb/05613767"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9785267e4ebf34082693f",
+                "uri": "http://register.openownership.org/entities/59b9785267e4ebf34082693f"
+            }
+        ],
+        "foundingDate": "2005-11-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "15 Palmers Avenue, Grays, Essex, RM17 5TX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3038805515985707653",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-07",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11488261060142652714"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13746621820104433964"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-07"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13746621820104433964",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter Raymond Pledger"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05613767/persons-with-significant-control/individual/3nQLlYqDEUQsXhHHcCCIanFyZkI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9785267e4ebf34082694b",
+                "uri": "http://register.openownership.org/entities/59b9785267e4ebf34082694b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-03-01",
+        "addresses": [
+            {
+                "address": "15, Palmers Avenue, Grays, Essex, RM17 5TX"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05618803_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05618803_bods.json
@@ -1,1 +1,109 @@
-[{"statementID": "openownership-register-14020603430468015462", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ORACLE CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05618803"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05618803", "uri": "https://opencorporates.com/companies/gb/05618803"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95aff67e4ebf340f2d86b", "uri": "http://register.openownership.org/entities/59b95aff67e4ebf340f2d86b"}], "foundingDate": "2005-11-10", "addresses": [{"type": "registered", "address": "Unit 54 Wrest Park, Silsoe, Bedford, MK45 4HS", "country": "GB"}]}, {"statementID": "openownership-register-4981780269160477074", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14020603430468015462"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11856654556653757235"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11856654556653757235", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ORACLE CARE AND EDUCATION HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07822510"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07822510"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07822510", "uri": "https://opencorporates.com/companies/gb/07822510"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b953eb67e4ebf340d1d3d2", "uri": "http://register.openownership.org/entities/59b953eb67e4ebf340d1d3d2"}], "foundingDate": "2011-10-25", "addresses": [{"type": "registered", "address": "Unit 54 Wrest Park, Silsoe, Bedford, MK45 4HS", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14020603430468015462",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ORACLE CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05618803"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05618803",
+                "uri": "https://opencorporates.com/companies/gb/05618803"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95aff67e4ebf340f2d86b",
+                "uri": "http://register.openownership.org/entities/59b95aff67e4ebf340f2d86b"
+            }
+        ],
+        "foundingDate": "2005-11-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 54 Wrest Park, Silsoe, Bedford, MK45 4HS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4981780269160477074",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14020603430468015462"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11856654556653757235"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11856654556653757235",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ORACLE CARE AND EDUCATION HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07822510"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07822510"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07822510",
+                "uri": "https://opencorporates.com/companies/gb/07822510"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b953eb67e4ebf340d1d3d2",
+                "uri": "http://register.openownership.org/entities/59b953eb67e4ebf340d1d3d2"
+            }
+        ],
+        "foundingDate": "2011-10-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 54 Wrest Park, Silsoe, Bedford, MK45 4HS",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05650995_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05650995_bods.json
@@ -1,1 +1,331 @@
-[{"statementID": "openownership-register-17185923218869641433", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "G F TOMLINSON BIRMINGHAM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05650995"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05650995", "uri": "https://opencorporates.com/companies/gb/05650995"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96c7767e4ebf34047ad25", "uri": "http://register.openownership.org/entities/59b96c7767e4ebf34047ad25"}], "foundingDate": "2005-12-12", "addresses": [{"type": "registered", "address": "Tomlinson House Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR", "country": "GB"}]}, {"statementID": "openownership-register-12925916066289398155", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17185923218869641433"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6361268595778175410"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06", "endDate": "2019-05-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5459418723421579172", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17185923218869641433"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4912481543414990493"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4782577933145099989", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17185923218869641433"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17458964582270695001"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17458964582270695001", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "G.F.TOMLINSON GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00233721"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00233721", "uri": "https://opencorporates.com/companies/gb/00233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "233721"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9313d67e4ebf34033f9e5", "uri": "http://register.openownership.org/entities/59b9313d67e4ebf34033f9e5"}], "foundingDate": "1928-10-01", "addresses": [{"type": "registered", "address": "Tomlinson House Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR", "country": "GB"}]}, {"statementID": "openownership-register-6361268595778175410", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Barry Edward Sewards"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/00233721/persons-with-significant-control/individual/qWukhXcqJRxcBB8WZeYDSwYp2U8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9414367e4ebf3407f0152", "uri": "http://register.openownership.org/entities/59b9414367e4ebf3407f0152"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1937-09-01", "addresses": [{"address": "Tomlinson House, Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR", "country": "GB"}]}, {"statementID": "openownership-register-4912481543414990493", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew James Spencer Sewards"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/02332956/persons-with-significant-control/individual/O0LiJDlSd6fqRZG22E3mhdCLMgY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9418267e4ebf340801393", "uri": "http://register.openownership.org/entities/59b9418267e4ebf340801393"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-07-01", "addresses": [{"address": "Tomlinson House, Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR"}]}]
+[
+    {
+        "statementID": "openownership-register-17185923218869641433",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "G F TOMLINSON BIRMINGHAM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05650995"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05650995",
+                "uri": "https://opencorporates.com/companies/gb/05650995"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96c7767e4ebf34047ad25",
+                "uri": "http://register.openownership.org/entities/59b96c7767e4ebf34047ad25"
+            }
+        ],
+        "foundingDate": "2005-12-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Tomlinson House Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12925916066289398155",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17185923218869641433"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6361268595778175410"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06",
+                "endDate": "2019-05-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5459418723421579172",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17185923218869641433"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4912481543414990493"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4782577933145099989",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17185923218869641433"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17458964582270695001"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17458964582270695001",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "G.F.TOMLINSON GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00233721"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00233721",
+                "uri": "https://opencorporates.com/companies/gb/00233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "233721"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9313d67e4ebf34033f9e5",
+                "uri": "http://register.openownership.org/entities/59b9313d67e4ebf34033f9e5"
+            }
+        ],
+        "foundingDate": "1928-10-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Tomlinson House Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6361268595778175410",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Barry Edward Sewards"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/00233721/persons-with-significant-control/individual/qWukhXcqJRxcBB8WZeYDSwYp2U8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9414367e4ebf3407f0152",
+                "uri": "http://register.openownership.org/entities/59b9414367e4ebf3407f0152"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1937-09-01",
+        "addresses": [
+            {
+                "address": "Tomlinson House, Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4912481543414990493",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew James Spencer Sewards"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/02332956/persons-with-significant-control/individual/O0LiJDlSd6fqRZG22E3mhdCLMgY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9418267e4ebf340801393",
+                "uri": "http://register.openownership.org/entities/59b9418267e4ebf340801393"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-07-01",
+        "addresses": [
+            {
+                "address": "Tomlinson House, Duffield Road, Little Eaton, Derby, Derbyshire, DE21 5DR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05722765_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05722765_bods.json
@@ -1,1 +1,427 @@
-[{"statementID": "openownership-register-4020737607985592637", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PEOPLEPLUS GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05722765"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05722765", "uri": "https://opencorporates.com/companies/gb/05722765"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b945bf67e4ebf340912fb4", "uri": "http://register.openownership.org/entities/59b945bf67e4ebf340912fb4"}], "foundingDate": "2006-02-27", "addresses": [{"type": "registered", "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE", "country": "GB"}]}, {"statementID": "openownership-register-6609928074984964513", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4020737607985592637"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4799344139887549624"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-27"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2986836236047927840", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4020737607985592637"}, "interestedParty": {"describedByEntityStatement": "openownership-register-10447683429083546740"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06", "endDate": "2018-09-27"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-04-06", "endDate": "2018-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2018-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-trust", "startDate": "2016-04-06", "endDate": "2018-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-04-06", "endDate": "2018-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14535329282059599883", "statementType": "ownershipOrControlStatement", "statementDate": "2018-09-27", "subject": {"describedByEntityStatement": "openownership-register-4020737607985592637"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17273001065795339376"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-27"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2018-09-27"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2018-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17273001065795339376", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STAFFLINE GROUP PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05268636", "uri": "https://opencorporates.com/companies/gb/05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05268636"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92fff67e4ebf3402f2be8", "uri": "http://register.openownership.org/entities/59b92fff67e4ebf3402f2be8"}], "foundingDate": "2004-10-25", "addresses": [{"type": "registered", "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE", "country": "GB"}]}, {"statementID": "openownership-register-4799344139887549624", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BROOMCO (4198) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07029342"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07029342"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07029342", "uri": "https://opencorporates.com/companies/gb/07029342"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e6f67e4ebf3407241d7", "uri": "http://register.openownership.org/entities/59b93e6f67e4ebf3407241d7"}], "foundingDate": "2009-09-24", "addresses": [{"type": "registered", "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE", "country": "GB"}]}, {"statementID": "openownership-register-10447683429083546740", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STAFFLINE HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09033366"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09033366"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09033366"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09033366", "uri": "https://opencorporates.com/companies/gb/09033366"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93e7067e4ebf3407246f8", "uri": "http://register.openownership.org/entities/59b93e7067e4ebf3407246f8"}], "foundingDate": "2014-05-09", "addresses": [{"type": "registered", "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4020737607985592637",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PEOPLEPLUS GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05722765"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05722765",
+                "uri": "https://opencorporates.com/companies/gb/05722765"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b945bf67e4ebf340912fb4",
+                "uri": "http://register.openownership.org/entities/59b945bf67e4ebf340912fb4"
+            }
+        ],
+        "foundingDate": "2006-02-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6609928074984964513",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4020737607985592637"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4799344139887549624"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2986836236047927840",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4020737607985592637"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-10447683429083546740"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-trust",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-04-06",
+                "endDate": "2018-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14535329282059599883",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4020737607985592637"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17273001065795339376"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2018-09-27"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2018-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17273001065795339376",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STAFFLINE GROUP PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05268636",
+                "uri": "https://opencorporates.com/companies/gb/05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05268636"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92fff67e4ebf3402f2be8",
+                "uri": "http://register.openownership.org/entities/59b92fff67e4ebf3402f2be8"
+            }
+        ],
+        "foundingDate": "2004-10-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4799344139887549624",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BROOMCO (4198) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07029342"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07029342"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07029342",
+                "uri": "https://opencorporates.com/companies/gb/07029342"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e6f67e4ebf3407241d7",
+                "uri": "http://register.openownership.org/entities/59b93e6f67e4ebf3407241d7"
+            }
+        ],
+        "foundingDate": "2009-09-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10447683429083546740",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STAFFLINE HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09033366"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09033366"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09033366"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09033366",
+                "uri": "https://opencorporates.com/companies/gb/09033366"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93e7067e4ebf3407246f8",
+                "uri": "http://register.openownership.org/entities/59b93e7067e4ebf3407246f8"
+            }
+        ],
+        "foundingDate": "2014-05-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19-20 The Triangle, Ng2 Business Park, Nottingham, NG2 1AE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05831231_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05831231_bods.json
@@ -1,1 +1,474 @@
-[{"statementID": "openownership-register-17136917053803371053", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "QUADRANT SECURITY GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05831231"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05831231", "uri": "https://opencorporates.com/companies/gb/05831231"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cc8967e4ebf340c93a8a", "uri": "http://register.openownership.org/entities/59b9cc8967e4ebf340c93a8a"}], "foundingDate": "2006-05-30", "addresses": [{"type": "registered", "address": "3 Attenborough Lane, Chilwell, Nottingham, NG9 5JN", "country": "GB"}]}, {"statementID": "openownership-register-17798128572229928760", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-17136917053803371053"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13940504365112918790"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13940504365112918790", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SYNECTICS PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/01740011", "uri": "https://opencorporates.com/companies/gb/01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "1740011"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "01740011"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9241967e4ebf340f84209", "uri": "http://register.openownership.org/entities/59b9241967e4ebf340f84209"}], "foundingDate": "1983-07-15", "addresses": [{"type": "registered", "address": "Synectics House, 3-4 Broadfield Close, Sheffield, S8 0XN", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17136917053803371053",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "QUADRANT SECURITY GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05831231"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05831231",
+                "uri": "https://opencorporates.com/companies/gb/05831231"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cc8967e4ebf340c93a8a",
+                "uri": "http://register.openownership.org/entities/59b9cc8967e4ebf340c93a8a"
+            }
+        ],
+        "foundingDate": "2006-05-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "3 Attenborough Lane, Chilwell, Nottingham, NG9 5JN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17798128572229928760",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17136917053803371053"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13940504365112918790"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13940504365112918790",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SYNECTICS PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/01740011",
+                "uri": "https://opencorporates.com/companies/gb/01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "1740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "01740011"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9241967e4ebf340f84209",
+                "uri": "http://register.openownership.org/entities/59b9241967e4ebf340f84209"
+            }
+        ],
+        "foundingDate": "1983-07-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Synectics House, 3-4 Broadfield Close, Sheffield, S8 0XN",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05856000_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05856000_bods.json
@@ -1,1 +1,200 @@
-[{"statementID": "openownership-register-14372273333837368068", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BEDSPACE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05856000"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05856000", "uri": "https://opencorporates.com/companies/gb/05856000"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d41667e4ebf340e53d62", "uri": "http://register.openownership.org/entities/59b9d41667e4ebf340e53d62"}], "foundingDate": "2006-06-23", "addresses": [{"type": "registered", "address": "473 Chester Road, Trafford, Trafford, Manchester, M16 9HF", "country": "GB"}]}, {"statementID": "openownership-register-8437669506984386577", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14372273333837368068"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17833433035835480236"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-09-16"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-09-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14230183576543159387", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-16", "subject": {"describedByEntityStatement": "openownership-register-14372273333837368068"}, "interestedParty": {"describedByEntityStatement": "openownership-register-8725159134679543874"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-16"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8725159134679543874", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BEDSPACE RESOURCE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "04457083"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "04457083"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/04457083", "uri": "https://opencorporates.com/companies/gb/04457083"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cf6e67e4ebf340d3b95a", "uri": "http://register.openownership.org/entities/59b9cf6e67e4ebf340d3b95a"}], "foundingDate": "2002-06-07", "addresses": [{"type": "registered", "address": "473 Chester Road, Trafford, Manchester, M16 9HF", "country": "GB"}]}, {"statementID": "openownership-register-17833433035835480236", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Russell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08004493/persons-with-significant-control/individual/z5fe678NnFVQs3VFoGODDOlhCaM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9aa8d67e4ebf34047cbb6", "uri": "http://register.openownership.org/entities/59b9aa8d67e4ebf34047cbb6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1946-03-01", "addresses": [{"address": "27 Ingol Gardens, Hambleton, Poulton Le Fylde, Lancashire, FY6 9AY", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14372273333837368068",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BEDSPACE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05856000"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05856000",
+                "uri": "https://opencorporates.com/companies/gb/05856000"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d41667e4ebf340e53d62",
+                "uri": "http://register.openownership.org/entities/59b9d41667e4ebf340e53d62"
+            }
+        ],
+        "foundingDate": "2006-06-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "473 Chester Road, Trafford, Trafford, Manchester, M16 9HF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8437669506984386577",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14372273333837368068"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17833433035835480236"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-09-16"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-09-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14230183576543159387",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-16",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14372273333837368068"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-8725159134679543874"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-16"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8725159134679543874",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BEDSPACE RESOURCE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04457083"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "04457083"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/04457083",
+                "uri": "https://opencorporates.com/companies/gb/04457083"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cf6e67e4ebf340d3b95a",
+                "uri": "http://register.openownership.org/entities/59b9cf6e67e4ebf340d3b95a"
+            }
+        ],
+        "foundingDate": "2002-06-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "473 Chester Road, Trafford, Manchester, M16 9HF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17833433035835480236",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Russell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08004493/persons-with-significant-control/individual/z5fe678NnFVQs3VFoGODDOlhCaM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9aa8d67e4ebf34047cbb6",
+                "uri": "http://register.openownership.org/entities/59b9aa8d67e4ebf34047cbb6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1946-03-01",
+        "addresses": [
+            {
+                "address": "27 Ingol Gardens, Hambleton, Poulton Le Fylde, Lancashire, FY6 9AY",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05882567_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05882567_bods.json
@@ -1,1 +1,243 @@
-[{"statementID": "openownership-register-1144903274361503864", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TCL GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05882567"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05882567", "uri": "https://opencorporates.com/companies/gb/05882567"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05882567"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93eea67e4ebf3407462a2", "uri": "http://register.openownership.org/entities/59b93eea67e4ebf3407462a2"}], "foundingDate": "2006-07-20", "addresses": [{"type": "registered", "address": "1 Appold Street, London, EC2A 2UT", "country": "GB"}]}, {"statementID": "openownership-register-4229929551285028010", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-27", "subject": {"describedByEntityStatement": "openownership-register-1144903274361503864"}, "interestedParty": {"describedByEntityStatement": "openownership-register-805712728227963687"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-27"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12819126615236972332", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-19", "subject": {"describedByEntityStatement": "openownership-register-1144903274361503864"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4539711674459698481"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-07-19", "endDate": "2016-09-27"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-07-19", "endDate": "2016-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-19", "endDate": "2016-09-27"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-07-19", "endDate": "2016-09-27"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-07-19", "endDate": "2016-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-805712728227963687", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JUPITER HOLDCO LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10238811"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10238811"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10238811"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10238811", "uri": "https://opencorporates.com/companies/gb/10238811"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10238811"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10238811"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b16fe819dfc3fae18d8ab32", "uri": "http://register.openownership.org/entities/5b16fe819dfc3fae18d8ab32"}], "foundingDate": "2016-06-17", "addresses": [{"type": "registered", "address": "Charta House, 30-38 Church Street, Staines-Upon-Thames, Middlesex, TW18 4EP", "country": "GB"}]}, {"statementID": "openownership-register-4539711674459698481", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ayal Zylberman"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/05882567/persons-with-significant-control/individual/mPcdejwLFbTf6hl5E6GmH-4arc4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93eea67e4ebf3407462ad", "uri": "http://register.openownership.org/entities/59b93eea67e4ebf3407462ad"}], "nationalities": [{"name": "Israel", "code": "IL"}], "birthDate": "1975-04-01", "addresses": [{"address": "Charta House, 30-38 Church Street, Staines-Upon-Thames, Middlesex, TW18 4EP", "country": "IL"}]}]
+[
+    {
+        "statementID": "openownership-register-1144903274361503864",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TCL GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05882567"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05882567",
+                "uri": "https://opencorporates.com/companies/gb/05882567"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05882567"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93eea67e4ebf3407462a2",
+                "uri": "http://register.openownership.org/entities/59b93eea67e4ebf3407462a2"
+            }
+        ],
+        "foundingDate": "2006-07-20",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Appold Street, London, EC2A 2UT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4229929551285028010",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1144903274361503864"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-805712728227963687"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12819126615236972332",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1144903274361503864"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4539711674459698481"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-07-19",
+                "endDate": "2016-09-27"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-07-19",
+                "endDate": "2016-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-19",
+                "endDate": "2016-09-27"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-07-19",
+                "endDate": "2016-09-27"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-07-19",
+                "endDate": "2016-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-805712728227963687",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JUPITER HOLDCO LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10238811"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10238811"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10238811"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10238811",
+                "uri": "https://opencorporates.com/companies/gb/10238811"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10238811"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10238811"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b16fe819dfc3fae18d8ab32",
+                "uri": "http://register.openownership.org/entities/5b16fe819dfc3fae18d8ab32"
+            }
+        ],
+        "foundingDate": "2016-06-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Charta House, 30-38 Church Street, Staines-Upon-Thames, Middlesex, TW18 4EP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4539711674459698481",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ayal Zylberman"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/05882567/persons-with-significant-control/individual/mPcdejwLFbTf6hl5E6GmH-4arc4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93eea67e4ebf3407462ad",
+                "uri": "http://register.openownership.org/entities/59b93eea67e4ebf3407462ad"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Israel",
+                "code": "IL"
+            }
+        ],
+        "birthDate": "1975-04-01",
+        "addresses": [
+            {
+                "address": "Charta House, 30-38 Church Street, Staines-Upon-Thames, Middlesex, TW18 4EP",
+                "country": "IL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05983117_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_05983117_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-13775766143871873130", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SILVER BIRCH CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05983117"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05983117", "uri": "https://opencorporates.com/companies/gb/05983117"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95dd467e4ebf34000b4c0", "uri": "http://register.openownership.org/entities/59b95dd467e4ebf34000b4c0"}], "foundingDate": "2006-10-31", "addresses": [{"type": "registered", "address": "212 Ballards Lane, Sbch House, London, N3 2LX", "country": "GB"}]}, {"statementID": "openownership-register-17791442531508591224", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-23", "subject": {"describedByEntityStatement": "openownership-register-13775766143871873130"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17504636547038910440"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-17504636547038910440", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SILVER BIRCH CARE (HOLDINGS) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09049900"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09049900"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09049900", "uri": "https://opencorporates.com/companies/gb/09049900"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09049900"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "09049900"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95dd567e4ebf34000b78d", "uri": "http://register.openownership.org/entities/59b95dd567e4ebf34000b78d"}], "foundingDate": "2014-05-21", "addresses": [{"type": "registered", "address": "212 Ballards Lane, Sbch House, London, N3 2LX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13775766143871873130",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SILVER BIRCH CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05983117"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05983117",
+                "uri": "https://opencorporates.com/companies/gb/05983117"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95dd467e4ebf34000b4c0",
+                "uri": "http://register.openownership.org/entities/59b95dd467e4ebf34000b4c0"
+            }
+        ],
+        "foundingDate": "2006-10-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "212 Ballards Lane, Sbch House, London, N3 2LX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17791442531508591224",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13775766143871873130"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17504636547038910440"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17504636547038910440",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SILVER BIRCH CARE (HOLDINGS) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09049900"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09049900"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09049900",
+                "uri": "https://opencorporates.com/companies/gb/09049900"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09049900"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09049900"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95dd567e4ebf34000b78d",
+                "uri": "http://register.openownership.org/entities/59b95dd567e4ebf34000b78d"
+            }
+        ],
+        "foundingDate": "2014-05-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "212 Ballards Lane, Sbch House, London, N3 2LX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06129256_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06129256_bods.json
@@ -1,1 +1,104 @@
-[{"statementID": "openownership-register-17537337472726483550", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RAPID IMPROVEMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06129256"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06129256", "uri": "https://opencorporates.com/companies/gb/06129256"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9929c67e4ebf340f11ce6", "uri": "http://register.openownership.org/entities/59b9929c67e4ebf340f11ce6"}], "foundingDate": "2007-02-27", "addresses": [{"type": "registered", "address": "34-38 Upper Green East, Mitcham, CR4 2PB", "country": "GB"}]}, {"statementID": "openownership-register-17212505598105927345", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-27", "subject": {"describedByEntityStatement": "openownership-register-17537337472726483550"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9016991444604656251"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-02-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9016991444604656251", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Isaac Kofi Dweben"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06129256/persons-with-significant-control/individual/3SjVX_ZQtyMHmyhgfCFL0kK98IM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9929c67e4ebf340f11cf9", "uri": "http://register.openownership.org/entities/59b9929c67e4ebf340f11cf9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-01-01", "addresses": [{"address": "34-38, Upper Green East, Mitcham, CR4 2PB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-17537337472726483550",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RAPID IMPROVEMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06129256"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06129256",
+                "uri": "https://opencorporates.com/companies/gb/06129256"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9929c67e4ebf340f11ce6",
+                "uri": "http://register.openownership.org/entities/59b9929c67e4ebf340f11ce6"
+            }
+        ],
+        "foundingDate": "2007-02-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "34-38 Upper Green East, Mitcham, CR4 2PB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17212505598105927345",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17537337472726483550"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9016991444604656251"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-02-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9016991444604656251",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Isaac Kofi Dweben"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06129256/persons-with-significant-control/individual/3SjVX_ZQtyMHmyhgfCFL0kK98IM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9929c67e4ebf340f11cf9",
+                "uri": "http://register.openownership.org/entities/59b9929c67e4ebf340f11cf9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-01-01",
+        "addresses": [
+            {
+                "address": "34-38, Upper Green East, Mitcham, CR4 2PB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06207784_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06207784_bods.json
@@ -1,1 +1,211 @@
-[{"statementID": "openownership-register-8668426368769036793", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "D A LANGUAGES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06207784"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06207784", "uri": "https://opencorporates.com/companies/gb/06207784"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038a8", "uri": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038a8"}], "foundingDate": "2007-04-10", "addresses": [{"type": "registered", "address": "Suite 4a Statham House Talbot Road, Stretford, Manchester, M32 0FP", "country": "GB"}]}, {"statementID": "openownership-register-330937457296850624", "statementType": "ownershipOrControlStatement", "statementDate": "2018-05-16", "subject": {"describedByEntityStatement": "openownership-register-8668426368769036793"}, "interestedParty": {"describedByEntityStatement": "openownership-register-153154129814381560"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-05-16"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-05-16"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-05-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6012459064468283133", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-8668426368769036793"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17317722330795482091"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01", "endDate": "2018-05-16"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-07-01", "endDate": "2018-05-16"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01", "endDate": "2018-05-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17317722330795482091", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Actar Arya"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06207784/persons-with-significant-control/individual/julJHjAbx9EAdYPUbT5xMcDkNGQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038af", "uri": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038af"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-01-01", "addresses": [{"address": "34, Ashley Road, Altrincham, WA14 2DW", "country": "GB"}]}, {"statementID": "openownership-register-153154129814381560", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "D A LANGUAGES HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11260547"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "11260547"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11260547", "uri": "https://opencorporates.com/companies/gb/11260547"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab99c4f9dfc3fae18390e36", "uri": "http://register.openownership.org/entities/5ab99c4f9dfc3fae18390e36"}], "foundingDate": "2018-03-16", "addresses": [{"type": "registered", "address": "Suite 4a Statham House Talbot Road, Stretford, Manchester, M32 0FP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8668426368769036793",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "D A LANGUAGES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06207784"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06207784",
+                "uri": "https://opencorporates.com/companies/gb/06207784"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038a8",
+                "uri": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038a8"
+            }
+        ],
+        "foundingDate": "2007-04-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Suite 4a Statham House Talbot Road, Stretford, Manchester, M32 0FP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-330937457296850624",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-05-16",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8668426368769036793"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-153154129814381560"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-05-16"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-05-16"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-05-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6012459064468283133",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8668426368769036793"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17317722330795482091"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01",
+                "endDate": "2018-05-16"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01",
+                "endDate": "2018-05-16"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01",
+                "endDate": "2018-05-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17317722330795482091",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Actar Arya"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06207784/persons-with-significant-control/individual/julJHjAbx9EAdYPUbT5xMcDkNGQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038af",
+                "uri": "http://register.openownership.org/entities/59b9bd6467e4ebf3409038af"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-01-01",
+        "addresses": [
+            {
+                "address": "34, Ashley Road, Altrincham, WA14 2DW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-153154129814381560",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "D A LANGUAGES HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11260547"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11260547"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11260547",
+                "uri": "https://opencorporates.com/companies/gb/11260547"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab99c4f9dfc3fae18390e36",
+                "uri": "http://register.openownership.org/entities/5ab99c4f9dfc3fae18390e36"
+            }
+        ],
+        "foundingDate": "2018-03-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Suite 4a Statham House Talbot Road, Stretford, Manchester, M32 0FP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06262204_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06262204_bods.json
@@ -1,1 +1,97 @@
-[{"statementID": "openownership-register-7083851520667872086", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DOLPHIN LIFTS MIDLANDS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06262204"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06262204", "uri": "https://opencorporates.com/companies/gb/06262204"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d82d67e4ebf340f2ecde", "uri": "http://register.openownership.org/entities/59b9d82d67e4ebf340f2ecde"}], "foundingDate": "2007-05-30", "addresses": [{"type": "registered", "address": "Unit 2 Vaughan Trading Estate, Sedgley Road East, Tipton, DY4 7UJ", "country": "GB"}]}, {"statementID": "openownership-register-16281840918440037993", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7083851520667872086"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15820863554109084214"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-15820863554109084214", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Norman Heinze Farrington"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07887341/persons-with-significant-control/individual/-Tlju0wuQZOk5ypVgkxgFY70gJM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97bee67e4ebf34094a87f", "uri": "http://register.openownership.org/entities/59b97bee67e4ebf34094a87f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1949-11-01", "addresses": [{"address": "196, Oldbury Road, West Bromwich, West Midlands, B70 9DT"}]}]
+[
+    {
+        "statementID": "openownership-register-7083851520667872086",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DOLPHIN LIFTS MIDLANDS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06262204"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06262204",
+                "uri": "https://opencorporates.com/companies/gb/06262204"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d82d67e4ebf340f2ecde",
+                "uri": "http://register.openownership.org/entities/59b9d82d67e4ebf340f2ecde"
+            }
+        ],
+        "foundingDate": "2007-05-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 2 Vaughan Trading Estate, Sedgley Road East, Tipton, DY4 7UJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16281840918440037993",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7083851520667872086"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15820863554109084214"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15820863554109084214",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Norman Heinze Farrington"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07887341/persons-with-significant-control/individual/-Tlju0wuQZOk5ypVgkxgFY70gJM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97bee67e4ebf34094a87f",
+                "uri": "http://register.openownership.org/entities/59b97bee67e4ebf34094a87f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1949-11-01",
+        "addresses": [
+            {
+                "address": "196, Oldbury Road, West Bromwich, West Midlands, B70 9DT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06291076_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06291076_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-7589789291810974457", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ACKLAM'S COACHES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06291076"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06291076", "uri": "https://opencorporates.com/companies/gb/06291076"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d78767e4ebf340f0adc0", "uri": "http://register.openownership.org/entities/59b9d78767e4ebf340f0adc0"}], "foundingDate": "2007-06-25", "addresses": [{"type": "registered", "address": "Barmston Close, Swinemoor Lane, Beverley, East Yorkshire, HU17 0LA", "country": "GB"}]}, {"statementID": "openownership-register-14657933451749663601", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7589789291810974457"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11334713963275452489"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11334713963275452489", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ACKLAMS PROPERTIES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06166907"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06166907"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06166907"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06166907", "uri": "https://opencorporates.com/companies/gb/06166907"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93f6f67e4ebf34076a4a2", "uri": "http://register.openownership.org/entities/59b93f6f67e4ebf34076a4a2"}], "foundingDate": "2007-03-19", "addresses": [{"type": "registered", "address": "Barmston Close, Swinemoor Lane, Beverley, East Yorkshire, HU17 0LA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-7589789291810974457",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ACKLAM'S COACHES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06291076"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06291076",
+                "uri": "https://opencorporates.com/companies/gb/06291076"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d78767e4ebf340f0adc0",
+                "uri": "http://register.openownership.org/entities/59b9d78767e4ebf340f0adc0"
+            }
+        ],
+        "foundingDate": "2007-06-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Barmston Close, Swinemoor Lane, Beverley, East Yorkshire, HU17 0LA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14657933451749663601",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7589789291810974457"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11334713963275452489"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11334713963275452489",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ACKLAMS PROPERTIES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06166907"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06166907"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06166907"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06166907",
+                "uri": "https://opencorporates.com/companies/gb/06166907"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93f6f67e4ebf34076a4a2",
+                "uri": "http://register.openownership.org/entities/59b93f6f67e4ebf34076a4a2"
+            }
+        ],
+        "foundingDate": "2007-03-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Barmston Close, Swinemoor Lane, Beverley, East Yorkshire, HU17 0LA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06314620_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06314620_bods.json
@@ -1,1 +1,165 @@
-[{"statementID": "openownership-register-9456767331982698190", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HEALTH ASSURED LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06314620"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06314620", "uri": "https://opencorporates.com/companies/gb/06314620"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9be6f67e4ebf340944a74", "uri": "http://register.openownership.org/entities/59b9be6f67e4ebf340944a74"}], "foundingDate": "2007-07-16", "addresses": [{"type": "registered", "address": "The Peninsula, Victoria Place, Manchester, M4 4FB", "country": "GB"}]}, {"statementID": "openownership-register-7628928499762988910", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9456767331982698190"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11732976043762694189"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11732976043762694189", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PENINSULA BUSINESS SERVICES GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02567996"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02567996", "uri": "https://opencorporates.com/companies/gb/02567996"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91a9b67e4ebf340d6a7d1", "uri": "http://register.openownership.org/entities/59b91a9b67e4ebf340d6a7d1"}], "foundingDate": "1990-12-12", "addresses": [{"type": "registered", "address": "The Peninsula, Victoria Place, Manchester, M4 4FB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9456767331982698190",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HEALTH ASSURED LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06314620"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06314620",
+                "uri": "https://opencorporates.com/companies/gb/06314620"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9be6f67e4ebf340944a74",
+                "uri": "http://register.openownership.org/entities/59b9be6f67e4ebf340944a74"
+            }
+        ],
+        "foundingDate": "2007-07-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Peninsula, Victoria Place, Manchester, M4 4FB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7628928499762988910",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9456767331982698190"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11732976043762694189"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11732976043762694189",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PENINSULA BUSINESS SERVICES GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02567996"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02567996",
+                "uri": "https://opencorporates.com/companies/gb/02567996"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91a9b67e4ebf340d6a7d1",
+                "uri": "http://register.openownership.org/entities/59b91a9b67e4ebf340d6a7d1"
+            }
+        ],
+        "foundingDate": "1990-12-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Peninsula, Victoria Place, Manchester, M4 4FB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06437479_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06437479_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-14775540247897523805", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FMS INTERIOR SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06437479"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06437479", "uri": "https://opencorporates.com/companies/gb/06437479"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9632167e4ebf34019aeeb", "uri": "http://register.openownership.org/entities/59b9632167e4ebf34019aeeb"}], "foundingDate": "2007-11-26", "addresses": [{"type": "registered", "address": "C/O Scullard Chartered Accountants 197 - 201 Manchester Road, West Timperley, Altrincham, Greater Manchester, WA14 5NU", "country": "GB"}]}, {"statementID": "openownership-register-146344247128637728", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-14775540247897523805"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9610622653380258046"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-9610622653380258046", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James David Beddy"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06437479/persons-with-significant-control/individual/L7a3zyySWyPghyRL7q8wWodAk4k"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9632267e4ebf34019af07", "uri": "http://register.openownership.org/entities/59b9632267e4ebf34019af07"}], "nationalities": [{"name": "Ireland", "code": "IE"}], "birthDate": "1957-05-01", "addresses": [{"address": "Hall Bank, Woodville Road, Bowdon, Altrincham, Cheshire, WA14 2AN"}]}]
+[
+    {
+        "statementID": "openownership-register-14775540247897523805",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FMS INTERIOR SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06437479"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06437479",
+                "uri": "https://opencorporates.com/companies/gb/06437479"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9632167e4ebf34019aeeb",
+                "uri": "http://register.openownership.org/entities/59b9632167e4ebf34019aeeb"
+            }
+        ],
+        "foundingDate": "2007-11-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "C/O Scullard Chartered Accountants 197 - 201 Manchester Road, West Timperley, Altrincham, Greater Manchester, WA14 5NU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-146344247128637728",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14775540247897523805"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9610622653380258046"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9610622653380258046",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James David Beddy"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06437479/persons-with-significant-control/individual/L7a3zyySWyPghyRL7q8wWodAk4k"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9632267e4ebf34019af07",
+                "uri": "http://register.openownership.org/entities/59b9632267e4ebf34019af07"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Ireland",
+                "code": "IE"
+            }
+        ],
+        "birthDate": "1957-05-01",
+        "addresses": [
+            {
+                "address": "Hall Bank, Woodville Road, Bowdon, Altrincham, Cheshire, WA14 2AN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06477162_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06477162_bods.json
@@ -1,1 +1,81 @@
-[{"statementID": "openownership-register-9925551355087157004", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "THIRTEEN HOUSING GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06477162"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06477162"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06477162"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06477162", "uri": "https://opencorporates.com/companies/gb/06477162"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6477162"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "6477162"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab967ae9dfc3fae18b8557f", "uri": "http://register.openownership.org/entities/5ab967ae9dfc3fae18b8557f"}], "foundingDate": "2008-01-18", "dissolutionDate": "2017-04-04", "addresses": [{"type": "registered", "address": "Northshore, North Shore Road, Stockton-On-Tees, Cleveland, TS18 2NB", "country": "GB"}]}, {"statementID": "openownership-register-8117091232262198386", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-16", "subject": {"describedByEntityStatement": "openownership-register-9925551355087157004"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-9925551355087157004",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "THIRTEEN HOUSING GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06477162"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06477162"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06477162"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06477162",
+                "uri": "https://opencorporates.com/companies/gb/06477162"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6477162"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "6477162"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab967ae9dfc3fae18b8557f",
+                "uri": "http://register.openownership.org/entities/5ab967ae9dfc3fae18b8557f"
+            }
+        ],
+        "foundingDate": "2008-01-18",
+        "dissolutionDate": "2017-04-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Northshore, North Shore Road, Stockton-On-Tees, Cleveland, TS18 2NB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8117091232262198386",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-16",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9925551355087157004"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06528218_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06528218_bods.json
@@ -1,1 +1,201 @@
-[{"statementID": "openownership-register-15250282650763065694", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LOUTH TAXIS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06528218"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06528218", "uri": "https://opencorporates.com/companies/gb/06528218"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101c25", "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101c25"}], "foundingDate": "2008-03-08", "addresses": [{"type": "registered", "address": "Unit 1 Albion Court Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ", "country": "GB"}]}, {"statementID": "openownership-register-18233935798943206763", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15250282650763065694"}, "interestedParty": {"describedByPersonStatement": "openownership-register-594638659848145249"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8754579900192699732", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15250282650763065694"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11712124346050986812"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-594638659848145249", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Joan Alma Partridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06528218/persons-with-significant-control/individual/KE8zas6JEMJapobckI5EaRJ-ZQ4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101c2d", "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101c2d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1946-06-01", "addresses": [{"address": "Unit 1 Albion Court, Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ"}]}, {"statementID": "openownership-register-11712124346050986812", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew Starr Partridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06528218/persons-with-significant-control/individual/OGts06hANCwqtAsG1Yyt9gYkAfc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101d0a", "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101d0a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-12-01", "addresses": [{"address": "Unit 1 Albion Court, Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ"}]}]
+[
+    {
+        "statementID": "openownership-register-15250282650763065694",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LOUTH TAXIS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06528218"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06528218",
+                "uri": "https://opencorporates.com/companies/gb/06528218"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101c25",
+                "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101c25"
+            }
+        ],
+        "foundingDate": "2008-03-08",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 1 Albion Court Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18233935798943206763",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15250282650763065694"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-594638659848145249"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8754579900192699732",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15250282650763065694"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11712124346050986812"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-594638659848145249",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Joan Alma Partridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06528218/persons-with-significant-control/individual/KE8zas6JEMJapobckI5EaRJ-ZQ4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101c2d",
+                "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101c2d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1946-06-01",
+        "addresses": [
+            {
+                "address": "Unit 1 Albion Court, Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11712124346050986812",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew Starr Partridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06528218/persons-with-significant-control/individual/OGts06hANCwqtAsG1Yyt9gYkAfc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b8667e4ebf340101d0a",
+                "uri": "http://register.openownership.org/entities/59b99b8667e4ebf340101d0a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-12-01",
+        "addresses": [
+            {
+                "address": "Unit 1 Albion Court, Tattershall Way, Fairfield Industrial Estate, Louth, Lincolnshire, LN11 0YZ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06531268_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06531268_bods.json
@@ -1,1 +1,286 @@
-[{"statementID": "openownership-register-2331071148359961008", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WARWICKSHIRE COMMUNITY AND VOLUNTARY ACTION", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06531268"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06531268", "uri": "https://opencorporates.com/companies/gb/06531268"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c39", "uri": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c39"}], "foundingDate": "2008-03-11", "addresses": [{"type": "registered", "address": "19-20 North Street, Rugby, Warwickshire, CV21 2AG", "country": "GB"}]}, {"statementID": "openownership-register-12660436450687543473", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-25", "subject": {"describedByEntityStatement": "openownership-register-2331071148359961008"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16618640580868179535"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2019-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-10294348812745668795", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-31", "subject": {"describedByEntityStatement": "openownership-register-2331071148359961008"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5493782459856237183"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-10-31", "endDate": "2017-10-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-18319200098231144113", "statementType": "ownershipOrControlStatement", "statementDate": "2018-10-17", "subject": {"describedByEntityStatement": "openownership-register-2331071148359961008"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2891829403239595311"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-10-17", "endDate": "2019-09-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-10388356053988278219", "statementType": "ownershipOrControlStatement", "statementDate": "2017-10-30", "subject": {"describedByEntityStatement": "openownership-register-2331071148359961008"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5188067166954255667"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2017-10-30", "endDate": "2018-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16618640580868179535", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew Arnold Gabbitas"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06531268/persons-with-significant-control/individual/PjvAH7wp0b9OSspFNjCm737Baeg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da759e99dfc3fae1831e297", "uri": "http://register.openownership.org/entities/5da759e99dfc3fae1831e297"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-09-01", "addresses": [{"address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"}]}, {"statementID": "openownership-register-5493782459856237183", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Joanne Audrey Shine"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06531268/persons-with-significant-control/individual/eS2LU3fFsoJzlIhdTPSCb0O09tU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c41", "uri": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c41"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1951-11-01", "addresses": [{"address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"}]}, {"statementID": "openownership-register-2891829403239595311", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Kathleen Elizabeth Harper"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06531268/persons-with-significant-control/individual/nffN7NAU1mypWoS3ztqaPnnSm4g"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bcf8c139dfc3fae18cbb484", "uri": "http://register.openownership.org/entities/5bcf8c139dfc3fae18cbb484"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1945-12-01", "addresses": [{"address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"}]}, {"statementID": "openownership-register-5188067166954255667", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Judith Mary Morley"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06531268/persons-with-significant-control/individual/rFpxLZtRgc7FOt1dE0GBKAYeySs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9fe4d9dfc3fae18363f76", "uri": "http://register.openownership.org/entities/5ab9fe4d9dfc3fae18363f76"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1943-04-01", "addresses": [{"address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"}]}]
+[
+    {
+        "statementID": "openownership-register-2331071148359961008",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WARWICKSHIRE COMMUNITY AND VOLUNTARY ACTION",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06531268"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06531268",
+                "uri": "https://opencorporates.com/companies/gb/06531268"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c39",
+                "uri": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c39"
+            }
+        ],
+        "foundingDate": "2008-03-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19-20 North Street, Rugby, Warwickshire, CV21 2AG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12660436450687543473",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2331071148359961008"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16618640580868179535"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2019-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10294348812745668795",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2331071148359961008"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5493782459856237183"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-10-31",
+                "endDate": "2017-10-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-18319200098231144113",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-10-17",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2331071148359961008"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2891829403239595311"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-10-17",
+                "endDate": "2019-09-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10388356053988278219",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-10-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2331071148359961008"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5188067166954255667"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2017-10-30",
+                "endDate": "2018-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16618640580868179535",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew Arnold Gabbitas"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06531268/persons-with-significant-control/individual/PjvAH7wp0b9OSspFNjCm737Baeg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da759e99dfc3fae1831e297",
+                "uri": "http://register.openownership.org/entities/5da759e99dfc3fae1831e297"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-09-01",
+        "addresses": [
+            {
+                "address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5493782459856237183",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Joanne Audrey Shine"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06531268/persons-with-significant-control/individual/eS2LU3fFsoJzlIhdTPSCb0O09tU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c41",
+                "uri": "http://register.openownership.org/entities/59b9a0b467e4ebf340234c41"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1951-11-01",
+        "addresses": [
+            {
+                "address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2891829403239595311",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Kathleen Elizabeth Harper"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06531268/persons-with-significant-control/individual/nffN7NAU1mypWoS3ztqaPnnSm4g"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bcf8c139dfc3fae18cbb484",
+                "uri": "http://register.openownership.org/entities/5bcf8c139dfc3fae18cbb484"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1945-12-01",
+        "addresses": [
+            {
+                "address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5188067166954255667",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Judith Mary Morley"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06531268/persons-with-significant-control/individual/rFpxLZtRgc7FOt1dE0GBKAYeySs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9fe4d9dfc3fae18363f76",
+                "uri": "http://register.openownership.org/entities/5ab9fe4d9dfc3fae18363f76"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1943-04-01",
+        "addresses": [
+            {
+                "address": "19-20, North Street, Rugby, Warwickshire, CV21 2AG"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06549885_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06549885_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-3524727836120453367", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SOUTHCOTT SUPPORT SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06549885"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06549885", "uri": "https://opencorporates.com/companies/gb/06549885"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9aad467e4ebf34048c12e", "uri": "http://register.openownership.org/entities/59b9aad467e4ebf34048c12e"}], "foundingDate": "2008-03-31", "addresses": [{"type": "registered", "address": "Burn Bank, Old Barnstaple Road, Bideford, Devon, EX39 4ND", "country": "GB"}]}, {"statementID": "openownership-register-14560617682316348210", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-01", "subject": {"describedByEntityStatement": "openownership-register-3524727836120453367"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14132914442568037106"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14132914442568037106", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Sara Jane Oke"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06549885/persons-with-significant-control/individual/_VVBkgVXVUHLFqPEu56Arls0TlA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9aad467e4ebf34048c139", "uri": "http://register.openownership.org/entities/59b9aad467e4ebf34048c139"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-08-01", "addresses": [{"address": "Burn Bank, Old Barnstaple Road, Bideford, Devon, EX39 4ND"}]}]
+[
+    {
+        "statementID": "openownership-register-3524727836120453367",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SOUTHCOTT SUPPORT SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06549885"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06549885",
+                "uri": "https://opencorporates.com/companies/gb/06549885"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9aad467e4ebf34048c12e",
+                "uri": "http://register.openownership.org/entities/59b9aad467e4ebf34048c12e"
+            }
+        ],
+        "foundingDate": "2008-03-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Burn Bank, Old Barnstaple Road, Bideford, Devon, EX39 4ND",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14560617682316348210",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3524727836120453367"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14132914442568037106"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14132914442568037106",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Sara Jane Oke"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06549885/persons-with-significant-control/individual/_VVBkgVXVUHLFqPEu56Arls0TlA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9aad467e4ebf34048c139",
+                "uri": "http://register.openownership.org/entities/59b9aad467e4ebf34048c139"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-08-01",
+        "addresses": [
+            {
+                "address": "Burn Bank, Old Barnstaple Road, Bideford, Devon, EX39 4ND"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06561170_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06561170_bods.json
@@ -1,1 +1,209 @@
-[{"statementID": "openownership-register-2503263248945616433", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REFOOD UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06561170"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06561170", "uri": "https://opencorporates.com/companies/gb/06561170"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ba7267e4ebf340850d4c", "uri": "http://register.openownership.org/entities/59b9ba7267e4ebf340850d4c"}], "foundingDate": "2008-04-10", "addresses": [{"type": "registered", "address": "Ings Road, Bentley, Doncaster, South Yorkshire, DN5 9TL", "country": "GB"}]}, {"statementID": "openownership-register-11397880606847503065", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2503263248945616433"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17987623421648703174"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17987623421648703174", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SARIA LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00547564", "uri": "https://opencorporates.com/companies/gb/00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00547564"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b928c867e4ebf3400ba192", "uri": "http://register.openownership.org/entities/59b928c867e4ebf3400ba192"}], "foundingDate": "1955-04-07", "addresses": [{"type": "registered", "address": "Ings Road, Bentley, Doncaster, South Yorkshire, DN5 9TL", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2503263248945616433",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REFOOD UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06561170"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06561170",
+                "uri": "https://opencorporates.com/companies/gb/06561170"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ba7267e4ebf340850d4c",
+                "uri": "http://register.openownership.org/entities/59b9ba7267e4ebf340850d4c"
+            }
+        ],
+        "foundingDate": "2008-04-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ings Road, Bentley, Doncaster, South Yorkshire, DN5 9TL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11397880606847503065",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2503263248945616433"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17987623421648703174"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17987623421648703174",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SARIA LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00547564",
+                "uri": "https://opencorporates.com/companies/gb/00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00547564"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b928c867e4ebf3400ba192",
+                "uri": "http://register.openownership.org/entities/59b928c867e4ebf3400ba192"
+            }
+        ],
+        "foundingDate": "1955-04-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ings Road, Bentley, Doncaster, South Yorkshire, DN5 9TL",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06668975_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06668975_bods.json
@@ -1,1 +1,193 @@
-[{"statementID": "openownership-register-13468432536608724351", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STEP AHEAD SOCIAL ENTERPRISE COMMUNITY INTEREST COMPANY", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06668975"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06668975", "uri": "https://opencorporates.com/companies/gb/06668975"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c3267e4ebf3406837a6", "uri": "http://register.openownership.org/entities/59b93c3267e4ebf3406837a6"}], "foundingDate": "2008-08-11", "addresses": [{"type": "registered", "address": "Highdale House 7 Centre Court, Treforest Industrial Estate, Pontypridd, Rhondda Cynon Taff, CF37 5YR", "country": "GB"}]}, {"statementID": "openownership-register-7273611268682087545", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13468432536608724351"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6975768195199277433"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-03-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16198912481995020018", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-16", "subject": {"describedByEntityStatement": "openownership-register-13468432536608724351"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17233195780351673912"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-03-16"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-03-16"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6975768195199277433", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SAE REALISATIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08819557"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08819557"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08819557", "uri": "https://opencorporates.com/companies/gb/08819557"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93c3367e4ebf3406839e8", "uri": "http://register.openownership.org/entities/59b93c3367e4ebf3406839e8"}], "foundingDate": "2013-12-18", "addresses": [{"type": "registered", "address": "2nd Floor 110 Cannon Street, London, EC4N 6EU", "country": "GB"}]}, {"statementID": "openownership-register-17233195780351673912", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ENRICH AND INSPIRE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10665746"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10665746"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10665746", "uri": "https://opencorporates.com/companies/gb/10665746"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9996567e4ebf340086536", "uri": "http://register.openownership.org/entities/59b9996567e4ebf340086536"}], "foundingDate": "2017-03-13", "addresses": [{"type": "registered", "address": "Highdale House 7 Centre Court, Main Avenue, Treforest Industrial Estate, Pontypridd, CF37 5YR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13468432536608724351",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STEP AHEAD SOCIAL ENTERPRISE COMMUNITY INTEREST COMPANY",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06668975"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06668975",
+                "uri": "https://opencorporates.com/companies/gb/06668975"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c3267e4ebf3406837a6",
+                "uri": "http://register.openownership.org/entities/59b93c3267e4ebf3406837a6"
+            }
+        ],
+        "foundingDate": "2008-08-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Highdale House 7 Centre Court, Treforest Industrial Estate, Pontypridd, Rhondda Cynon Taff, CF37 5YR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7273611268682087545",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13468432536608724351"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6975768195199277433"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-03-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16198912481995020018",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-16",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13468432536608724351"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17233195780351673912"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-03-16"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-03-16"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6975768195199277433",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SAE REALISATIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08819557"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08819557"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08819557",
+                "uri": "https://opencorporates.com/companies/gb/08819557"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93c3367e4ebf3406839e8",
+                "uri": "http://register.openownership.org/entities/59b93c3367e4ebf3406839e8"
+            }
+        ],
+        "foundingDate": "2013-12-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "2nd Floor 110 Cannon Street, London, EC4N 6EU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17233195780351673912",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ENRICH AND INSPIRE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10665746"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10665746"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10665746",
+                "uri": "https://opencorporates.com/companies/gb/10665746"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9996567e4ebf340086536",
+                "uri": "http://register.openownership.org/entities/59b9996567e4ebf340086536"
+            }
+        ],
+        "foundingDate": "2017-03-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Highdale House 7 Centre Court, Main Avenue, Treforest Industrial Estate, Pontypridd, CF37 5YR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06676850_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06676850_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-7765446697655359824", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VISION HOUSING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06676850"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06676850", "uri": "https://opencorporates.com/companies/gb/06676850"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035dc", "uri": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035dc"}], "foundingDate": "2008-08-19", "addresses": [{"type": "registered", "address": "Unit 6 Sugar Mill Business Park, 432 Dewsbury Road, Leeds, West Yorkshire, LS11 7DF", "country": "GB"}]}, {"statementID": "openownership-register-3429013040547620772", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-01", "subject": {"describedByEntityStatement": "openownership-register-7765446697655359824"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7294357168908925997"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13311287070290142777", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-01", "subject": {"describedByEntityStatement": "openownership-register-7765446697655359824"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1559439231715980484"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7294357168908925997", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Claire Lincoln"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06676850/persons-with-significant-control/individual/dL7a1VINaPmPQpzEa22u3yXLwM4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035f1", "uri": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035f1"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1984-11-01", "addresses": [{"address": "Unit 12, 432 Dewsbury Road, Leeds, LS11 7DF"}]}, {"statementID": "openownership-register-1559439231715980484", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Esther Powell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06676850/persons-with-significant-control/individual/qfJWwFXCu6ebz_KR33ul3J84LDs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99b9067e4ebf34010369e", "uri": "http://register.openownership.org/entities/59b99b9067e4ebf34010369e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1978-08-01", "addresses": [{"address": "Unit 12, 432 Dewsbury Road, Beeston, Leeds, West Yorkshire, LS11 7DF"}]}]
+[
+    {
+        "statementID": "openownership-register-7765446697655359824",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VISION HOUSING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06676850"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06676850",
+                "uri": "https://opencorporates.com/companies/gb/06676850"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035dc",
+                "uri": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035dc"
+            }
+        ],
+        "foundingDate": "2008-08-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 6 Sugar Mill Business Park, 432 Dewsbury Road, Leeds, West Yorkshire, LS11 7DF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3429013040547620772",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7765446697655359824"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7294357168908925997"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13311287070290142777",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7765446697655359824"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1559439231715980484"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7294357168908925997",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Claire Lincoln"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06676850/persons-with-significant-control/individual/dL7a1VINaPmPQpzEa22u3yXLwM4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035f1",
+                "uri": "http://register.openownership.org/entities/59b99b8f67e4ebf3401035f1"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1984-11-01",
+        "addresses": [
+            {
+                "address": "Unit 12, 432 Dewsbury Road, Leeds, LS11 7DF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1559439231715980484",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Esther Powell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06676850/persons-with-significant-control/individual/qfJWwFXCu6ebz_KR33ul3J84LDs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99b9067e4ebf34010369e",
+                "uri": "http://register.openownership.org/entities/59b99b9067e4ebf34010369e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1978-08-01",
+        "addresses": [
+            {
+                "address": "Unit 12, 432 Dewsbury Road, Beeston, Leeds, West Yorkshire, LS11 7DF"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06687348_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06687348_bods.json
@@ -1,1 +1,236 @@
-[{"statementID": "openownership-register-3618612506829300342", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AMBLEARCH LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06687348"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06687348", "uri": "https://opencorporates.com/companies/gb/06687348"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b961ea67e4ebf340137640", "uri": "http://register.openownership.org/entities/59b961ea67e4ebf340137640"}], "foundingDate": "2008-09-02", "addresses": [{"type": "registered", "address": "52, Main Street., North Frodingham,, Driffield,, East Yorkshire., YO25 8LG", "country": "GB"}]}, {"statementID": "openownership-register-1558677257971679876", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-01", "subject": {"describedByEntityStatement": "openownership-register-3618612506829300342"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14632314159561192649"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-03-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6330298650462701303", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3618612506829300342"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5123971218262773410"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13588400180565406259", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3618612506829300342"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11700404942716046331"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2017-03-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14632314159561192649", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Diana Rosemary Mcqueen"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09109830/persons-with-significant-control/individual/PBlBvwcdCwgbtcJBqYC1S3XoAUM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92ed767e4ebf340293dae", "uri": "http://register.openownership.org/entities/59b92ed767e4ebf340293dae"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1952-09-01", "addresses": [{"address": "6, Hillside, Lichfield, WS14 9DQ"}]}, {"statementID": "openownership-register-5123971218262773410", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alan Wilkinson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06687348/persons-with-significant-control/individual/vSIgSgvgY-wRlmEyxBv9F6SdjSA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b961ea67e4ebf340137647", "uri": "http://register.openownership.org/entities/59b961ea67e4ebf340137647"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1946-11-01", "addresses": [{"address": "52,, Main Street., North Frodingham,, Driffield,, East Yorkshire., YO25 8LG"}]}, {"statementID": "openownership-register-11700404942716046331", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Mcqueen"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06687348/persons-with-significant-control/individual/xfjzPQZQ_RU8nj1LHe4C35u5XvE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b961ea67e4ebf3401376db", "uri": "http://register.openownership.org/entities/59b961ea67e4ebf3401376db"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1952-09-01", "addresses": [{"address": "6, Hillside, Lichfield, WS14 9DQ"}]}]
+[
+    {
+        "statementID": "openownership-register-3618612506829300342",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AMBLEARCH LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06687348"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06687348",
+                "uri": "https://opencorporates.com/companies/gb/06687348"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b961ea67e4ebf340137640",
+                "uri": "http://register.openownership.org/entities/59b961ea67e4ebf340137640"
+            }
+        ],
+        "foundingDate": "2008-09-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "52, Main Street., North Frodingham,, Driffield,, East Yorkshire., YO25 8LG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1558677257971679876",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3618612506829300342"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14632314159561192649"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-03-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6330298650462701303",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3618612506829300342"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5123971218262773410"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13588400180565406259",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3618612506829300342"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11700404942716046331"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2017-03-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14632314159561192649",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Diana Rosemary Mcqueen"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09109830/persons-with-significant-control/individual/PBlBvwcdCwgbtcJBqYC1S3XoAUM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92ed767e4ebf340293dae",
+                "uri": "http://register.openownership.org/entities/59b92ed767e4ebf340293dae"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1952-09-01",
+        "addresses": [
+            {
+                "address": "6, Hillside, Lichfield, WS14 9DQ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5123971218262773410",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alan Wilkinson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06687348/persons-with-significant-control/individual/vSIgSgvgY-wRlmEyxBv9F6SdjSA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b961ea67e4ebf340137647",
+                "uri": "http://register.openownership.org/entities/59b961ea67e4ebf340137647"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1946-11-01",
+        "addresses": [
+            {
+                "address": "52,, Main Street., North Frodingham,, Driffield,, East Yorkshire., YO25 8LG"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11700404942716046331",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Mcqueen"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06687348/persons-with-significant-control/individual/xfjzPQZQ_RU8nj1LHe4C35u5XvE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b961ea67e4ebf3401376db",
+                "uri": "http://register.openownership.org/entities/59b961ea67e4ebf3401376db"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1952-09-01",
+        "addresses": [
+            {
+                "address": "6, Hillside, Lichfield, WS14 9DQ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06828016_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06828016_bods.json
@@ -1,1 +1,354 @@
-[{"statementID": "openownership-register-3864206681311251537", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DYNAMIC COLLEGE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06828016"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06828016", "uri": "https://opencorporates.com/companies/gb/06828016"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c08d67e4ebf3409c68d0", "uri": "http://register.openownership.org/entities/59b9c08d67e4ebf3409c68d0"}], "foundingDate": "2009-02-24", "addresses": [{"type": "registered", "address": "173 York Road, Hartlepool, Cleveland, TS29 9EQ", "country": "GB"}]}, {"statementID": "openownership-register-18241417624742815304", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-21", "subject": {"describedByEntityStatement": "openownership-register-3864206681311251537"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1037418347246171564"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-21"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-21"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15194431460011237606", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3864206681311251537"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7565747263294410202"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14849922937831987722", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3864206681311251537"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3704900178127170066"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1491435723501803914", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3864206681311251537"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6269056019270767542"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-06-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7565747263294410202", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Claire Gardner"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06828016/persons-with-significant-control/individual/EJCr_S92bI-giCiAXTqbP7il1mY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491fa4", "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491fa4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1974-04-01", "addresses": [{"address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ", "country": "GB"}]}, {"statementID": "openownership-register-3704900178127170066", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Caron Keys"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06828016/persons-with-significant-control/individual/JLzajYBhdMbOcwlOkcfWm7V09E4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18492080", "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18492080"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-02-01", "addresses": [{"address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ", "country": "GB"}]}, {"statementID": "openownership-register-6269056019270767542", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Anthoney Gardner"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06828016/persons-with-significant-control/individual/fdWbs1csbSyG7G4xnB02SEuyyDE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491ff2", "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491ff2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-06-01", "addresses": [{"address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ", "country": "GB"}]}, {"statementID": "openownership-register-1037418347246171564", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Godert Van Buren"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06374888/persons-with-significant-control/individual/2_7e57kiLByUgGrjwdirTI9ukls"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94f2b67e4ebf340bcfe4a", "uri": "http://register.openownership.org/entities/59b94f2b67e4ebf340bcfe4a"}], "birthDate": "1960-11-01", "addresses": [{"address": "28, Obrechstraat, Zwolle, 8031 AZ", "country": "NL"}]}]
+[
+    {
+        "statementID": "openownership-register-3864206681311251537",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DYNAMIC COLLEGE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06828016"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06828016",
+                "uri": "https://opencorporates.com/companies/gb/06828016"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c08d67e4ebf3409c68d0",
+                "uri": "http://register.openownership.org/entities/59b9c08d67e4ebf3409c68d0"
+            }
+        ],
+        "foundingDate": "2009-02-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "173 York Road, Hartlepool, Cleveland, TS29 9EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18241417624742815304",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-21",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3864206681311251537"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1037418347246171564"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-21"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-21"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15194431460011237606",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3864206681311251537"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7565747263294410202"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14849922937831987722",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3864206681311251537"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3704900178127170066"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1491435723501803914",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3864206681311251537"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6269056019270767542"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-06-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7565747263294410202",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Claire Gardner"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06828016/persons-with-significant-control/individual/EJCr_S92bI-giCiAXTqbP7il1mY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491fa4",
+                "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491fa4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1974-04-01",
+        "addresses": [
+            {
+                "address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3704900178127170066",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Caron Keys"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06828016/persons-with-significant-control/individual/JLzajYBhdMbOcwlOkcfWm7V09E4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18492080",
+                "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18492080"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-02-01",
+        "addresses": [
+            {
+                "address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6269056019270767542",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Anthoney Gardner"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06828016/persons-with-significant-control/individual/fdWbs1csbSyG7G4xnB02SEuyyDE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491ff2",
+                "uri": "http://register.openownership.org/entities/5ab9a2dc9dfc3fae18491ff2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-06-01",
+        "addresses": [
+            {
+                "address": "173, York Road, Hartlepool, Cleveland, TS29 9EQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1037418347246171564",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Godert Van Buren"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06374888/persons-with-significant-control/individual/2_7e57kiLByUgGrjwdirTI9ukls"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94f2b67e4ebf340bcfe4a",
+                "uri": "http://register.openownership.org/entities/59b94f2b67e4ebf340bcfe4a"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "28, Obrechstraat, Zwolle, 8031 AZ",
+                "country": "NL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06903140_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06903140_bods.json
@@ -1,1 +1,197 @@
-[{"statementID": "openownership-register-746486342085374943", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REED SPECIALIST RECRUITMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06903140"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06903140", "uri": "https://opencorporates.com/companies/gb/06903140"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "06903140"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bee167e4ebf34095fd69", "uri": "http://register.openownership.org/entities/59b9bee167e4ebf34095fd69"}], "foundingDate": "2009-05-12", "addresses": [{"type": "registered", "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT", "country": "GB"}]}, {"statementID": "openownership-register-10472729119013673977", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-746486342085374943"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3274878148568023999"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6179561907350305835", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-746486342085374943"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3642049359273931717"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3274878148568023999", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REED EXECUTIVE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02061422"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02061422", "uri": "https://opencorporates.com/companies/gb/02061422"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9433e67e4ebf340869646", "uri": "http://register.openownership.org/entities/59b9433e67e4ebf340869646"}], "foundingDate": "1986-10-03", "addresses": [{"type": "registered", "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT", "country": "GB"}]}, {"statementID": "openownership-register-3642049359273931717", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Andrew Reed"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06317279/persons-with-significant-control/individual/A2bRR3cQO9-imdlmXoMtvgA53tI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0", "uri": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-04-01", "addresses": [{"address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT"}]}]
+[
+    {
+        "statementID": "openownership-register-746486342085374943",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REED SPECIALIST RECRUITMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06903140"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06903140",
+                "uri": "https://opencorporates.com/companies/gb/06903140"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06903140"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bee167e4ebf34095fd69",
+                "uri": "http://register.openownership.org/entities/59b9bee167e4ebf34095fd69"
+            }
+        ],
+        "foundingDate": "2009-05-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10472729119013673977",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-746486342085374943"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3274878148568023999"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6179561907350305835",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-746486342085374943"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3642049359273931717"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3274878148568023999",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REED EXECUTIVE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02061422"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02061422",
+                "uri": "https://opencorporates.com/companies/gb/02061422"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9433e67e4ebf340869646",
+                "uri": "http://register.openownership.org/entities/59b9433e67e4ebf340869646"
+            }
+        ],
+        "foundingDate": "1986-10-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3642049359273931717",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Andrew Reed"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06317279/persons-with-significant-control/individual/A2bRR3cQO9-imdlmXoMtvgA53tI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0",
+                "uri": "http://register.openownership.org/entities/59b9278f67e4ebf3400693d0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-04-01",
+        "addresses": [
+            {
+                "address": "Academy Court, 94 Chancery Lane, London, WC2A 1DT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06908655_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06908655_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-5925234767049129453", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASPINALL VERDI LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06908655"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06908655", "uri": "https://opencorporates.com/companies/gb/06908655"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a9000f", "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a9000f"}], "foundingDate": "2009-05-18", "addresses": [{"type": "registered", "address": "Second Floor Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN", "country": "GB"}]}, {"statementID": "openownership-register-5886994523451110441", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5925234767049129453"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8789664852908103428"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13084631236032467496", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5925234767049129453"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4377010663764204988"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8789664852908103428", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Atam Parkash Singh Verdi"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06908655/persons-with-significant-control/individual/96mVoNQPtYv9wA1r6ZPIij9LVik"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90045", "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90045"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-05-01", "addresses": [{"address": "Second Floor, Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN"}]}, {"statementID": "openownership-register-4377010663764204988", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Benjamin Egerton Aspinall"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06908655/persons-with-significant-control/individual/yxVEOzNmAr4aHhEEriCZEEdIk9w"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90027", "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90027"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1973-08-01", "addresses": [{"address": "Second Floor, Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN"}]}]
+[
+    {
+        "statementID": "openownership-register-5925234767049129453",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASPINALL VERDI LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06908655"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06908655",
+                "uri": "https://opencorporates.com/companies/gb/06908655"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a9000f",
+                "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a9000f"
+            }
+        ],
+        "foundingDate": "2009-05-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Second Floor Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5886994523451110441",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5925234767049129453"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8789664852908103428"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13084631236032467496",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5925234767049129453"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4377010663764204988"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8789664852908103428",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Atam Parkash Singh Verdi"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06908655/persons-with-significant-control/individual/96mVoNQPtYv9wA1r6ZPIij9LVik"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90045",
+                "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90045"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-05-01",
+        "addresses": [
+            {
+                "address": "Second Floor, Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4377010663764204988",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Benjamin Egerton Aspinall"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06908655/persons-with-significant-control/individual/yxVEOzNmAr4aHhEEriCZEEdIk9w"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90027",
+                "uri": "http://register.openownership.org/entities/59b9c3d567e4ebf340a90027"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1973-08-01",
+        "addresses": [
+            {
+                "address": "Second Floor, Matthew Murray House, 97 Water Lane, Leeds, LS11 5QN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06939047_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06939047_bods.json
@@ -1,1 +1,115 @@
-[{"statementID": "openownership-register-10593353822116484909", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BRISTOL BUSINESS FORMS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06939047"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06939047", "uri": "https://opencorporates.com/companies/gb/06939047"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d88567e4ebf340f43afe", "uri": "http://register.openownership.org/entities/59b9d88567e4ebf340f43afe"}], "foundingDate": "2009-06-19", "addresses": [{"type": "registered", "address": "The Island House, The Island, Midsomer Norton, Radstock, BA3 2DZ", "country": "GB"}]}, {"statementID": "openownership-register-17918321692845512359", "statementType": "ownershipOrControlStatement", "statementDate": "2017-06-19", "subject": {"describedByEntityStatement": "openownership-register-10593353822116484909"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4979746705247740555"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-06-19"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-06-19"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4979746705247740555", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Jesse Mark Brooks"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06939047/persons-with-significant-control/individual/yHHbB5BZmhT1BKQ7fk8pGEsBQy8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d88567e4ebf340f43b09", "uri": "http://register.openownership.org/entities/59b9d88567e4ebf340f43b09"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-11-01", "addresses": [{"address": "Highbury House, Highbury Street, Coleford, Radstock, BA3 5NT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-10593353822116484909",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BRISTOL BUSINESS FORMS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06939047"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06939047",
+                "uri": "https://opencorporates.com/companies/gb/06939047"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d88567e4ebf340f43afe",
+                "uri": "http://register.openownership.org/entities/59b9d88567e4ebf340f43afe"
+            }
+        ],
+        "foundingDate": "2009-06-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Island House, The Island, Midsomer Norton, Radstock, BA3 2DZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17918321692845512359",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-06-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10593353822116484909"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4979746705247740555"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-06-19"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-06-19"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4979746705247740555",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Jesse Mark Brooks"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06939047/persons-with-significant-control/individual/yHHbB5BZmhT1BKQ7fk8pGEsBQy8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d88567e4ebf340f43b09",
+                "uri": "http://register.openownership.org/entities/59b9d88567e4ebf340f43b09"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "Highbury House, Highbury Street, Coleford, Radstock, BA3 5NT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06942967_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06942967_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-11648807693319690447", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CHOSEN CARE GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06942967"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06942967", "uri": "https://opencorporates.com/companies/gb/06942967"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63c2", "uri": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63c2"}], "foundingDate": "2009-06-24", "addresses": [{"type": "registered", "address": "61 Cranbrook Road, Ilford, IG1 4PG", "country": "GB"}]}, {"statementID": "openownership-register-1816029105499124039", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11648807693319690447"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1906573336425811831"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1906573336425811831", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Pakkirisany Bhoopalan Natarjan"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06942967/persons-with-significant-control/individual/hkhp9BP7RSj3AQNyvaEhNcZdfFI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63d0", "uri": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63d0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-12-01", "addresses": [{"address": "163, Gordon Road, Ilford, Essex, IG1 2XS"}]}]
+[
+    {
+        "statementID": "openownership-register-11648807693319690447",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CHOSEN CARE GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06942967"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06942967",
+                "uri": "https://opencorporates.com/companies/gb/06942967"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63c2",
+                "uri": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63c2"
+            }
+        ],
+        "foundingDate": "2009-06-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "61 Cranbrook Road, Ilford, IG1 4PG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1816029105499124039",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11648807693319690447"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1906573336425811831"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1906573336425811831",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Pakkirisany Bhoopalan Natarjan"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06942967/persons-with-significant-control/individual/hkhp9BP7RSj3AQNyvaEhNcZdfFI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63d0",
+                "uri": "http://register.openownership.org/entities/59b9a39b67e4ebf3402e63d0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-12-01",
+        "addresses": [
+            {
+                "address": "163, Gordon Road, Ilford, Essex, IG1 2XS"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06952980_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06952980_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-8066399185822168252", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NOISE SOLUTION C.I.C.", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06952980"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06952980", "uri": "https://opencorporates.com/companies/gb/06952980"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4f07c67e4ebf3403e53f4", "uri": "http://register.openownership.org/entities/59c4f07c67e4ebf3403e53f4"}], "foundingDate": "2009-07-06", "addresses": [{"type": "registered", "address": "Hunter Club, 6 St. Andrews Street South, Bury St. Edmunds, Suffolk, IP33 3PH", "country": "GB"}]}, {"statementID": "openownership-register-2451762015735264451", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-14", "subject": {"describedByEntityStatement": "openownership-register-8066399185822168252"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-8066399185822168252",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NOISE SOLUTION C.I.C.",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06952980"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06952980",
+                "uri": "https://opencorporates.com/companies/gb/06952980"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4f07c67e4ebf3403e53f4",
+                "uri": "http://register.openownership.org/entities/59c4f07c67e4ebf3403e53f4"
+            }
+        ],
+        "foundingDate": "2009-07-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hunter Club, 6 St. Andrews Street South, Bury St. Edmunds, Suffolk, IP33 3PH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2451762015735264451",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8066399185822168252"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06974487_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_06974487_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-2973566187350882172", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INCLUSIVE CARE SUPPORT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "06974487"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/06974487", "uri": "https://opencorporates.com/companies/gb/06974487"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6dc", "uri": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6dc"}], "foundingDate": "2009-07-28", "addresses": [{"type": "registered", "address": "46 The Ridgeway, North Harrow, Harrow, HA2 7QN", "country": "GB"}]}, {"statementID": "openownership-register-2720480470905586823", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2973566187350882172"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17832368474792691038"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-17832368474792691038", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Hafsa Khan"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/06974487/persons-with-significant-control/individual/SSclVj7ApWEdv_YlxwiJeQRVf7o"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6e2", "uri": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6e2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-05-01", "addresses": [{"address": "298, Romford Road, London, E7 9HD"}]}]
+[
+    {
+        "statementID": "openownership-register-2973566187350882172",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INCLUSIVE CARE SUPPORT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "06974487"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/06974487",
+                "uri": "https://opencorporates.com/companies/gb/06974487"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6dc",
+                "uri": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6dc"
+            }
+        ],
+        "foundingDate": "2009-07-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "46 The Ridgeway, North Harrow, Harrow, HA2 7QN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2720480470905586823",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2973566187350882172"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17832368474792691038"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17832368474792691038",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Hafsa Khan"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/06974487/persons-with-significant-control/individual/SSclVj7ApWEdv_YlxwiJeQRVf7o"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6e2",
+                "uri": "http://register.openownership.org/entities/59b9430f67e4ebf34085e6e2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-05-01",
+        "addresses": [
+            {
+                "address": "298, Romford Road, London, E7 9HD"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07007374_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07007374_bods.json
@@ -1,1 +1,193 @@
-[{"statementID": "openownership-register-2494062864182050783", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AB SCIEX UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07007374"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07007374"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07007374", "uri": "https://opencorporates.com/companies/gb/07007374"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9765367e4ebf3407863bb", "uri": "http://register.openownership.org/entities/59b9765367e4ebf3407863bb"}], "foundingDate": "2009-09-02", "addresses": [{"type": "registered", "address": "19 Jessops Riverside, 800 Brightside Lane, Sheffield, S9 2RX", "country": "GB"}]}, {"statementID": "openownership-register-7716589431187685943", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-25", "subject": {"describedByEntityStatement": "openownership-register-2494062864182050783"}, "interestedParty": {"describedByEntityStatement": "openownership-register-3905455573376837292"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-01-25"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-01-25"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-01-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3905455573376837292", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LAUNCHCHANGE OPERATIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07105768"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07105768", "uri": "https://opencorporates.com/companies/gb/07105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7105768"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7105768"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9425767e4ebf340831b98", "uri": "http://register.openownership.org/entities/59b9425767e4ebf340831b98"}], "foundingDate": "2009-12-15", "addresses": [{"type": "registered", "address": "19 Jessops Riverside, 800 Brightside Lane, Sheffield, S9 2RX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2494062864182050783",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AB SCIEX UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07007374"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07007374"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07007374",
+                "uri": "https://opencorporates.com/companies/gb/07007374"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9765367e4ebf3407863bb",
+                "uri": "http://register.openownership.org/entities/59b9765367e4ebf3407863bb"
+            }
+        ],
+        "foundingDate": "2009-09-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19 Jessops Riverside, 800 Brightside Lane, Sheffield, S9 2RX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7716589431187685943",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2494062864182050783"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-3905455573376837292"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-25"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-25"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-01-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3905455573376837292",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LAUNCHCHANGE OPERATIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07105768"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07105768",
+                "uri": "https://opencorporates.com/companies/gb/07105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7105768"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9425767e4ebf340831b98",
+                "uri": "http://register.openownership.org/entities/59b9425767e4ebf340831b98"
+            }
+        ],
+        "foundingDate": "2009-12-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "19 Jessops Riverside, 800 Brightside Lane, Sheffield, S9 2RX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07092845_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07092845_bods.json
@@ -1,1 +1,185 @@
-[{"statementID": "openownership-register-1300543275755554443", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ACE ELEVATORS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07092845"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07092845", "uri": "https://opencorporates.com/companies/gb/07092845"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9854767e4ebf340c1ea94", "uri": "http://register.openownership.org/entities/59b9854767e4ebf340c1ea94"}], "foundingDate": "2009-12-02", "addresses": [{"type": "registered", "address": "146 Ashbourne Way, Bradford, West Yorkshire, BD2 1ES", "country": "GB"}]}, {"statementID": "openownership-register-8274510886031772276", "statementType": "ownershipOrControlStatement", "statementDate": "2019-12-04", "subject": {"describedByEntityStatement": "openownership-register-1300543275755554443"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17156353862707620003"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-04"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2019-12-04"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-12-04"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-12-10T10:45:26Z"}}, {"statementID": "openownership-register-7525186346586918409", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-02", "subject": {"describedByEntityStatement": "openownership-register-1300543275755554443"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12320017189311836446"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-12-02"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17156353862707620003", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Kaldip Singh"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11653474/persons-with-significant-control/individual/xGl7cgF70zlo_5nIYVnx4JEHcj4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bf43d169dfc3fae18987972", "uri": "http://register.openownership.org/entities/5bf43d169dfc3fae18987972"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-04-01", "addresses": [{"address": "Kiplings Cottage, Greenhow Hill, Harrogate, HG3 5JQ"}]}, {"statementID": "openownership-register-12320017189311836446", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ravinder Shergill"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07092845/persons-with-significant-control/individual/Yp7kZhyXr540FOnSFZlTpmxUZhg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9854767e4ebf340c1eaa8", "uri": "http://register.openownership.org/entities/59b9854767e4ebf340c1eaa8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1975-02-01", "addresses": [{"address": "Kiplings, Greenhow Hill, Harrogate, North Yorkshire, HG3 5JQ"}]}]
+[
+    {
+        "statementID": "openownership-register-1300543275755554443",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ACE ELEVATORS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07092845"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07092845",
+                "uri": "https://opencorporates.com/companies/gb/07092845"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9854767e4ebf340c1ea94",
+                "uri": "http://register.openownership.org/entities/59b9854767e4ebf340c1ea94"
+            }
+        ],
+        "foundingDate": "2009-12-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "146 Ashbourne Way, Bradford, West Yorkshire, BD2 1ES",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8274510886031772276",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-12-04",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1300543275755554443"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17156353862707620003"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-04"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2019-12-04"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-12-04"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-12-10T10:45:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7525186346586918409",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-02",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1300543275755554443"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12320017189311836446"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-12-02"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17156353862707620003",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Kaldip Singh"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11653474/persons-with-significant-control/individual/xGl7cgF70zlo_5nIYVnx4JEHcj4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bf43d169dfc3fae18987972",
+                "uri": "http://register.openownership.org/entities/5bf43d169dfc3fae18987972"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-04-01",
+        "addresses": [
+            {
+                "address": "Kiplings Cottage, Greenhow Hill, Harrogate, HG3 5JQ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12320017189311836446",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ravinder Shergill"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07092845/persons-with-significant-control/individual/Yp7kZhyXr540FOnSFZlTpmxUZhg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9854767e4ebf340c1eaa8",
+                "uri": "http://register.openownership.org/entities/59b9854767e4ebf340c1eaa8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1975-02-01",
+        "addresses": [
+            {
+                "address": "Kiplings, Greenhow Hill, Harrogate, North Yorkshire, HG3 5JQ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07126069_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07126069_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-17306722235810549829", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MOBILITY SOLUTIONS (SOUTH) LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07126069"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07126069", "uri": "https://opencorporates.com/companies/gb/07126069"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06d9", "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06d9"}], "foundingDate": "2010-01-14", "addresses": [{"type": "registered", "address": "21 Brookside Centre, Sumpters Way Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR", "country": "GB"}]}, {"statementID": "openownership-register-6902982277192661542", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-14", "subject": {"describedByEntityStatement": "openownership-register-17306722235810549829"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5063172860808152444"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-01-14"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3268092565308794166", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-14", "subject": {"describedByEntityStatement": "openownership-register-17306722235810549829"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8988967854279155531"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-01-14"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5063172860808152444", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Michael Edward John Schacht"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07126069/persons-with-significant-control/individual/48UqjMlmivcI2Fy4QGgP0er-1FU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f6", "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-08-01", "addresses": [{"address": "21 Brookside Centre, Sumpters Way, Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR"}]}, {"statementID": "openownership-register-8988967854279155531", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter Francis Chandler"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07126069/persons-with-significant-control/individual/tA4OT8L6CwLGu_G7tfd2oy1NyT0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f3", "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f3"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-11-01", "addresses": [{"address": "21 Brookside Centre, Sumpters Way, Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR"}]}]
+[
+    {
+        "statementID": "openownership-register-17306722235810549829",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MOBILITY SOLUTIONS (SOUTH) LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07126069"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07126069",
+                "uri": "https://opencorporates.com/companies/gb/07126069"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06d9",
+                "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06d9"
+            }
+        ],
+        "foundingDate": "2010-01-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "21 Brookside Centre, Sumpters Way Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6902982277192661542",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17306722235810549829"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5063172860808152444"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-14"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3268092565308794166",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17306722235810549829"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8988967854279155531"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-14"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5063172860808152444",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michael Edward John Schacht"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07126069/persons-with-significant-control/individual/48UqjMlmivcI2Fy4QGgP0er-1FU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f6",
+                "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-08-01",
+        "addresses": [
+            {
+                "address": "21 Brookside Centre, Sumpters Way, Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8988967854279155531",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter Francis Chandler"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07126069/persons-with-significant-control/individual/tA4OT8L6CwLGu_G7tfd2oy1NyT0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f3",
+                "uri": "http://register.openownership.org/entities/59b9a38467e4ebf3402e06f3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "21 Brookside Centre, Sumpters Way, Temple Farm Industrial Estate, Southend-On-Sea, SS2 5RR"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07133204_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07133204_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-3530732949981686926", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FRESH START IN EDUCATION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07133204"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07133204"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07133204", "uri": "https://opencorporates.com/companies/gb/07133204"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d71c", "uri": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d71c"}], "foundingDate": "2010-01-22", "addresses": [{"type": "registered", "address": "45 Queen Street, Deal, Kent, CT14 6EY", "country": "GB"}]}, {"statementID": "openownership-register-10719871888034298078", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-22", "subject": {"describedByEntityStatement": "openownership-register-3530732949981686926"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1447480266313142422"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-01-22"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-1447480266313142422", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Antony Meade"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07133204/persons-with-significant-control/individual/aTqSdOz8AG8jOuT0-UajBqbW-aU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d727", "uri": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d727"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-06-01", "addresses": [{"address": "45, Queen Street, Deal, Kent, CT14 6EY"}]}]
+[
+    {
+        "statementID": "openownership-register-3530732949981686926",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FRESH START IN EDUCATION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07133204"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07133204"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07133204",
+                "uri": "https://opencorporates.com/companies/gb/07133204"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d71c",
+                "uri": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d71c"
+            }
+        ],
+        "foundingDate": "2010-01-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "45 Queen Street, Deal, Kent, CT14 6EY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10719871888034298078",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-22",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3530732949981686926"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1447480266313142422"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-01-22"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1447480266313142422",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Antony Meade"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07133204/persons-with-significant-control/individual/aTqSdOz8AG8jOuT0-UajBqbW-aU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d727",
+                "uri": "http://register.openownership.org/entities/59b98f8a67e4ebf340e6d727"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-06-01",
+        "addresses": [
+            {
+                "address": "45, Queen Street, Deal, Kent, CT14 6EY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07211819_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07211819_bods.json
@@ -1,1 +1,70 @@
-[{"statementID": "openownership-register-7274490259064417091", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HERITAGE CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07211819"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07211819"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07211819", "uri": "https://opencorporates.com/companies/gb/07211819"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07211819"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9527a67e4ebf340cb72ec", "uri": "http://register.openownership.org/entities/59b9527a67e4ebf340cb72ec"}], "foundingDate": "2010-04-01", "addresses": [{"type": "registered", "address": "Connaught House, 112-120 High Road, Loughton, Essex, IG10 4HJ", "country": "GB"}]}, {"statementID": "openownership-register-10235673316017368782", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-01", "subject": {"describedByEntityStatement": "openownership-register-7274490259064417091"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-7274490259064417091",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HERITAGE CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07211819"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07211819"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07211819",
+                "uri": "https://opencorporates.com/companies/gb/07211819"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07211819"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9527a67e4ebf340cb72ec",
+                "uri": "http://register.openownership.org/entities/59b9527a67e4ebf340cb72ec"
+            }
+        ],
+        "foundingDate": "2010-04-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Connaught House, 112-120 High Road, Loughton, Essex, IG10 4HJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10235673316017368782",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7274490259064417091"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07511105_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07511105_bods.json
@@ -1,1 +1,192 @@
-[{"statementID": "openownership-register-12422096703133699488", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "INSPIRE CARE OUTREACH LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07511105"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07511105", "uri": "https://opencorporates.com/companies/gb/07511105"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e90", "uri": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e90"}], "foundingDate": "2011-01-31", "addresses": [{"type": "registered", "address": "45 Elsenham Road, Manor Park, London, London, E12 6JZ", "country": "GB"}]}, {"statementID": "openownership-register-10907246470544741275", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-01", "subject": {"describedByEntityStatement": "openownership-register-12422096703133699488"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13951694981644744949"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-09-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-09-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5149562359841217134", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-12422096703133699488"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18098570902617388771"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13951694981644744949", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Isaac Olurotimi Odejimi"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07511105/persons-with-significant-control/individual/9ulPVRn14RwZ7CRPF9oczWWtNUw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d5067e4ebf340de8feb", "uri": "http://register.openownership.org/entities/59b98d5067e4ebf340de8feb"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-03-01", "addresses": [{"address": "45, Elsenham Road, Manor Park, London, London, E12 6JZ"}]}, {"statementID": "openownership-register-18098570902617388771", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Helen Okwuoma Odejimi"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07511105/persons-with-significant-control/individual/t2P-qXGMRSwOtefJ47NMhuQyj3c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e9f", "uri": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e9f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-09-01", "addresses": [{"address": "45, Elsenham Road, Manor Park, London, London, E12 6JZ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12422096703133699488",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "INSPIRE CARE OUTREACH LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07511105"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07511105",
+                "uri": "https://opencorporates.com/companies/gb/07511105"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e90",
+                "uri": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e90"
+            }
+        ],
+        "foundingDate": "2011-01-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "45 Elsenham Road, Manor Park, London, London, E12 6JZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10907246470544741275",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12422096703133699488"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13951694981644744949"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-09-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-09-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5149562359841217134",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12422096703133699488"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18098570902617388771"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13951694981644744949",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Isaac Olurotimi Odejimi"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07511105/persons-with-significant-control/individual/9ulPVRn14RwZ7CRPF9oczWWtNUw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d5067e4ebf340de8feb",
+                "uri": "http://register.openownership.org/entities/59b98d5067e4ebf340de8feb"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-03-01",
+        "addresses": [
+            {
+                "address": "45, Elsenham Road, Manor Park, London, London, E12 6JZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18098570902617388771",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Helen Okwuoma Odejimi"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07511105/persons-with-significant-control/individual/t2P-qXGMRSwOtefJ47NMhuQyj3c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e9f",
+                "uri": "http://register.openownership.org/entities/59b98d4f67e4ebf340de8e9f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-09-01",
+        "addresses": [
+            {
+                "address": "45, Elsenham Road, Manor Park, London, London, E12 6JZ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07619797_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07619797_bods.json
@@ -1,1 +1,120 @@
-[{"statementID": "openownership-register-16959614849599198106", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "UKCLOUD LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07619797"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07619797", "uri": "https://opencorporates.com/companies/gb/07619797"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bc5d67e4ebf3408c66fd", "uri": "http://register.openownership.org/entities/59b9bc5d67e4ebf3408c66fd"}], "foundingDate": "2011-05-03", "addresses": [{"type": "registered", "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP", "country": "GB"}]}, {"statementID": "openownership-register-13784987120475079156", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16959614849599198106"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6825921624352056776"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6825921624352056776", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "VIRTUAL INFRASTRUCTURE GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08099285"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08099285"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08099285", "uri": "https://opencorporates.com/companies/gb/08099285"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bc5e67e4ebf3408c6bff", "uri": "http://register.openownership.org/entities/59b9bc5e67e4ebf3408c6bff"}], "foundingDate": "2012-06-11", "addresses": [{"type": "registered", "address": "Hartham Park, Hartham, Corsham, Wiltshire, SN13 0RP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16959614849599198106",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "UKCLOUD LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07619797"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07619797",
+                "uri": "https://opencorporates.com/companies/gb/07619797"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bc5d67e4ebf3408c66fd",
+                "uri": "http://register.openownership.org/entities/59b9bc5d67e4ebf3408c66fd"
+            }
+        ],
+        "foundingDate": "2011-05-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hartham Park, Corsham, Wiltshire, SN13 0RP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13784987120475079156",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16959614849599198106"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6825921624352056776"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6825921624352056776",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "VIRTUAL INFRASTRUCTURE GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08099285"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08099285"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08099285",
+                "uri": "https://opencorporates.com/companies/gb/08099285"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bc5e67e4ebf3408c6bff",
+                "uri": "http://register.openownership.org/entities/59b9bc5e67e4ebf3408c6bff"
+            }
+        ],
+        "foundingDate": "2012-06-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Hartham Park, Hartham, Corsham, Wiltshire, SN13 0RP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07623917_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07623917_bods.json
@@ -1,1 +1,74 @@
-[{"statementID": "openownership-register-5155164333391548252", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "UNIVERSITY OF CENTRAL LANCASHIRE STUDENTS' UNION", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07623917"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07623917"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07623917", "uri": "https://opencorporates.com/companies/gb/07623917"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "7623917"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b93fa767e4ebf34077d444", "uri": "http://register.openownership.org/entities/59b93fa767e4ebf34077d444"}], "foundingDate": "2011-05-05", "addresses": [{"type": "registered", "address": "24 Fylde Road, Preston, Lancashaire, PR1 7BY", "country": "GB"}]}, {"statementID": "openownership-register-3130837786890042124", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-05", "subject": {"describedByEntityStatement": "openownership-register-5155164333391548252"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-5155164333391548252",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "UNIVERSITY OF CENTRAL LANCASHIRE STUDENTS' UNION",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07623917"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07623917"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07623917",
+                "uri": "https://opencorporates.com/companies/gb/07623917"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "7623917"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b93fa767e4ebf34077d444",
+                "uri": "http://register.openownership.org/entities/59b93fa767e4ebf34077d444"
+            }
+        ],
+        "foundingDate": "2011-05-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "24 Fylde Road, Preston, Lancashaire, PR1 7BY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3130837786890042124",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5155164333391548252"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07627219_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07627219_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-8358302724013554819", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RADIANTLIFE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07627219"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07627219", "uri": "https://opencorporates.com/companies/gb/07627219"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b4b", "uri": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b4b"}], "foundingDate": "2011-05-09", "addresses": [{"type": "registered", "address": "183 Cherry Tree Lane, Rainham, Essex, RM13 8TU", "country": "GB"}]}, {"statementID": "openownership-register-5613387181027228537", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8358302724013554819"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5985692920917875015"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5985692920917875015", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Tayo Babatunde"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07627219/persons-with-significant-control/individual/0Tn33ltWHGxk_jTGJBYNfg47Plg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b54", "uri": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b54"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1977-05-01", "addresses": [{"address": "11, Edwards Close, Hutton, Brentwood, CM13 1BU"}]}]
+[
+    {
+        "statementID": "openownership-register-8358302724013554819",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RADIANTLIFE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07627219"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07627219",
+                "uri": "https://opencorporates.com/companies/gb/07627219"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b4b",
+                "uri": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b4b"
+            }
+        ],
+        "foundingDate": "2011-05-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "183 Cherry Tree Lane, Rainham, Essex, RM13 8TU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5613387181027228537",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8358302724013554819"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5985692920917875015"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5985692920917875015",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Tayo Babatunde"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07627219/persons-with-significant-control/individual/0Tn33ltWHGxk_jTGJBYNfg47Plg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b54",
+                "uri": "http://register.openownership.org/entities/59b9c7d167e4ebf340b79b54"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1977-05-01",
+        "addresses": [
+            {
+                "address": "11, Edwards Close, Hutton, Brentwood, CM13 1BU"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07829078_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07829078_bods.json
@@ -1,1 +1,265 @@
-[{"statementID": "openownership-register-13400620703423095663", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CHURCHILL HUI LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07829078"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07829078", "uri": "https://opencorporates.com/companies/gb/07829078"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d7d167e4ebf340f1c248", "uri": "http://register.openownership.org/entities/59b9d7d167e4ebf340f1c248"}], "foundingDate": "2011-10-31", "addresses": [{"type": "registered", "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB", "country": "GB"}]}, {"statementID": "openownership-register-1556062881145969576", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-31", "subject": {"describedByEntityStatement": "openownership-register-13400620703423095663"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2206452316948288742"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-10-31", "endDate": "2017-03-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1106714048561518340", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-31", "subject": {"describedByEntityStatement": "openownership-register-13400620703423095663"}, "interestedParty": {"describedByPersonStatement": "openownership-register-17281759112560984299"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-10-31", "endDate": "2017-03-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13897689138626568908", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-31", "subject": {"describedByEntityStatement": "openownership-register-13400620703423095663"}, "interestedParty": {"describedByEntityStatement": "openownership-register-15306553079274936238"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2017-03-31"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-03-31"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-03-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17281759112560984299", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Geoffrey Mules"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07829078/persons-with-significant-control/individual/y0W48EQNl5EAjNk_NQd4Z2FsBTk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab9fbc89dfc3fae18303ba7", "uri": "http://register.openownership.org/entities/5ab9fbc89dfc3fae18303ba7"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1951-05-01", "addresses": [{"address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB"}]}, {"statementID": "openownership-register-15306553079274936238", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CHURCHILL HUI GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10507477"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10507477"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10507477", "uri": "https://opencorporates.com/companies/gb/10507477"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10507477"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b965b167e4ebf340258390", "uri": "http://register.openownership.org/entities/59b965b167e4ebf340258390"}], "foundingDate": "2016-12-02", "addresses": [{"type": "registered", "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB", "country": "GB"}]}, {"statementID": "openownership-register-2206452316948288742", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Neil Adrian Manley"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/03846491/persons-with-significant-control/individual/9alwBipZhDnHIxC_OdKK3fQewOI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9433867e4ebf34086773e", "uri": "http://register.openownership.org/entities/59b9433867e4ebf34086773e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-07-01", "addresses": [{"address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13400620703423095663",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CHURCHILL HUI LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07829078"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07829078",
+                "uri": "https://opencorporates.com/companies/gb/07829078"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d7d167e4ebf340f1c248",
+                "uri": "http://register.openownership.org/entities/59b9d7d167e4ebf340f1c248"
+            }
+        ],
+        "foundingDate": "2011-10-31",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1556062881145969576",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13400620703423095663"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2206452316948288742"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-31",
+                "endDate": "2017-03-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1106714048561518340",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13400620703423095663"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-17281759112560984299"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-31",
+                "endDate": "2017-03-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13897689138626568908",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13400620703423095663"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-15306553079274936238"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2017-03-31"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-03-31"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-03-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17281759112560984299",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Geoffrey Mules"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07829078/persons-with-significant-control/individual/y0W48EQNl5EAjNk_NQd4Z2FsBTk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab9fbc89dfc3fae18303ba7",
+                "uri": "http://register.openownership.org/entities/5ab9fbc89dfc3fae18303ba7"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1951-05-01",
+        "addresses": [
+            {
+                "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15306553079274936238",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CHURCHILL HUI GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10507477"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10507477"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10507477",
+                "uri": "https://opencorporates.com/companies/gb/10507477"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10507477"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b965b167e4ebf340258390",
+                "uri": "http://register.openownership.org/entities/59b965b167e4ebf340258390"
+            }
+        ],
+        "foundingDate": "2016-12-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2206452316948288742",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Neil Adrian Manley"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/03846491/persons-with-significant-control/individual/9alwBipZhDnHIxC_OdKK3fQewOI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9433867e4ebf34086773e",
+                "uri": "http://register.openownership.org/entities/59b9433867e4ebf34086773e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-07-01",
+        "addresses": [
+            {
+                "address": "Grosvenor House, 4-7 Station Road, Sunbury-On-Thames, Middlesex, TW16 6SB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07945421_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07945421_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-11671628070842014296", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SOLIHULL ACTION THROUGH ADVOCACY", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07945421"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07945421", "uri": "https://opencorporates.com/companies/gb/07945421"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5018667e4ebf3405efe4e", "uri": "http://register.openownership.org/entities/59c5018667e4ebf3405efe4e"}], "foundingDate": "2012-02-10", "addresses": [{"type": "registered", "address": "11-13 Land Lane, Marston Green, Birmingham, B37 7DE", "country": "GB"}]}, {"statementID": "openownership-register-926083203046507683", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-08", "subject": {"describedByEntityStatement": "openownership-register-11671628070842014296"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-11671628070842014296",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SOLIHULL ACTION THROUGH ADVOCACY",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07945421"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07945421",
+                "uri": "https://opencorporates.com/companies/gb/07945421"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5018667e4ebf3405efe4e",
+                "uri": "http://register.openownership.org/entities/59c5018667e4ebf3405efe4e"
+            }
+        ],
+        "foundingDate": "2012-02-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "11-13 Land Lane, Marston Green, Birmingham, B37 7DE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-926083203046507683",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-08",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11671628070842014296"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07975563_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_07975563_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-9661412472226247757", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SOUTHERN DOMESTIC ABUSE SERVICE", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07975563"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07975563", "uri": "https://opencorporates.com/companies/gb/07975563"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c502e167e4ebf34061c5fe", "uri": "http://register.openownership.org/entities/59c502e167e4ebf34061c5fe"}], "foundingDate": "2012-03-05", "addresses": [{"type": "registered", "address": "Piper House Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX", "country": "GB"}]}, {"statementID": "openownership-register-3967553379318385919", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-05", "subject": {"describedByEntityStatement": "openownership-register-9661412472226247757"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-9661412472226247757",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SOUTHERN DOMESTIC ABUSE SERVICE",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07975563"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07975563",
+                "uri": "https://opencorporates.com/companies/gb/07975563"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c502e167e4ebf34061c5fe",
+                "uri": "http://register.openownership.org/entities/59c502e167e4ebf34061c5fe"
+            }
+        ],
+        "foundingDate": "2012-03-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Piper House Dukes Court, Bognor Road, Chichester, West Sussex, PO19 8FX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3967553379318385919",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-05",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9661412472226247757"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08229264_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08229264_bods.json
@@ -1,1 +1,295 @@
-[{"statementID": "openownership-register-9827140376955476556", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RICARDO-AEA LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08229264"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08229264", "uri": "https://opencorporates.com/companies/gb/08229264"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b959ca67e4ebf340ecb25f", "uri": "http://register.openownership.org/entities/59b959ca67e4ebf340ecb25f"}], "foundingDate": "2012-09-26", "addresses": [{"type": "registered", "address": "Shoreham Technical Centre, Old Shoreham Rd, Shoreham-By-Sea, West Sussex, BN43 5FG", "country": "GB"}]}, {"statementID": "openownership-register-14947150391504144383", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-10", "subject": {"describedByEntityStatement": "openownership-register-9827140376955476556"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11430334193575991250"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-10-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3048250175078400069", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9827140376955476556"}, "interestedParty": {"describedByEntityStatement": "openownership-register-16353169220408347084"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16353169220408347084", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RICARDO PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00222915"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00222915", "uri": "https://opencorporates.com/companies/gb/00222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "222915"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00222915"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b940da67e4ebf3407d5318", "uri": "http://register.openownership.org/entities/59b940da67e4ebf3407d5318"}], "foundingDate": "1927-06-30", "addresses": [{"type": "registered", "address": "Shoreham Technical Centre, Shoreham By Sea, West Sussex, BN43 5FG", "country": "GB"}]}, {"statementID": "openownership-register-11430334193575991250", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RICARDO INVESTMENTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02251330", "uri": "https://opencorporates.com/companies/gb/02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2251330"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "2251330"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02251330"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9681567e4ebf34031549f", "uri": "http://register.openownership.org/entities/59b9681567e4ebf34031549f"}], "foundingDate": "1988-05-04", "addresses": [{"type": "registered", "address": "Shoreham Technical Centre, Shoreham By Sea, West Sussex, BN43 5FG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9827140376955476556",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RICARDO-AEA LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08229264"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08229264",
+                "uri": "https://opencorporates.com/companies/gb/08229264"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b959ca67e4ebf340ecb25f",
+                "uri": "http://register.openownership.org/entities/59b959ca67e4ebf340ecb25f"
+            }
+        ],
+        "foundingDate": "2012-09-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Shoreham Technical Centre, Old Shoreham Rd, Shoreham-By-Sea, West Sussex, BN43 5FG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14947150391504144383",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9827140376955476556"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11430334193575991250"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-10-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3048250175078400069",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9827140376955476556"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-16353169220408347084"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16353169220408347084",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RICARDO PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00222915"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00222915",
+                "uri": "https://opencorporates.com/companies/gb/00222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "222915"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00222915"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b940da67e4ebf3407d5318",
+                "uri": "http://register.openownership.org/entities/59b940da67e4ebf3407d5318"
+            }
+        ],
+        "foundingDate": "1927-06-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Shoreham Technical Centre, Shoreham By Sea, West Sussex, BN43 5FG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11430334193575991250",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RICARDO INVESTMENTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02251330",
+                "uri": "https://opencorporates.com/companies/gb/02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "2251330"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02251330"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9681567e4ebf34031549f",
+                "uri": "http://register.openownership.org/entities/59b9681567e4ebf34031549f"
+            }
+        ],
+        "foundingDate": "1988-05-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Shoreham Technical Centre, Shoreham By Sea, West Sussex, BN43 5FG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08264781_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08264781_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-167359794930544466", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Y J C LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08264781"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08264781", "uri": "https://opencorporates.com/companies/gb/08264781"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b2a667e4ebf340668132", "uri": "http://register.openownership.org/entities/59b9b2a667e4ebf340668132"}], "foundingDate": "2012-10-23", "addresses": [{"type": "registered", "address": "Unit 1 Fernwood House, 5, Frederick Street, South Shields, Tyne And Wear, NE33 5DY", "country": "GB"}]}, {"statementID": "openownership-register-18165116401371715814", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-01", "subject": {"describedByEntityStatement": "openownership-register-167359794930544466"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13897148056960944354"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-01"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-04-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13897148056960944354", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Zhi Teng Chen"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08264781/persons-with-significant-control/individual/8_ABpEIUKCwZcTqffwBmvxO9l14"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9b2a667e4ebf340668137", "uri": "http://register.openownership.org/entities/59b9b2a667e4ebf340668137"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-11-01", "addresses": [{"address": "Unit 1, Fernwood House, 5, Frederick Street, South Shields, Tyne And Wear, NE33 5DY"}]}]
+[
+    {
+        "statementID": "openownership-register-167359794930544466",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Y J C LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08264781"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08264781",
+                "uri": "https://opencorporates.com/companies/gb/08264781"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b2a667e4ebf340668132",
+                "uri": "http://register.openownership.org/entities/59b9b2a667e4ebf340668132"
+            }
+        ],
+        "foundingDate": "2012-10-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 1 Fernwood House, 5, Frederick Street, South Shields, Tyne And Wear, NE33 5DY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18165116401371715814",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-167359794930544466"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13897148056960944354"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-04-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13897148056960944354",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Zhi Teng Chen"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08264781/persons-with-significant-control/individual/8_ABpEIUKCwZcTqffwBmvxO9l14"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9b2a667e4ebf340668137",
+                "uri": "http://register.openownership.org/entities/59b9b2a667e4ebf340668137"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "Unit 1, Fernwood House, 5, Frederick Street, South Shields, Tyne And Wear, NE33 5DY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08310037_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08310037_bods.json
@@ -1,1 +1,206 @@
-[{"statementID": "openownership-register-17432270389284248582", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REDWOOD GLOBAL HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08310037"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08310037"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08310037", "uri": "https://opencorporates.com/companies/gb/08310037"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9701267e4ebf340597965", "uri": "http://register.openownership.org/entities/59b9701267e4ebf340597965"}], "foundingDate": "2012-11-27", "addresses": [{"type": "registered", "address": "Walworth Business Park, 86 Livingstone Road, Andover, Hampshire, SP10 5NS", "country": "GB"}]}, {"statementID": "openownership-register-7584036128693495168", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-17432270389284248582"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14555506726398087300"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14533169198531055542", "statementType": "ownershipOrControlStatement", "statementDate": "2016-07-01", "subject": {"describedByEntityStatement": "openownership-register-17432270389284248582"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16816681859685786552"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-07-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-07-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16816681859685786552", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Douglas Ghinn"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08310037/persons-with-significant-control/individual/7V5PttWt_wYIWxHdrY2dnXiDDP4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9701267e4ebf34059796b", "uri": "http://register.openownership.org/entities/59b9701267e4ebf34059796b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1987-10-01", "addresses": [{"address": "Walworth Business Park 86 Livingstone Road, Andover, Hampshire, England, SP10 5NS"}]}, {"statementID": "openownership-register-14555506726398087300", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Raymond Gardner"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC376963/persons-with-significant-control/individual/CwuWGulD_JbG-a8Jiy9gltzKA-I"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b924d867e4ebf340fb78a7", "uri": "http://register.openownership.org/entities/59b924d867e4ebf340fb78a7"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1977-01-01", "addresses": [{"address": "Walworth Business Park, 86 Livingstone Road, Andover, Hampshire, SP10 5NS"}]}]
+[
+    {
+        "statementID": "openownership-register-17432270389284248582",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REDWOOD GLOBAL HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08310037"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08310037"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08310037",
+                "uri": "https://opencorporates.com/companies/gb/08310037"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9701267e4ebf340597965",
+                "uri": "http://register.openownership.org/entities/59b9701267e4ebf340597965"
+            }
+        ],
+        "foundingDate": "2012-11-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Walworth Business Park, 86 Livingstone Road, Andover, Hampshire, SP10 5NS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7584036128693495168",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17432270389284248582"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14555506726398087300"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14533169198531055542",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-07-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17432270389284248582"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16816681859685786552"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-07-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-07-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16816681859685786552",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Douglas Ghinn"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08310037/persons-with-significant-control/individual/7V5PttWt_wYIWxHdrY2dnXiDDP4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9701267e4ebf34059796b",
+                "uri": "http://register.openownership.org/entities/59b9701267e4ebf34059796b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1987-10-01",
+        "addresses": [
+            {
+                "address": "Walworth Business Park 86 Livingstone Road, Andover, Hampshire, England, SP10 5NS"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14555506726398087300",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Raymond Gardner"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC376963/persons-with-significant-control/individual/CwuWGulD_JbG-a8Jiy9gltzKA-I"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b924d867e4ebf340fb78a7",
+                "uri": "http://register.openownership.org/entities/59b924d867e4ebf340fb78a7"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1977-01-01",
+        "addresses": [
+            {
+                "address": "Walworth Business Park, 86 Livingstone Road, Andover, Hampshire, SP10 5NS"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08322856_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08322856_bods.json
@@ -1,1 +1,130 @@
-[{"statementID": "openownership-register-4508035442823591030", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REDCENTRIC SOLUTIONS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08322856"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08322856"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08322856", "uri": "https://opencorporates.com/companies/gb/08322856"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b16a5659dfc3fae18ed5839", "uri": "http://register.openownership.org/entities/5b16a5659dfc3fae18ed5839"}], "foundingDate": "2012-12-07", "addresses": [{"type": "registered", "address": "Central House, Beckwith Knowle, Harrogate, North Yorkshire, HG3 1UG", "country": "GB"}]}, {"statementID": "openownership-register-6463521420461938569", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4508035442823591030"}, "interestedParty": {"describedByEntityStatement": "openownership-register-205158923675308097"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-205158923675308097", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "REDCENTRIC PLC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08397584"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08397584"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08397584"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08397584", "uri": "https://opencorporates.com/companies/gb/08397584"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b16a2f89dfc3fae18e6f68a", "uri": "http://register.openownership.org/entities/5b16a2f89dfc3fae18e6f68a"}], "foundingDate": "2013-02-11", "addresses": [{"type": "registered", "address": "Central House, Beckwith Knowle, Harrogate, North Yorkshire, HG3 1UG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-4508035442823591030",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REDCENTRIC SOLUTIONS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08322856"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08322856"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08322856",
+                "uri": "https://opencorporates.com/companies/gb/08322856"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b16a5659dfc3fae18ed5839",
+                "uri": "http://register.openownership.org/entities/5b16a5659dfc3fae18ed5839"
+            }
+        ],
+        "foundingDate": "2012-12-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Central House, Beckwith Knowle, Harrogate, North Yorkshire, HG3 1UG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6463521420461938569",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4508035442823591030"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-205158923675308097"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-205158923675308097",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "REDCENTRIC PLC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08397584"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08397584"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08397584"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08397584",
+                "uri": "https://opencorporates.com/companies/gb/08397584"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b16a2f89dfc3fae18e6f68a",
+                "uri": "http://register.openownership.org/entities/5b16a2f89dfc3fae18e6f68a"
+            }
+        ],
+        "foundingDate": "2013-02-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Central House, Beckwith Knowle, Harrogate, North Yorkshire, HG3 1UG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08397525_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08397525_bods.json
@@ -1,1 +1,114 @@
-[{"statementID": "openownership-register-7304274729032299552", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MIDCO CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08397525"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08397525", "uri": "https://opencorporates.com/companies/gb/08397525"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f7067e4ebf340e6862f", "uri": "http://register.openownership.org/entities/59b98f7067e4ebf340e6862f"}], "foundingDate": "2013-02-11", "addresses": [{"type": "registered", "address": "Laxton House, 191 Lincoln Road, Peterborough, PE1 2PN", "country": "GB"}]}, {"statementID": "openownership-register-7010293915002988413", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-01", "subject": {"describedByEntityStatement": "openownership-register-7304274729032299552"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9278112927788432855"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-01-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-01-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9278112927788432855", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mzingaye Bhebe"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08397525/persons-with-significant-control/individual/38ikFAA8Xpwlu9UeI0WegbuXiqQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f7067e4ebf340e68639", "uri": "http://register.openownership.org/entities/59b98f7067e4ebf340e68639"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-04-01", "addresses": [{"address": "Laxton House, 191 Lincoln Road, Peterborough, PE1 2PN"}]}]
+[
+    {
+        "statementID": "openownership-register-7304274729032299552",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MIDCO CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08397525"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08397525",
+                "uri": "https://opencorporates.com/companies/gb/08397525"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f7067e4ebf340e6862f",
+                "uri": "http://register.openownership.org/entities/59b98f7067e4ebf340e6862f"
+            }
+        ],
+        "foundingDate": "2013-02-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Laxton House, 191 Lincoln Road, Peterborough, PE1 2PN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7010293915002988413",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7304274729032299552"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9278112927788432855"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-01-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9278112927788432855",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mzingaye Bhebe"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08397525/persons-with-significant-control/individual/38ikFAA8Xpwlu9UeI0WegbuXiqQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f7067e4ebf340e68639",
+                "uri": "http://register.openownership.org/entities/59b98f7067e4ebf340e68639"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-04-01",
+        "addresses": [
+            {
+                "address": "Laxton House, 191 Lincoln Road, Peterborough, PE1 2PN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08403375_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08403375_bods.json
@@ -1,1 +1,107 @@
-[{"statementID": "openownership-register-1042591150674724966", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LINKS TAXIS LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08403375"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08403375", "uri": "https://opencorporates.com/companies/gb/08403375"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969cfb", "uri": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969cfb"}], "foundingDate": "2013-02-14", "addresses": [{"type": "registered", "address": "11 Mendip Avenue, Grimsby, N.E. Lincolnshire, DN33 3AB", "country": "GB"}]}, {"statementID": "openownership-register-8584539567568715795", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-01", "subject": {"describedByEntityStatement": "openownership-register-1042591150674724966"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5470550189844250853"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2017-02-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-trust", "startDate": "2017-02-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2017-02-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5470550189844250853", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Gordon Grantham"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08403375/persons-with-significant-control/individual/QCNv4rYmLydMg7hhH_-RsIksSRo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969d03", "uri": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969d03"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1955-01-01", "addresses": [{"address": "11, Mendip Avenue, Grimsby, DN33 3AB"}]}]
+[
+    {
+        "statementID": "openownership-register-1042591150674724966",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LINKS TAXIS LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08403375"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08403375",
+                "uri": "https://opencorporates.com/companies/gb/08403375"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969cfb",
+                "uri": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969cfb"
+            }
+        ],
+        "foundingDate": "2013-02-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "11 Mendip Avenue, Grimsby, N.E. Lincolnshire, DN33 3AB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8584539567568715795",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-1042591150674724966"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5470550189844250853"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2017-02-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-trust",
+                "startDate": "2017-02-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2017-02-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5470550189844250853",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Gordon Grantham"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08403375/persons-with-significant-control/individual/QCNv4rYmLydMg7hhH_-RsIksSRo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969d03",
+                "uri": "http://register.openownership.org/entities/59b9bf0d67e4ebf340969d03"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1955-01-01",
+        "addresses": [
+            {
+                "address": "11, Mendip Avenue, Grimsby, DN33 3AB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08497028_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08497028_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-5117083330356038685", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BIRMINGHAM CITY UNIVERSITY ACADEMIES TRUST", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08497028"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08497028", "uri": "https://opencorporates.com/companies/gb/08497028"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5060d67e4ebf340688796", "uri": "http://register.openownership.org/entities/59c5060d67e4ebf340688796"}], "foundingDate": "2013-04-19", "addresses": [{"type": "registered", "address": "Birmingham City University University House, 15 Bartholomew Row, Birmingham, B5 5JU", "country": "GB"}]}, {"statementID": "openownership-register-2062225003777768743", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-19", "subject": {"describedByEntityStatement": "openownership-register-5117083330356038685"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-5117083330356038685",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BIRMINGHAM CITY UNIVERSITY ACADEMIES TRUST",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08497028"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08497028",
+                "uri": "https://opencorporates.com/companies/gb/08497028"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5060d67e4ebf340688796",
+                "uri": "http://register.openownership.org/entities/59c5060d67e4ebf340688796"
+            }
+        ],
+        "foundingDate": "2013-04-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Birmingham City University University House, 15 Bartholomew Row, Birmingham, B5 5JU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2062225003777768743",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5117083330356038685"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08815891_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08815891_bods.json
@@ -1,1 +1,203 @@
-[{"statementID": "openownership-register-5852273235919127580", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AGILENT TECHNOLOGIES LDA UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08815891"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08815891"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08815891"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08815891", "uri": "https://opencorporates.com/companies/gb/08815891"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08815891"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d07367e4ebf340d76f02", "uri": "http://register.openownership.org/entities/59b9d07367e4ebf340d76f02"}], "foundingDate": "2013-12-16", "addresses": [{"type": "registered", "address": "5500 Lakeside Cheadle Royal Business Park, Cheadle, Cheshire, SK8 3GR", "country": "GB"}]}, {"statementID": "openownership-register-8641902891681782656", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5852273235919127580"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1059606136091040749"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8757285031567154943", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5852273235919127580"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13721618443772522746"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1059606136091040749", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Agilent Technologies Inc.", "incorporatedInJurisdiction": {"name": "United States of America", "code": "US"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08815891/persons-with-significant-control/corporate-entity/-w4rtJK0TQb_pB2v_ySTO5EiwpM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5c11d67e9dfc3fae18da6881", "uri": "http://register.openownership.org/entities/5c11d67e9dfc3fae18da6881"}], "addresses": [{"type": "registered", "address": "5301, Stevens Creek Boulevard, Santa Clara, Ca 95051", "country": "US"}]}, {"statementID": "openownership-register-13721618443772522746", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Agilent Technologies Luxco S.\u00e0 r.l.", "incorporatedInJurisdiction": {"name": "Luxembourg", "code": "LU"}, "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08815891/persons-with-significant-control/corporate-entity/ehZdQfhnsNOWzswN5By7wE7GxB0"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/lu/B112905", "uri": "https://opencorporates.com/companies/lu/B112905"}, {"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08815891/persons-with-significant-control/corporate-entity/ehZdQfhnsNOWzswN5By7wE7GxB0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d9cd67e4ebf340f964a3", "uri": "http://register.openownership.org/entities/59b9d9cd67e4ebf340f964a3"}], "foundingDate": "2006-01-02", "addresses": [{"type": "registered", "address": "46A, Avenue JF Kennedy, L - 1855 Luxembourg", "country": "LU"}]}]
+[
+    {
+        "statementID": "openownership-register-5852273235919127580",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AGILENT TECHNOLOGIES LDA UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08815891"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08815891"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08815891"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08815891",
+                "uri": "https://opencorporates.com/companies/gb/08815891"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08815891"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d07367e4ebf340d76f02",
+                "uri": "http://register.openownership.org/entities/59b9d07367e4ebf340d76f02"
+            }
+        ],
+        "foundingDate": "2013-12-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5500 Lakeside Cheadle Royal Business Park, Cheadle, Cheshire, SK8 3GR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8641902891681782656",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5852273235919127580"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1059606136091040749"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8757285031567154943",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5852273235919127580"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13721618443772522746"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1059606136091040749",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Agilent Technologies Inc.",
+        "incorporatedInJurisdiction": {
+            "name": "United States of America",
+            "code": "US"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08815891/persons-with-significant-control/corporate-entity/-w4rtJK0TQb_pB2v_ySTO5EiwpM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5c11d67e9dfc3fae18da6881",
+                "uri": "http://register.openownership.org/entities/5c11d67e9dfc3fae18da6881"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5301, Stevens Creek Boulevard, Santa Clara, Ca 95051",
+                "country": "US"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13721618443772522746",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Agilent Technologies Luxco S.\u00e0 r.l.",
+        "incorporatedInJurisdiction": {
+            "name": "Luxembourg",
+            "code": "LU"
+        },
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08815891/persons-with-significant-control/corporate-entity/ehZdQfhnsNOWzswN5By7wE7GxB0"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/lu/B112905",
+                "uri": "https://opencorporates.com/companies/lu/B112905"
+            },
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08815891/persons-with-significant-control/corporate-entity/ehZdQfhnsNOWzswN5By7wE7GxB0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d9cd67e4ebf340f964a3",
+                "uri": "http://register.openownership.org/entities/59b9d9cd67e4ebf340f964a3"
+            }
+        ],
+        "foundingDate": "2006-01-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "46A, Avenue JF Kennedy, L - 1855 Luxembourg",
+                "country": "LU"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08900560_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08900560_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-9991404033050819269", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "YOU FIRST SUPPORT SERVICES CIC", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08900560"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08900560", "uri": "https://opencorporates.com/companies/gb/08900560"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c501f667e4ebf3405fd155", "uri": "http://register.openownership.org/entities/59c501f667e4ebf3405fd155"}], "foundingDate": "2014-02-18", "addresses": [{"type": "registered", "address": "28 Bower Hinton, Martock, TA12 6JY", "country": "GB"}]}, {"statementID": "openownership-register-10829596814212392791", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-18", "subject": {"describedByEntityStatement": "openownership-register-9991404033050819269"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-9991404033050819269",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "YOU FIRST SUPPORT SERVICES CIC",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08900560"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08900560",
+                "uri": "https://opencorporates.com/companies/gb/08900560"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c501f667e4ebf3405fd155",
+                "uri": "http://register.openownership.org/entities/59c501f667e4ebf3405fd155"
+            }
+        ],
+        "foundingDate": "2014-02-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "28 Bower Hinton, Martock, TA12 6JY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10829596814212392791",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9991404033050819269"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08925113_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08925113_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-16221987785674608307", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SUMMIT LODGE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08925113"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08925113", "uri": "https://opencorporates.com/companies/gb/08925113"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5dc", "uri": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5dc"}], "foundingDate": "2014-03-06", "addresses": [{"type": "registered", "address": "7 Holly Road, London, E11 2PF", "country": "GB"}]}, {"statementID": "openownership-register-2622297071238089131", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-16221987785674608307"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7612540595397716409"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-7612540595397716409", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Samuel Acheampong Adarkwa"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/08925113/persons-with-significant-control/individual/bUA-rQY69pHiwwnf3CFre6iA5sg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5ec", "uri": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5ec"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-10-01", "addresses": [{"address": "7, Holly Road, London, E11 2PF"}]}]
+[
+    {
+        "statementID": "openownership-register-16221987785674608307",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SUMMIT LODGE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08925113"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08925113",
+                "uri": "https://opencorporates.com/companies/gb/08925113"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5dc",
+                "uri": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5dc"
+            }
+        ],
+        "foundingDate": "2014-03-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "7 Holly Road, London, E11 2PF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2622297071238089131",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16221987785674608307"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7612540595397716409"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7612540595397716409",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Samuel Acheampong Adarkwa"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/08925113/persons-with-significant-control/individual/bUA-rQY69pHiwwnf3CFre6iA5sg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5ec",
+                "uri": "http://register.openownership.org/entities/59b9c2f967e4ebf340a5a5ec"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-10-01",
+        "addresses": [
+            {
+                "address": "7, Holly Road, London, E11 2PF"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08971493_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_08971493_bods.json
@@ -1,1 +1,144 @@
-[{"statementID": "openownership-register-16763506862047698132", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CHOICE SUPPORT", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "08971493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08971493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "08971493"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/08971493", "uri": "https://opencorporates.com/companies/gb/08971493"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8971493 And 1156486"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8971493 And 1156486"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "8971493"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9595567e4ebf340eab8da", "uri": "http://register.openownership.org/entities/59b9595567e4ebf340eab8da"}], "foundingDate": "2014-04-01", "addresses": [{"type": "registered", "address": "One Hermitage Court, Hermitage Lane, Maidstone, Kent, ME16 9NT", "country": "GB"}]}, {"statementID": "openownership-register-15646841950934085136", "statementType": "ownershipOrControlStatement", "statementDate": "2017-11-01", "subject": {"describedByEntityStatement": "openownership-register-16763506862047698132"}, "interestedParty": {"describedByEntityStatement": "openownership-register-14692541098764463518"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2017-11-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14692541098764463518", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PARTNERSHIP SUPPORT GROUP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10805894"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10805894"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10805894"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10805894"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10805894", "uri": "https://opencorporates.com/companies/gb/10805894"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba04b09dfc3fae184573cc", "uri": "http://register.openownership.org/entities/5aba04b09dfc3fae184573cc"}], "foundingDate": "2017-06-06", "addresses": [{"type": "registered", "address": "One - Ground Floor Hermitage Court, Hermitage Lane, Maidstone, Kent, ME16 9NT", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-16763506862047698132",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CHOICE SUPPORT",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08971493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08971493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "08971493"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/08971493",
+                "uri": "https://opencorporates.com/companies/gb/08971493"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8971493 And 1156486"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8971493 And 1156486"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "8971493"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9595567e4ebf340eab8da",
+                "uri": "http://register.openownership.org/entities/59b9595567e4ebf340eab8da"
+            }
+        ],
+        "foundingDate": "2014-04-01",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Hermitage Court, Hermitage Lane, Maidstone, Kent, ME16 9NT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15646841950934085136",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-11-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-16763506862047698132"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-14692541098764463518"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-11-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14692541098764463518",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PARTNERSHIP SUPPORT GROUP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10805894"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10805894"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10805894"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10805894"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10805894",
+                "uri": "https://opencorporates.com/companies/gb/10805894"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba04b09dfc3fae184573cc",
+                "uri": "http://register.openownership.org/entities/5aba04b09dfc3fae184573cc"
+            }
+        ],
+        "foundingDate": "2017-06-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One - Ground Floor Hermitage Court, Hermitage Lane, Maidstone, Kent, ME16 9NT",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09003518_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09003518_bods.json
@@ -1,1 +1,120 @@
-[{"statementID": "openownership-register-15748838470583377966", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DEVON ENABLING SERVICES LTD.", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09003518"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09003518", "uri": "https://opencorporates.com/companies/gb/09003518"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9631167e4ebf3401958b9", "uri": "http://register.openownership.org/entities/59b9631167e4ebf3401958b9"}], "foundingDate": "2014-04-22", "addresses": [{"type": "registered", "address": "26 St. Annes Road, Torquay, TQ1 3NX", "country": "GB"}]}, {"statementID": "openownership-register-9322590320947926559", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-28", "subject": {"describedByEntityStatement": "openownership-register-15748838470583377966"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11033765320354268914"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-11-28"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-11-28"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-11-28"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11033765320354268914", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Anthony Moore"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09003518/persons-with-significant-control/individual/L3ge2VJFHi-5sxosdVxyzg2QS88"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9631167e4ebf3401958c2", "uri": "http://register.openownership.org/entities/59b9631167e4ebf3401958c2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-03-01", "addresses": [{"address": "26, St. Annes Road, Torquay, TQ1 3NX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15748838470583377966",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DEVON ENABLING SERVICES LTD.",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09003518"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09003518",
+                "uri": "https://opencorporates.com/companies/gb/09003518"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9631167e4ebf3401958b9",
+                "uri": "http://register.openownership.org/entities/59b9631167e4ebf3401958b9"
+            }
+        ],
+        "foundingDate": "2014-04-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "26 St. Annes Road, Torquay, TQ1 3NX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9322590320947926559",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-28",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15748838470583377966"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11033765320354268914"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-28"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-28"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-11-28"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11033765320354268914",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Anthony Moore"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09003518/persons-with-significant-control/individual/L3ge2VJFHi-5sxosdVxyzg2QS88"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9631167e4ebf3401958c2",
+                "uri": "http://register.openownership.org/entities/59b9631167e4ebf3401958c2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-03-01",
+        "addresses": [
+            {
+                "address": "26, St. Annes Road, Torquay, TQ1 3NX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09198997_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09198997_bods.json
@@ -1,1 +1,169 @@
-[{"statementID": "openownership-register-12535003801379538234", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "YOUNG PEOPLE AT HEART LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09198997"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09198997", "uri": "https://opencorporates.com/companies/gb/09198997"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b938ab67e4ebf34057e28e", "uri": "http://register.openownership.org/entities/59b938ab67e4ebf34057e28e"}], "foundingDate": "2014-09-02", "addresses": [{"type": "registered", "address": "36 Rosslyn Park, Weybridge, KT13 9QZ", "country": "GB"}]}, {"statementID": "openownership-register-1184186360494773462", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-12535003801379538234"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2051142009650006771"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6674949479309458437", "statementType": "ownershipOrControlStatement", "statementDate": "2017-09-11", "subject": {"describedByEntityStatement": "openownership-register-12535003801379538234"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14155419400798982645"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2017-09-11"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2051142009650006771", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Gary Alan Cox"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09198997/persons-with-significant-control/individual/XHk7_OqtWz53cpolIb0PfNxUsJg"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b938ab67e4ebf34057e299", "uri": "http://register.openownership.org/entities/59b938ab67e4ebf34057e299"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-01-01", "addresses": [{"address": "36, Rosslyn Park, Weybridge, KT13 9QZ"}]}, {"statementID": "openownership-register-14155419400798982645", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Davina Elizabeth Cox"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/07554138/persons-with-significant-control/individual/J_7Lhe6_iYIgT1T4JOezEuDqnpA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99dd467e4ebf340189bc7", "uri": "http://register.openownership.org/entities/59b99dd467e4ebf340189bc7"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-04-01", "addresses": [{"address": "36, Rosslyn Park, Weybridge, KT13 9QZ"}]}]
+[
+    {
+        "statementID": "openownership-register-12535003801379538234",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "YOUNG PEOPLE AT HEART LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09198997"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09198997",
+                "uri": "https://opencorporates.com/companies/gb/09198997"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b938ab67e4ebf34057e28e",
+                "uri": "http://register.openownership.org/entities/59b938ab67e4ebf34057e28e"
+            }
+        ],
+        "foundingDate": "2014-09-02",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "36 Rosslyn Park, Weybridge, KT13 9QZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1184186360494773462",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12535003801379538234"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2051142009650006771"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6674949479309458437",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-09-11",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12535003801379538234"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14155419400798982645"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2017-09-11"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2051142009650006771",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Gary Alan Cox"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09198997/persons-with-significant-control/individual/XHk7_OqtWz53cpolIb0PfNxUsJg"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b938ab67e4ebf34057e299",
+                "uri": "http://register.openownership.org/entities/59b938ab67e4ebf34057e299"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-01-01",
+        "addresses": [
+            {
+                "address": "36, Rosslyn Park, Weybridge, KT13 9QZ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14155419400798982645",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Davina Elizabeth Cox"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/07554138/persons-with-significant-control/individual/J_7Lhe6_iYIgT1T4JOezEuDqnpA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99dd467e4ebf340189bc7",
+                "uri": "http://register.openownership.org/entities/59b99dd467e4ebf340189bc7"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-04-01",
+        "addresses": [
+            {
+                "address": "36, Rosslyn Park, Weybridge, KT13 9QZ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09312403_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09312403_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-4760525886887652960", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LDA DESIGN CONSULTING LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09312403"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09312403", "uri": "https://opencorporates.com/companies/gb/09312403"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4fa3067e4ebf3404fc398", "uri": "http://register.openownership.org/entities/59c4fa3067e4ebf3404fc398"}], "foundingDate": "2014-11-14", "addresses": [{"type": "registered", "address": "17 Minster Precincts, Peterborough, Cambridgeshire, PE1 1XX", "country": "GB"}]}, {"statementID": "openownership-register-11770855720113570345", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-14", "subject": {"describedByEntityStatement": "openownership-register-4760525886887652960"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-4760525886887652960",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LDA DESIGN CONSULTING LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09312403"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09312403",
+                "uri": "https://opencorporates.com/companies/gb/09312403"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4fa3067e4ebf3404fc398",
+                "uri": "http://register.openownership.org/entities/59c4fa3067e4ebf3404fc398"
+            }
+        ],
+        "foundingDate": "2014-11-14",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "17 Minster Precincts, Peterborough, Cambridgeshire, PE1 1XX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11770855720113570345",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4760525886887652960"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09329025_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09329025_bods.json
@@ -1,1 +1,124 @@
-[{"statementID": "openownership-register-5686982019986813044", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BABCOCK DSG LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09329025"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09329025", "uri": "https://opencorporates.com/companies/gb/09329025"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96ead67e4ebf34052ad64", "uri": "http://register.openownership.org/entities/59b96ead67e4ebf34052ad64"}], "foundingDate": "2014-11-26", "addresses": [{"type": "registered", "address": "33 Wigmore Street, London, W1U 1QX", "country": "GB"}]}, {"statementID": "openownership-register-2204502233003031239", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5686982019986813044"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6262980564623159276"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6262980564623159276", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BABCOCK LAND LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03493110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03493110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03493110"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03493110", "uri": "https://opencorporates.com/companies/gb/03493110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3493110"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3493110"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96eb067e4ebf34052b2a4", "uri": "http://register.openownership.org/entities/59b96eb067e4ebf34052b2a4"}], "foundingDate": "1998-01-15", "addresses": [{"type": "registered", "address": "33 Wigmore Street, London, W1U 1QX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5686982019986813044",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BABCOCK DSG LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09329025"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09329025",
+                "uri": "https://opencorporates.com/companies/gb/09329025"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96ead67e4ebf34052ad64",
+                "uri": "http://register.openownership.org/entities/59b96ead67e4ebf34052ad64"
+            }
+        ],
+        "foundingDate": "2014-11-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33 Wigmore Street, London, W1U 1QX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2204502233003031239",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5686982019986813044"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6262980564623159276"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6262980564623159276",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BABCOCK LAND LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03493110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03493110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03493110"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03493110",
+                "uri": "https://opencorporates.com/companies/gb/03493110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3493110"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3493110"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96eb067e4ebf34052b2a4",
+                "uri": "http://register.openownership.org/entities/59b96eb067e4ebf34052b2a4"
+            }
+        ],
+        "foundingDate": "1998-01-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "33 Wigmore Street, London, W1U 1QX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09340464_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09340464_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-5720253184165638449", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SUPREME LINGUISTIC SERVICES LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09340464"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09340464", "uri": "https://opencorporates.com/companies/gb/09340464"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a8e5", "uri": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a8e5"}], "foundingDate": "2014-12-04", "addresses": [{"type": "registered", "address": "Unit 4 Great Barr Business Park, Baltimore Road, Birmingham, B42 1DY", "country": "GB"}]}, {"statementID": "openownership-register-9805663801921780873", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5720253184165638449"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4931970913064715811"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-4931970913064715811", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ines Houidi"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09340464/persons-with-significant-control/individual/ygjGBOlC6xMxJuaNcbYXetchVb0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a906", "uri": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a906"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1983-10-01", "addresses": [{"address": "Unit 4, Great Barr Business Park, Baltimore Road, Birmingham, B42 1DY"}]}]
+[
+    {
+        "statementID": "openownership-register-5720253184165638449",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SUPREME LINGUISTIC SERVICES LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09340464"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09340464",
+                "uri": "https://opencorporates.com/companies/gb/09340464"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a8e5",
+                "uri": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a8e5"
+            }
+        ],
+        "foundingDate": "2014-12-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 4 Great Barr Business Park, Baltimore Road, Birmingham, B42 1DY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9805663801921780873",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5720253184165638449"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4931970913064715811"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4931970913064715811",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ines Houidi"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09340464/persons-with-significant-control/individual/ygjGBOlC6xMxJuaNcbYXetchVb0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a906",
+                "uri": "http://register.openownership.org/entities/59b923aa67e4ebf340f6a906"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1983-10-01",
+        "addresses": [
+            {
+                "address": "Unit 4, Great Barr Business Park, Baltimore Road, Birmingham, B42 1DY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09885585_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_09885585_bods.json
@@ -1,1 +1,120 @@
-[{"statementID": "openownership-register-5107949797889526030", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "NEW STREET TAXIS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "09885585"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/09885585", "uri": "https://opencorporates.com/companies/gb/09885585"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c53", "uri": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c53"}], "foundingDate": "2015-11-24", "dissolutionDate": "2019-04-30", "addresses": [{"type": "registered", "address": "Unit 3a Park Steet, Burton On Trent, Staffordshire, DE14 3TN", "country": "GB"}]}, {"statementID": "openownership-register-15544329181476583213", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-01", "subject": {"describedByEntityStatement": "openownership-register-5107949797889526030"}, "interestedParty": {"describedByPersonStatement": "openownership-register-609918801343123342"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-08-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-08-01"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-08-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-609918801343123342", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mohammed Rashid"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/09885585/persons-with-significant-control/individual/nPFKXTK1A1F6co9hu_5CREvxL0Q"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c5d", "uri": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c5d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-05-01", "addresses": [{"address": "Unit 3a, Park Steet, Burton On Trent, Staffordshire, DE14 3TN"}]}]
+[
+    {
+        "statementID": "openownership-register-5107949797889526030",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "NEW STREET TAXIS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "09885585"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/09885585",
+                "uri": "https://opencorporates.com/companies/gb/09885585"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c53",
+                "uri": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c53"
+            }
+        ],
+        "foundingDate": "2015-11-24",
+        "dissolutionDate": "2019-04-30",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Unit 3a Park Steet, Burton On Trent, Staffordshire, DE14 3TN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15544329181476583213",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5107949797889526030"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-609918801343123342"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-08-01"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-08-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-609918801343123342",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mohammed Rashid"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/09885585/persons-with-significant-control/individual/nPFKXTK1A1F6co9hu_5CREvxL0Q"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c5d",
+                "uri": "http://register.openownership.org/entities/59b991d567e4ebf340ee2c5d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-05-01",
+        "addresses": [
+            {
+                "address": "Unit 3a, Park Steet, Burton On Trent, Staffordshire, DE14 3TN"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10213143_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10213143_bods.json
@@ -1,1 +1,120 @@
-[{"statementID": "openownership-register-12655852439293565374", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "A1 TAXIS (ASHBY) LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10213143"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10213143", "uri": "https://opencorporates.com/companies/gb/10213143"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01003", "uri": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01003"}], "foundingDate": "2016-06-03", "addresses": [{"type": "registered", "address": "10 Brook Street, Ashby De-La-Zouch, Leicestershire, LE65 1HA", "country": "GB"}]}, {"statementID": "openownership-register-2473126479294287995", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-03", "subject": {"describedByEntityStatement": "openownership-register-12655852439293565374"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6925075715690003430"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-03"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-03"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6925075715690003430", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Samina Bibi"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10213143/persons-with-significant-control/individual/0mFHwqF790RDFiB8Eotg9N1mrII"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01010", "uri": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01010"}], "nationalities": [{"name": "Pakistan", "code": "PK"}], "birthDate": "1980-12-01", "addresses": [{"address": "10 Brook Street, Ashby De-La-Zouch, Leicestershire, LE65 1HA", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12655852439293565374",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "A1 TAXIS (ASHBY) LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10213143"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10213143",
+                "uri": "https://opencorporates.com/companies/gb/10213143"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01003",
+                "uri": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01003"
+            }
+        ],
+        "foundingDate": "2016-06-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "10 Brook Street, Ashby De-La-Zouch, Leicestershire, LE65 1HA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2473126479294287995",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12655852439293565374"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6925075715690003430"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-03"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-03"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6925075715690003430",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Samina Bibi"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10213143/persons-with-significant-control/individual/0mFHwqF790RDFiB8Eotg9N1mrII"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01010",
+                "uri": "http://register.openownership.org/entities/59b9ca3767e4ebf340c01010"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Pakistan",
+                "code": "PK"
+            }
+        ],
+        "birthDate": "1980-12-01",
+        "addresses": [
+            {
+                "address": "10 Brook Street, Ashby De-La-Zouch, Leicestershire, LE65 1HA",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10228384_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10228384_bods.json
@@ -1,1 +1,196 @@
-[{"statementID": "openownership-register-5865415560216516041", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "AIREY MILLER LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10228384"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10228384", "uri": "https://opencorporates.com/companies/gb/10228384"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d2851a", "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d2851a"}], "foundingDate": "2016-06-13", "addresses": [{"type": "registered", "address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL", "country": "GB"}]}, {"statementID": "openownership-register-4797329849661011277", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-14", "subject": {"describedByEntityStatement": "openownership-register-5865415560216516041"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2136846302799660582"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-14"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-06-14"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-452432506210788860", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-14", "subject": {"describedByEntityStatement": "openownership-register-5865415560216516041"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15096636990205924530"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-06-14"}, {"type": "voting-rights", "details": "voting-rights-50-to-75-percent", "share": {"minimum": 50, "maximum": 75, "exclusiveMinimum": true, "exclusiveMaximum": true}, "startDate": "2016-06-14"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-14"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2136846302799660582", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Michael Murray"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10228384/persons-with-significant-control/individual/aE8KomE_GTA05uJM7cCw-jA-bP0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28552", "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28552"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-12-01", "addresses": [{"address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL"}]}, {"statementID": "openownership-register-15096636990205924530", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter Charles Airey"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10228384/persons-with-significant-control/individual/jCVC49kQn4MMb5Y5XHglXR1WIME"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28536", "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28536"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-02-01", "addresses": [{"address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL"}]}]
+[
+    {
+        "statementID": "openownership-register-5865415560216516041",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "AIREY MILLER LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10228384"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10228384",
+                "uri": "https://opencorporates.com/companies/gb/10228384"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d2851a",
+                "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d2851a"
+            }
+        ],
+        "foundingDate": "2016-06-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4797329849661011277",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5865415560216516041"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2136846302799660582"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-14"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-14"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-452432506210788860",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-14",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5865415560216516041"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15096636990205924530"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-06-14"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-50-to-75-percent",
+                "share": {
+                    "minimum": 50,
+                    "maximum": 75,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": true
+                },
+                "startDate": "2016-06-14"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-14"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2136846302799660582",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Michael Murray"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10228384/persons-with-significant-control/individual/aE8KomE_GTA05uJM7cCw-jA-bP0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28552",
+                "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28552"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-12-01",
+        "addresses": [
+            {
+                "address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15096636990205924530",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter Charles Airey"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10228384/persons-with-significant-control/individual/jCVC49kQn4MMb5Y5XHglXR1WIME"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28536",
+                "uri": "http://register.openownership.org/entities/59b9cf2867e4ebf340d28536"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-02-01",
+        "addresses": [
+            {
+                "address": "Ground Floor, St John's House, Suffolk Way, Sevenoaks, TN13 1YL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10310534_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10310534_bods.json
@@ -1,1 +1,97 @@
-[{"statementID": "openownership-register-17656501771762153665", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ADEKAMS CARE SERVICES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10310534"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10310534", "uri": "https://opencorporates.com/companies/gb/10310534"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b4367e4ebf340172c83", "uri": "http://register.openownership.org/entities/59b92b4367e4ebf340172c83"}], "foundingDate": "2016-08-03", "addresses": [{"type": "registered", "address": "27 North Road, Brentwood, CM14 4UZ", "country": "GB"}]}, {"statementID": "openownership-register-5976756943388431845", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-03", "subject": {"describedByEntityStatement": "openownership-register-17656501771762153665"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12873226292424788928"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors-as-firm", "startDate": "2016-08-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12873226292424788928", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Adegbola Adeyemi Moliki"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/10310534/persons-with-significant-control/individual/k0zZ4eihZe-tipsYRwETmTVNPLE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b4367e4ebf340172c91", "uri": "http://register.openownership.org/entities/59b92b4367e4ebf340172c91"}], "nationalities": [{"name": "Germany", "code": "DE"}], "birthDate": "1974-04-01", "addresses": [{"address": "4, Melksham Green, Romford, RM3 8QT"}]}]
+[
+    {
+        "statementID": "openownership-register-17656501771762153665",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ADEKAMS CARE SERVICES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10310534"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10310534",
+                "uri": "https://opencorporates.com/companies/gb/10310534"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b4367e4ebf340172c83",
+                "uri": "http://register.openownership.org/entities/59b92b4367e4ebf340172c83"
+            }
+        ],
+        "foundingDate": "2016-08-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "27 North Road, Brentwood, CM14 4UZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5976756943388431845",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17656501771762153665"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12873226292424788928"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors-as-firm",
+                "startDate": "2016-08-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12873226292424788928",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Adegbola Adeyemi Moliki"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/10310534/persons-with-significant-control/individual/k0zZ4eihZe-tipsYRwETmTVNPLE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b4367e4ebf340172c91",
+                "uri": "http://register.openownership.org/entities/59b92b4367e4ebf340172c91"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "Germany",
+                "code": "DE"
+            }
+        ],
+        "birthDate": "1974-04-01",
+        "addresses": [
+            {
+                "address": "4, Melksham Green, Romford, RM3 8QT"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10486936_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_10486936_bods.json
@@ -1,1 +1,296 @@
-[{"statementID": "openownership-register-251882409127287750", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RSK ADAS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "10486936"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/10486936", "uri": "https://opencorporates.com/companies/gb/10486936"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "10486936"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c30b", "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c30b"}], "foundingDate": "2016-11-18", "addresses": [{"type": "registered", "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR", "country": "GB"}]}, {"statementID": "openownership-register-16732138829548214946", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-18", "subject": {"describedByEntityStatement": "openownership-register-251882409127287750"}, "interestedParty": {"describedByEntityStatement": "openownership-register-9871802860954631032"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-11-18"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-11-18"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-11-18"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13433376423401684378", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-18", "subject": {"describedByEntityStatement": "openownership-register-251882409127287750"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2299048395076470051"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-11-18", "endDate": "2017-11-11"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-11-18", "endDate": "2017-11-11"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-11-18", "endDate": "2017-11-11"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-08-16T09:24:39Z"}}, {"statementID": "openownership-register-2299048395076470051", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RSK GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03761340", "uri": "https://opencorporates.com/companies/gb/03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3761340"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6", "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6"}], "foundingDate": "1999-04-28", "addresses": [{"type": "registered", "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR", "country": "GB"}]}, {"statementID": "openownership-register-9871802860954631032", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "R.W. MANAGEMENT (HOLDINGS) LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03846486"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03846486"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03846486", "uri": "https://opencorporates.com/companies/gb/03846486"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9450667e4ebf3408dbc79", "uri": "http://register.openownership.org/entities/59b9450667e4ebf3408dbc79"}], "foundingDate": "1999-09-22", "addresses": [{"type": "registered", "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-251882409127287750",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RSK ADAS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10486936"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/10486936",
+                "uri": "https://opencorporates.com/companies/gb/10486936"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "10486936"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c30b",
+                "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c30b"
+            }
+        ],
+        "foundingDate": "2016-11-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16732138829548214946",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-251882409127287750"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-9871802860954631032"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-18"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-18"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-11-18"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13433376423401684378",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-251882409127287750"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2299048395076470051"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-18",
+                "endDate": "2017-11-11"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-11-18",
+                "endDate": "2017-11-11"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-11-18",
+                "endDate": "2017-11-11"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-08-16T09:24:39Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2299048395076470051",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RSK GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03761340",
+                "uri": "https://opencorporates.com/companies/gb/03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3761340"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6",
+                "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6"
+            }
+        ],
+        "foundingDate": "1999-04-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9871802860954631032",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "R.W. MANAGEMENT (HOLDINGS) LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03846486"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03846486"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03846486",
+                "uri": "https://opencorporates.com/companies/gb/03846486"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9450667e4ebf3408dbc79",
+                "uri": "http://register.openownership.org/entities/59b9450667e4ebf3408dbc79"
+            }
+        ],
+        "foundingDate": "1999-09-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11477319_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11477319_bods.json
@@ -1,1 +1,200 @@
-[{"statementID": "openownership-register-12416832128923487601", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MI CASA CARE LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11477319"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11477319", "uri": "https://opencorporates.com/companies/gb/11477319"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e195", "uri": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e195"}], "foundingDate": "2018-07-23", "addresses": [{"type": "registered", "address": "Burnaby House 12 Church Street, Mansfield Woodhouse, Mansfield, Nottinghamshire, NG19 8AH", "country": "GB"}]}, {"statementID": "openownership-register-11450395054868005769", "statementType": "ownershipOrControlStatement", "statementDate": "2018-07-23", "subject": {"describedByEntityStatement": "openownership-register-12416832128923487601"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12963734885424208671"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-07-23"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-07-23"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-07-23"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16300400265899072139", "statementType": "ownershipOrControlStatement", "statementDate": "2018-07-23", "subject": {"describedByEntityStatement": "openownership-register-12416832128923487601"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12441872901332335247"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-07-23", "endDate": "2020-04-01"}, {"type": "voting-rights", "details": "voting-rights-25-to-50-percent", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2018-07-23", "endDate": "2020-04-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-04-24T09:24:16Z"}}, {"statementID": "openownership-register-12441872901332335247", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Michaela Cooper"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11477319/persons-with-significant-control/individual/_ZevPobNnHEWEpfPi51R53XGdiQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e25d", "uri": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e25d"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1988-12-01", "addresses": [{"address": "2 Milla Court, Wilstock, Somerset, TA5 2RW", "country": "GB"}]}, {"statementID": "openownership-register-12963734885424208671", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Sophia Michelle Harris"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11432787/persons-with-significant-control/individual/mWE-zKpf4yTq3Gv50eoljiJFVp8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b617b6f9dfc3fae1809124e", "uri": "http://register.openownership.org/entities/5b617b6f9dfc3fae1809124e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1978-11-01", "addresses": [{"address": "All Saints Vicarage, Church Road, Clipstone, NG21 9DG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-12416832128923487601",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MI CASA CARE LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11477319"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11477319",
+                "uri": "https://opencorporates.com/companies/gb/11477319"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e195",
+                "uri": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e195"
+            }
+        ],
+        "foundingDate": "2018-07-23",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Burnaby House 12 Church Street, Mansfield Woodhouse, Mansfield, Nottinghamshire, NG19 8AH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11450395054868005769",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-07-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12416832128923487601"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12963734885424208671"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-23"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-23"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-07-23"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16300400265899072139",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-07-23",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-12416832128923487601"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12441872901332335247"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-23",
+                "endDate": "2020-04-01"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-07-23",
+                "endDate": "2020-04-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-04-24T09:24:16Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12441872901332335247",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michaela Cooper"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11477319/persons-with-significant-control/individual/_ZevPobNnHEWEpfPi51R53XGdiQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e25d",
+                "uri": "http://register.openownership.org/entities/5bbc51899dfc3fae18a7e25d"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1988-12-01",
+        "addresses": [
+            {
+                "address": "2 Milla Court, Wilstock, Somerset, TA5 2RW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12963734885424208671",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Sophia Michelle Harris"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11432787/persons-with-significant-control/individual/mWE-zKpf4yTq3Gv50eoljiJFVp8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b617b6f9dfc3fae1809124e",
+                "uri": "http://register.openownership.org/entities/5b617b6f9dfc3fae1809124e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1978-11-01",
+        "addresses": [
+            {
+                "address": "All Saints Vicarage, Church Road, Clipstone, NG21 9DG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11535946_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11535946_bods.json
@@ -1,1 +1,120 @@
-[{"statementID": "openownership-register-14198750154650353851", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JAKARANDA CARE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11535946"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11535946", "uri": "https://opencorporates.com/companies/gb/11535946"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbb763c9dfc3fae18360579", "uri": "http://register.openownership.org/entities/5bbb763c9dfc3fae18360579"}], "foundingDate": "2018-08-24", "addresses": [{"type": "registered", "address": "12 Plough Lane, Newborough, Peterborough, PE6 7SR", "country": "GB"}]}, {"statementID": "openownership-register-11175210421644384553", "statementType": "ownershipOrControlStatement", "statementDate": "2018-08-24", "subject": {"describedByEntityStatement": "openownership-register-14198750154650353851"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15111544636522483007"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-08-24"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-08-24"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-08-24"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-08-16T09:24:39Z"}}, {"statementID": "openownership-register-15111544636522483007", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Mandlenkosi Munyoro"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11535946/persons-with-significant-control/individual/JdzPKK6LYPQ9iQjtSGcy-K1cyqQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbb763c9dfc3fae183605fc", "uri": "http://register.openownership.org/entities/5bbb763c9dfc3fae183605fc"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-10-01", "addresses": [{"address": "59, London Road, Leicester, Leicestershire, LE2 0PE", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-14198750154650353851",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JAKARANDA CARE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11535946"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11535946",
+                "uri": "https://opencorporates.com/companies/gb/11535946"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbb763c9dfc3fae18360579",
+                "uri": "http://register.openownership.org/entities/5bbb763c9dfc3fae18360579"
+            }
+        ],
+        "foundingDate": "2018-08-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "12 Plough Lane, Newborough, Peterborough, PE6 7SR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11175210421644384553",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-08-24",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14198750154650353851"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15111544636522483007"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-08-24"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-08-24"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-08-24"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-08-16T09:24:39Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15111544636522483007",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Mandlenkosi Munyoro"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11535946/persons-with-significant-control/individual/JdzPKK6LYPQ9iQjtSGcy-K1cyqQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbb763c9dfc3fae183605fc",
+                "uri": "http://register.openownership.org/entities/5bbb763c9dfc3fae183605fc"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-10-01",
+        "addresses": [
+            {
+                "address": "59, London Road, Leicester, Leicestershire, LE2 0PE",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11675325_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_11675325_bods.json
@@ -1,1 +1,119 @@
-[{"statementID": "openownership-register-10658334186289859501", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COMMUNITY CARDIOLOGY LTD", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "11675325"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/11675325", "uri": "https://opencorporates.com/companies/gb/11675325"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca708a", "uri": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca708a"}], "foundingDate": "2018-11-13", "addresses": [{"type": "registered", "address": "7 Sorrells 7 The Sorrells, Stanford-Le-Hope Ss17 7dz, Stanford-Le-Hope, SS17 7DZ", "country": "GB"}]}, {"statementID": "openownership-register-9856347413490870934", "statementType": "ownershipOrControlStatement", "statementDate": "2018-11-13", "subject": {"describedByEntityStatement": "openownership-register-10658334186289859501"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4997885502304371347"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-11-13"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-11-13"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2018-11-13"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4997885502304371347", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Raymond Peprah Arhin"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/11675325/persons-with-significant-control/individual/jVlq2yKQPIAQMh7dQJsw39Ky2U8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca7116", "uri": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca7116"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-04-01", "addresses": [{"address": "29, Mary Rose Close, Grays, Essex, RM16 6LY"}]}]
+[
+    {
+        "statementID": "openownership-register-10658334186289859501",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COMMUNITY CARDIOLOGY LTD",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "11675325"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/11675325",
+                "uri": "https://opencorporates.com/companies/gb/11675325"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca708a",
+                "uri": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca708a"
+            }
+        ],
+        "foundingDate": "2018-11-13",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "7 Sorrells 7 The Sorrells, Stanford-Le-Hope Ss17 7dz, Stanford-Le-Hope, SS17 7DZ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9856347413490870934",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-11-13",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10658334186289859501"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4997885502304371347"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-11-13"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-11-13"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2018-11-13"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4997885502304371347",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Raymond Peprah Arhin"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/11675325/persons-with-significant-control/individual/jVlq2yKQPIAQMh7dQJsw39Ky2U8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca7116",
+                "uri": "http://register.openownership.org/entities/5bf44e4e9dfc3fae18ca7116"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-04-01",
+        "addresses": [
+            {
+                "address": "29, Mary Rose Close, Grays, Essex, RM16 6LY"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_IP22981R_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_IP22981R_bods.json
@@ -1,1 +1,52 @@
-[{"statementID": "openownership-register-90575489375525800", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HOME GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "IP22981R"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/IP22981R", "uri": "https://opencorporates.com/companies/gb/IP22981R"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ip22981r"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b925ea67e4ebf340fffb00", "uri": "http://register.openownership.org/entities/59b925ea67e4ebf340fffb00"}]}, {"statementID": "openownership-register-4519329004053078907", "statementType": "ownershipOrControlStatement", "subject": {"describedByEntityStatement": "openownership-register-90575489375525800"}, "interestedParty": {"unspecified": {"reason": "unknown", "description": "Unknown person(s)"}}, "interests": []}]
+[
+    {
+        "statementID": "openownership-register-90575489375525800",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HOME GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "IP22981R"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/IP22981R",
+                "uri": "https://opencorporates.com/companies/gb/IP22981R"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ip22981r"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b925ea67e4ebf340fffb00",
+                "uri": "http://register.openownership.org/entities/59b925ea67e4ebf340fffb00"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4519329004053078907",
+        "statementType": "ownershipOrControlStatement",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-90575489375525800"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "unknown",
+                "description": "Unknown person(s)"
+            }
+        },
+        "interests": []
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI003503_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI003503_bods.json
@@ -1,1 +1,198 @@
-[{"statementID": "openownership-register-5068739231110588824", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JOHN GRAHAM CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI003503"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/NI003503", "uri": "https://opencorporates.com/companies/gb/NI003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni003503"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni003503"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9701767e4ebf3405995a5", "uri": "http://register.openownership.org/entities/59b9701767e4ebf3405995a5"}], "foundingDate": "1955-03-29", "addresses": [{"type": "registered", "address": "5 Ballygowan Road, Hillsborough, County Down, BT26 6HX", "country": "GB"}]}, {"statementID": "openownership-register-327572377792050550", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5068739231110588824"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1021309547064406233"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1021309547064406233", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "JOHN GRAHAM HOLDINGS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI057921"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/NI057921", "uri": "https://opencorporates.com/companies/gb/NI057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni057921"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Ni57921"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9605967e4ebf3400c44b2", "uri": "http://register.openownership.org/entities/59b9605967e4ebf3400c44b2"}], "foundingDate": "2006-01-24", "addresses": [{"type": "registered", "address": "5 Ballygowan Road, Hillsborough, County Down, BT26 6HX", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5068739231110588824",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JOHN GRAHAM CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI003503"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/NI003503",
+                "uri": "https://opencorporates.com/companies/gb/NI003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni003503"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9701767e4ebf3405995a5",
+                "uri": "http://register.openownership.org/entities/59b9701767e4ebf3405995a5"
+            }
+        ],
+        "foundingDate": "1955-03-29",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Ballygowan Road, Hillsborough, County Down, BT26 6HX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-327572377792050550",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5068739231110588824"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1021309547064406233"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1021309547064406233",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "JOHN GRAHAM HOLDINGS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI057921"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/NI057921",
+                "uri": "https://opencorporates.com/companies/gb/NI057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni057921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Ni57921"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9605967e4ebf3400c44b2",
+                "uri": "http://register.openownership.org/entities/59b9605967e4ebf3400c44b2"
+            }
+        ],
+        "foundingDate": "2006-01-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Ballygowan Road, Hillsborough, County Down, BT26 6HX",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI015098_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI015098_bods.json
@@ -1,1 +1,103 @@
-[{"statementID": "openownership-register-15636376957939020111", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FAST ENGINEERING LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI015098"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/NI015098", "uri": "https://opencorporates.com/companies/gb/NI015098"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517e5", "uri": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517e5"}], "foundingDate": "1981-08-21", "addresses": [{"type": "registered", "address": "26 Waterloo Park,, Belfast., BT15 5HU", "country": "GB"}]}, {"statementID": "openownership-register-2628934996033315724", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15636376957939020111"}, "interestedParty": {"describedByPersonStatement": "openownership-register-5541292213653084137"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5541292213653084137", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "James Patrick Connolly"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/NI015098/persons-with-significant-control/individual/Td8CXk-OT-b0ZTneE5j0qZndDM8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517ec", "uri": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517ec"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1945-02-01", "addresses": [{"address": "26 Waterloo Park,, Belfast., BT15 5HU"}]}]
+[
+    {
+        "statementID": "openownership-register-15636376957939020111",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FAST ENGINEERING LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI015098"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/NI015098",
+                "uri": "https://opencorporates.com/companies/gb/NI015098"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517e5",
+                "uri": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517e5"
+            }
+        ],
+        "foundingDate": "1981-08-21",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "26 Waterloo Park,, Belfast., BT15 5HU",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2628934996033315724",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15636376957939020111"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-5541292213653084137"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5541292213653084137",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "James Patrick Connolly"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/NI015098/persons-with-significant-control/individual/Td8CXk-OT-b0ZTneE5j0qZndDM8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517ec",
+                "uri": "http://register.openownership.org/entities/59b98f0a67e4ebf340e517ec"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1945-02-01",
+        "addresses": [
+            {
+                "address": "26 Waterloo Park,, Belfast., BT15 5HU"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI018971_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_NI018971_bods.json
@@ -1,1 +1,97 @@
-[{"statementID": "openownership-register-7635287014850944796", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "POLLOCK LIFTS LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "NI018971"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/NI018971", "uri": "https://opencorporates.com/companies/gb/NI018971"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9732567e4ebf3406966f9", "uri": "http://register.openownership.org/entities/59b9732567e4ebf3406966f9"}], "foundingDate": "1985-11-27", "addresses": [{"type": "registered", "address": "1 Sloefield Drive, Trooperslane Industrial Estate, Carrickfergus, County Antrim, BT38 8GX", "country": "GB"}]}, {"statementID": "openownership-register-11428660781752612081", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7635287014850944796"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9143376923004105722"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9143376923004105722", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Thomas Saunders Graham"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/NI018971/persons-with-significant-control/individual/bGOsYMXeIzgytOcZc8QjgbDv9wQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9732567e4ebf340696706", "uri": "http://register.openownership.org/entities/59b9732567e4ebf340696706"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1954-04-01", "addresses": [{"address": "1, Sloefield Drive, Trooperslane Industrial Estate, Carrickfergus, County Antrim, BT38 8GX"}]}]
+[
+    {
+        "statementID": "openownership-register-7635287014850944796",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "POLLOCK LIFTS LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "NI018971"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/NI018971",
+                "uri": "https://opencorporates.com/companies/gb/NI018971"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9732567e4ebf3406966f9",
+                "uri": "http://register.openownership.org/entities/59b9732567e4ebf3406966f9"
+            }
+        ],
+        "foundingDate": "1985-11-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Sloefield Drive, Trooperslane Industrial Estate, Carrickfergus, County Antrim, BT38 8GX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11428660781752612081",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7635287014850944796"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9143376923004105722"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9143376923004105722",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Thomas Saunders Graham"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/NI018971/persons-with-significant-control/individual/bGOsYMXeIzgytOcZc8QjgbDv9wQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9732567e4ebf340696706",
+                "uri": "http://register.openownership.org/entities/59b9732567e4ebf340696706"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1954-04-01",
+        "addresses": [
+            {
+                "address": "1, Sloefield Drive, Trooperslane Industrial Estate, Carrickfergus, County Antrim, BT38 8GX"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC301540_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC301540_bods.json
@@ -1,1 +1,345 @@
-[{"statementID": "openownership-register-15258958358566601261", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KPMG LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC301540"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC301540", "uri": "https://opencorporates.com/companies/gb/OC301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc301540"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91b7567e4ebf340d981e9", "uri": "http://register.openownership.org/entities/59b91b7567e4ebf340d981e9"}], "foundingDate": "2002-02-22", "addresses": [{"type": "registered", "address": "15 Canada Square, London, E14 5GL", "country": "GB"}]}, {"statementID": "openownership-register-14590813293760114091", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-22", "subject": {"describedByEntityStatement": "openownership-register-15258958358566601261"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-15258958358566601261",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KPMG LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC301540"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC301540",
+                "uri": "https://opencorporates.com/companies/gb/OC301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc301540"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91b7567e4ebf340d981e9",
+                "uri": "http://register.openownership.org/entities/59b91b7567e4ebf340d981e9"
+            }
+        ],
+        "foundingDate": "2002-02-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "15 Canada Square, London, E14 5GL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14590813293760114091",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-22",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15258958358566601261"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC303675_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC303675_bods.json
@@ -1,1 +1,225 @@
-[{"statementID": "openownership-register-18100939493846870241", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DELOITTE LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC303675"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC303675", "uri": "https://opencorporates.com/companies/gb/OC303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc303675"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b935bc67e4ebf3404a8117", "uri": "http://register.openownership.org/entities/59b935bc67e4ebf3404a8117"}], "foundingDate": "2003-01-10", "addresses": [{"type": "registered", "address": "1 New Street Square, London, EC4A 3HQ", "country": "GB"}]}, {"statementID": "openownership-register-15140616129245642329", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-31", "subject": {"describedByEntityStatement": "openownership-register-18100939493846870241"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-18100939493846870241",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DELOITTE LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC303675"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC303675",
+                "uri": "https://opencorporates.com/companies/gb/OC303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc303675"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b935bc67e4ebf3404a8117",
+                "uri": "http://register.openownership.org/entities/59b935bc67e4ebf3404a8117"
+            }
+        ],
+        "foundingDate": "2003-01-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 New Street Square, London, EC4A 3HQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15140616129245642329",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-18100939493846870241"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC304065_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC304065_bods.json
@@ -1,1 +1,535 @@
-[{"statementID": "openownership-register-11355115368097641139", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "EVERSHEDS SUTHERLAND (INTERNATIONAL) LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304065"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC304065", "uri": "https://opencorporates.com/companies/gb/OC304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc304065"}, {"schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora", "id": "oc304065"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9387b67e4ebf3405710eb", "uri": "http://register.openownership.org/entities/59b9387b67e4ebf3405710eb"}], "foundingDate": "2003-03-05", "addresses": [{"type": "registered", "address": "One Wood Street, London, EC2V 7WS", "country": "GB"}]}, {"statementID": "openownership-register-17892237778488292424", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12741447921334195179"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2017-05-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-4450917633751563063", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-01", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14047504090590826825"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2017-05-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15514984305491478929", "statementType": "ownershipOrControlStatement", "statementDate": "2019-03-12", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4500269519399064286"}, "interests": [], "source": {"type": ["officialRegister"], "description": "SK Register Partnerov Verejn\u00e9ho Sektora", "url": "https://rpvs.gov.sk/", "retrievedAt": "2019-11-04T10:52:49Z"}}, {"statementID": "openownership-register-14498031966007697676", "statementType": "ownershipOrControlStatement", "statementDate": "2019-03-12", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12459719141335438325"}, "interests": [], "source": {"type": ["officialRegister"], "description": "SK Register Partnerov Verejn\u00e9ho Sektora", "url": "https://rpvs.gov.sk/", "retrievedAt": "2019-11-04T10:52:49Z"}}, {"statementID": "openownership-register-13312292945543177521", "statementType": "ownershipOrControlStatement", "statementDate": "2019-03-12", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6316473453339195071"}, "interests": [], "source": {"type": ["officialRegister"], "description": "SK Register Partnerov Verejn\u00e9ho Sektora", "url": "https://rpvs.gov.sk/", "retrievedAt": "2019-11-04T10:52:49Z"}}, {"statementID": "openownership-register-12394404633553742109", "statementType": "ownershipOrControlStatement", "statementDate": "2019-03-12", "subject": {"describedByEntityStatement": "openownership-register-11355115368097641139"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16839446427242473729"}, "interests": [], "source": {"type": ["officialRegister"], "description": "SK Register Partnerov Verejn\u00e9ho Sektora", "url": "https://rpvs.gov.sk/", "retrievedAt": "2019-11-04T10:52:49Z"}}, {"statementID": "openownership-register-12741447921334195179", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Bryan Gordon Hughes"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC367681/persons-with-significant-control/individual/4erMwW15nxE_XDNawGZvzQxFG9w"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5ab98f2c9dfc3fae18196a4c", "uri": "http://register.openownership.org/entities/5ab98f2c9dfc3fae18196a4c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-11-01", "addresses": [{"address": "One, Wood Street, London, EC2V 7WS", "country": "GB"}]}, {"statementID": "openownership-register-14047504090590826825", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Lee Ranson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC367681/persons-with-significant-control/individual/HXBonjGR34r5eA2IoUcAXs1Byr8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d89a67e4ebf340f498ea", "uri": "http://register.openownership.org/entities/59b9d89a67e4ebf340f498ea"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-12-01", "addresses": [{"address": "One, Wood Street, London, EC2V 7WS", "country": "GB"}]}, {"statementID": "openownership-register-4500269519399064286", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Julian Philip Nigel Lee"}], "identifiers": [{"schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora", "id": "122124"}, {"scheme": "MISC-Slovakia PSP Register", "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility", "id": "122124"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868b8", "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868b8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-09-27", "addresses": [{"address": "Apartment 25.03, Aragon Tower, Lond\u00fdn, SE8 3AL"}]}, {"statementID": "openownership-register-12459719141335438325", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ian John Basil Gray"}], "identifiers": [{"schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora", "id": "122125"}, {"scheme": "MISC-Slovakia PSP Register", "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility", "id": "122125"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868c2", "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868c2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-04-26", "addresses": [{"address": "Tramore, 3 Stonewell, Shippon, Abington, OX13 6LW"}]}, {"statementID": "openownership-register-6316473453339195071", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Keith Froud"}], "identifiers": [{"schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora", "id": "122126"}, {"scheme": "MISC-Slovakia PSP Register", "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility", "id": "122126"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868d2", "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868d2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-09-14", "addresses": [{"address": "High Meadows, Wescoe Hill Lane, Weeton, Leeds, LS17 0AS"}]}, {"statementID": "openownership-register-16839446427242473729", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Lee Ranson"}], "identifiers": [{"schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora", "id": "122127"}, {"scheme": "MISC-Slovakia PSP Register", "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility", "id": "122127"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868f0", "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868f0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-12-16", "addresses": [{"address": "4 Ogden Road, Bramhall, Stockport, SK7 1HJ"}]}]
+[
+    {
+        "statementID": "openownership-register-11355115368097641139",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "EVERSHEDS SUTHERLAND (INTERNATIONAL) LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304065"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC304065",
+                "uri": "https://opencorporates.com/companies/gb/OC304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc304065"
+            },
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "oc304065"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9387b67e4ebf3405710eb",
+                "uri": "http://register.openownership.org/entities/59b9387b67e4ebf3405710eb"
+            }
+        ],
+        "foundingDate": "2003-03-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Wood Street, London, EC2V 7WS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17892237778488292424",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12741447921334195179"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2017-05-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4450917633751563063",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14047504090590826825"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2017-05-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15514984305491478929",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-03-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4500269519399064286"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14498031966007697676",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-03-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12459719141335438325"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13312292945543177521",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-03-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6316473453339195071"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12394404633553742109",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-03-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11355115368097641139"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16839446427242473729"
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "SK Register Partnerov Verejn\u00e9ho Sektora",
+            "url": "https://rpvs.gov.sk/",
+            "retrievedAt": "2019-11-04T10:52:49Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12741447921334195179",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Bryan Gordon Hughes"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC367681/persons-with-significant-control/individual/4erMwW15nxE_XDNawGZvzQxFG9w"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5ab98f2c9dfc3fae18196a4c",
+                "uri": "http://register.openownership.org/entities/5ab98f2c9dfc3fae18196a4c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-11-01",
+        "addresses": [
+            {
+                "address": "One, Wood Street, London, EC2V 7WS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-14047504090590826825",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Lee Ranson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC367681/persons-with-significant-control/individual/HXBonjGR34r5eA2IoUcAXs1Byr8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d89a67e4ebf340f498ea",
+                "uri": "http://register.openownership.org/entities/59b9d89a67e4ebf340f498ea"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-12-01",
+        "addresses": [
+            {
+                "address": "One, Wood Street, London, EC2V 7WS",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4500269519399064286",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Julian Philip Nigel Lee"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "122124"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "122124"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868b8",
+                "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868b8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-09-27",
+        "addresses": [
+            {
+                "address": "Apartment 25.03, Aragon Tower, Lond\u00fdn, SE8 3AL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12459719141335438325",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ian John Basil Gray"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "122125"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "122125"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868c2",
+                "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868c2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-04-26",
+        "addresses": [
+            {
+                "address": "Tramore, 3 Stonewell, Shippon, Abington, OX13 6LW"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6316473453339195071",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Keith Froud"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "122126"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "122126"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868d2",
+                "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868d2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-09-14",
+        "addresses": [
+            {
+                "address": "High Meadows, Wescoe Hill Lane, Weeton, Leeds, LS17 0AS"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16839446427242473729",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Lee Ranson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "SK Register Partnerov Verejn\u00e9ho Sektora",
+                "id": "122127"
+            },
+            {
+                "scheme": "MISC-Slovakia PSP Register",
+                "schemeName": "Not a valid Org-Id scheme, provided for backwards compatibility",
+                "id": "122127"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868f0",
+                "uri": "http://register.openownership.org/entities/5dc00e9f9dfc3fae188868f0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-12-16",
+        "addresses": [
+            {
+                "address": "4 Ogden Road, Bramhall, Stockport, SK7 1HJ"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC304417_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC304417_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-6573060773100090617", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CARTER JONAS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC304417"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC304417", "uri": "https://opencorporates.com/companies/gb/OC304417"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4fdd567e4ebf3405716a8", "uri": "http://register.openownership.org/entities/59c4fdd567e4ebf3405716a8"}], "foundingDate": "2003-04-11", "addresses": [{"type": "registered", "address": "One, Chapel Place, London, W1G 0BG", "country": "GB"}]}, {"statementID": "openownership-register-9841581836779289305", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-31", "subject": {"describedByEntityStatement": "openownership-register-6573060773100090617"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-6573060773100090617",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CARTER JONAS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC304417"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC304417",
+                "uri": "https://opencorporates.com/companies/gb/OC304417"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4fdd567e4ebf3405716a8",
+                "uri": "http://register.openownership.org/entities/59c4fdd567e4ebf3405716a8"
+            }
+        ],
+        "foundingDate": "2003-04-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One, Chapel Place, London, W1G 0BG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9841581836779289305",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-31",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-6573060773100090617"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC305934_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC305934_bods.json
@@ -1,1 +1,273 @@
-[{"statementID": "openownership-register-14186510566899574640", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "KNIGHT FRANK LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC305934"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC305934", "uri": "https://opencorporates.com/companies/gb/OC305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc305934"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9316067e4ebf34034a269", "uri": "http://register.openownership.org/entities/59b9316067e4ebf34034a269"}], "foundingDate": "2003-11-03", "addresses": [{"type": "registered", "address": "55 Baker Street, London, W1U 8AN", "country": "GB"}]}, {"statementID": "openownership-register-7442169679566259805", "statementType": "ownershipOrControlStatement", "statementDate": "2016-11-03", "subject": {"describedByEntityStatement": "openownership-register-14186510566899574640"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-14186510566899574640",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "KNIGHT FRANK LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC305934"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC305934",
+                "uri": "https://opencorporates.com/companies/gb/OC305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc305934"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9316067e4ebf34034a269",
+                "uri": "http://register.openownership.org/entities/59b9316067e4ebf34034a269"
+            }
+        ],
+        "foundingDate": "2003-11-03",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "55 Baker Street, London, W1U 8AN",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7442169679566259805",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-11-03",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14186510566899574640"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC307138_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC307138_bods.json
@@ -1,1 +1,100 @@
-[{"statementID": "openownership-register-15478742157055774516", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WARDELL ARMSTRONG LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC307138"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC307138", "uri": "https://opencorporates.com/companies/gb/OC307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc307138"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc307138"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92b9767e4ebf340189ed6", "uri": "http://register.openownership.org/entities/59b92b9767e4ebf340189ed6"}], "foundingDate": "2004-03-04", "addresses": [{"type": "registered", "address": "Sir Henry Doulton House Forge, Lane Etruria Stoke On Trent, Staffordshire, ST1 5BD", "country": "GB"}]}, {"statementID": "openownership-register-5294881441179871011", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-01", "subject": {"describedByEntityStatement": "openownership-register-15478742157055774516"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-15478742157055774516",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WARDELL ARMSTRONG LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC307138"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC307138",
+                "uri": "https://opencorporates.com/companies/gb/OC307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc307138"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc307138"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92b9767e4ebf340189ed6",
+                "uri": "http://register.openownership.org/entities/59b92b9767e4ebf340189ed6"
+            }
+        ],
+        "foundingDate": "2004-03-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Sir Henry Doulton House Forge, Lane Etruria Stoke On Trent, Staffordshire, ST1 5BD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5294881441179871011",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15478742157055774516"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC308658_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC308658_bods.json
@@ -1,1 +1,258 @@
-[{"statementID": "openownership-register-2909554497019989923", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "TLT LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC308658"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC308658", "uri": "https://opencorporates.com/companies/gb/OC308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc308658"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91ed567e4ebf340e4514a", "uri": "http://register.openownership.org/entities/59b91ed567e4ebf340e4514a"}], "foundingDate": "2004-07-16", "addresses": [{"type": "registered", "address": "One Redcliff Street, Bristol, BS1 6TP", "country": "GB"}]}, {"statementID": "openownership-register-2538818158793711564", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2909554497019989923"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7979646986329302845"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13554082440623453527", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2909554497019989923"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8429986132395477145"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7979646986329302845", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Peter Pester"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC308658/persons-with-significant-control/individual/9zWLW0cuzEYqdsDVhBPyLh1lVpA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f2f3", "uri": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f2f3"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-05-01", "addresses": [{"address": "One Redcliff Street, Bristol, BS1 6TP"}]}, {"statementID": "openownership-register-8429986132395477145", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Stephen John Willson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC308658/persons-with-significant-control/individual/JxX8TPogcer54BpHWj_gX9XuTlM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f36e", "uri": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f36e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1969-10-01", "addresses": [{"address": "One Redcliff Street, Bristol, BS1 6TP", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2909554497019989923",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "TLT LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC308658"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC308658",
+                "uri": "https://opencorporates.com/companies/gb/OC308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc308658"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91ed567e4ebf340e4514a",
+                "uri": "http://register.openownership.org/entities/59b91ed567e4ebf340e4514a"
+            }
+        ],
+        "foundingDate": "2004-07-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One Redcliff Street, Bristol, BS1 6TP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2538818158793711564",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2909554497019989923"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7979646986329302845"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13554082440623453527",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2909554497019989923"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8429986132395477145"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7979646986329302845",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Peter Pester"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC308658/persons-with-significant-control/individual/9zWLW0cuzEYqdsDVhBPyLh1lVpA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f2f3",
+                "uri": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f2f3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-05-01",
+        "addresses": [
+            {
+                "address": "One Redcliff Street, Bristol, BS1 6TP"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8429986132395477145",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Stephen John Willson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC308658/persons-with-significant-control/individual/JxX8TPogcer54BpHWj_gX9XuTlM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f36e",
+                "uri": "http://register.openownership.org/entities/59b9243f67e4ebf340f8f36e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1969-10-01",
+        "addresses": [
+            {
+                "address": "One Redcliff Street, Bristol, BS1 6TP",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC309219_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC309219_bods.json
@@ -1,1 +1,80 @@
-[{"statementID": "openownership-register-5678958064539308530", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BEVAN BRITTAN LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309219"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC309219", "uri": "https://opencorporates.com/companies/gb/OC309219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309219"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309219"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9485367e4ebf3409e0a22", "uri": "http://register.openownership.org/entities/59b9485367e4ebf3409e0a22"}], "foundingDate": "2004-09-09", "addresses": [{"type": "registered", "address": "Kings Orchard, 1 Queen Street, Bristol, BS2 0HQ", "country": "GB"}]}, {"statementID": "openownership-register-13547956184808332983", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-09", "subject": {"describedByEntityStatement": "openownership-register-5678958064539308530"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-5678958064539308530",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BEVAN BRITTAN LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309219"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC309219",
+                "uri": "https://opencorporates.com/companies/gb/OC309219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309219"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309219"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9485367e4ebf3409e0a22",
+                "uri": "http://register.openownership.org/entities/59b9485367e4ebf3409e0a22"
+            }
+        ],
+        "foundingDate": "2004-09-09",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Kings Orchard, 1 Queen Street, Bristol, BS2 0HQ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13547956184808332983",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-09",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5678958064539308530"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC309501_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC309501_bods.json
@@ -1,1 +1,100 @@
-[{"statementID": "openownership-register-4176543203230166451", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BRABNERS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC309501"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC309501", "uri": "https://opencorporates.com/companies/gb/OC309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309501"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc309501"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b978b667e4ebf340846184", "uri": "http://register.openownership.org/entities/59b978b667e4ebf340846184"}], "foundingDate": "2004-10-07", "addresses": [{"type": "registered", "address": "Horton House, Exchange Flags, Liverpool, Merseyside, L2 3YL", "country": "GB"}]}, {"statementID": "openownership-register-15004535691719646976", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-07", "subject": {"describedByEntityStatement": "openownership-register-4176543203230166451"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-4176543203230166451",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BRABNERS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC309501"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC309501",
+                "uri": "https://opencorporates.com/companies/gb/OC309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309501"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc309501"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b978b667e4ebf340846184",
+                "uri": "http://register.openownership.org/entities/59b978b667e4ebf340846184"
+            }
+        ],
+        "foundingDate": "2004-10-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Horton House, Exchange Flags, Liverpool, Merseyside, L2 3YL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15004535691719646976",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-07",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4176543203230166451"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC312072_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC312072_bods.json
@@ -1,1 +1,108 @@
-[{"statementID": "openownership-register-9220721173195754129", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "MONTAGU EVANS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC312072"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC312072"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC312072", "uri": "https://opencorporates.com/companies/gb/OC312072"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc312072"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b967e367e4ebf340302398", "uri": "http://register.openownership.org/entities/59b967e367e4ebf340302398"}], "foundingDate": "2005-03-11", "addresses": [{"type": "registered", "address": "5 Bolton Street, London, W1J 8BA", "country": "GB"}]}, {"statementID": "openownership-register-9236401626114207773", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-9220721173195754129"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10793348860452187452"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-10793348860452187452", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Vern Bower"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC312072/persons-with-significant-control/individual/tqEwuZ6JQVaMRhbWfNUBKbNLCDw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b996b467e4ebf340ff37f2", "uri": "http://register.openownership.org/entities/59b996b467e4ebf340ff37f2"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-07-01", "addresses": [{"address": "5, Bolton Street, London, W1J 8BA"}]}]
+[
+    {
+        "statementID": "openownership-register-9220721173195754129",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "MONTAGU EVANS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC312072"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC312072"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC312072",
+                "uri": "https://opencorporates.com/companies/gb/OC312072"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc312072"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b967e367e4ebf340302398",
+                "uri": "http://register.openownership.org/entities/59b967e367e4ebf340302398"
+            }
+        ],
+        "foundingDate": "2005-03-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5 Bolton Street, London, W1J 8BA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9236401626114207773",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9220721173195754129"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10793348860452187452"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10793348860452187452",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Vern Bower"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC312072/persons-with-significant-control/individual/tqEwuZ6JQVaMRhbWfNUBKbNLCDw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b996b467e4ebf340ff37f2",
+                "uri": "http://register.openownership.org/entities/59b996b467e4ebf340ff37f2"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-07-01",
+        "addresses": [
+            {
+                "address": "5, Bolton Street, London, W1J 8BA"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC313432_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC313432_bods.json
@@ -1,1 +1,110 @@
-[{"statementID": "openownership-register-14762683523055955071", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ANTHONY COLLINS SOLICITORS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC313432"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC313432", "uri": "https://opencorporates.com/companies/gb/OC313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc313432"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c5094967e4ebf3406fd23a", "uri": "http://register.openownership.org/entities/59c5094967e4ebf3406fd23a"}], "foundingDate": "2005-05-27", "addresses": [{"type": "registered", "address": "134 Edmund Street, Birmingham, West Midlands, B3 2ES", "country": "GB"}]}, {"statementID": "openownership-register-5946700639338884870", "statementType": "ownershipOrControlStatement", "statementDate": "2017-05-27", "subject": {"describedByEntityStatement": "openownership-register-14762683523055955071"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-14762683523055955071",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ANTHONY COLLINS SOLICITORS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC313432"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC313432",
+                "uri": "https://opencorporates.com/companies/gb/OC313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc313432"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c5094967e4ebf3406fd23a",
+                "uri": "http://register.openownership.org/entities/59c5094967e4ebf3406fd23a"
+            }
+        ],
+        "foundingDate": "2005-05-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "134 Edmund Street, Birmingham, West Midlands, B3 2ES",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5946700639338884870",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-05-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14762683523055955071"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC315838_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC315838_bods.json
@@ -1,1 +1,102 @@
-[{"statementID": "openownership-register-7789199955797399213", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CALFORDSEADEN LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315838"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC315838", "uri": "https://opencorporates.com/companies/gb/OC315838"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c003", "uri": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c003"}], "foundingDate": "2005-10-27", "addresses": [{"type": "registered", "address": "Devonshire House, 60 Goswell Road, London, EC1M 7AD", "country": "GB"}]}, {"statementID": "openownership-register-9344057343743080962", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7789199955797399213"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2877206167559957384"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-as-firm-limited-liability-partnership", "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2877206167559957384", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Paul Miller"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315838/persons-with-significant-control/individual/WLaX_SeMlXRnmpz5kjQ5mw4KhbI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c014", "uri": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c014"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1961-08-01", "addresses": [{"address": "The Granary, Chelsham Road, Warlingham, CR6 9PA"}]}]
+[
+    {
+        "statementID": "openownership-register-7789199955797399213",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CALFORDSEADEN LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315838"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC315838",
+                "uri": "https://opencorporates.com/companies/gb/OC315838"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c003",
+                "uri": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c003"
+            }
+        ],
+        "foundingDate": "2005-10-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Devonshire House, 60 Goswell Road, London, EC1M 7AD",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9344057343743080962",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7789199955797399213"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2877206167559957384"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2877206167559957384",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Paul Miller"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315838/persons-with-significant-control/individual/WLaX_SeMlXRnmpz5kjQ5mw4KhbI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c014",
+                "uri": "http://register.openownership.org/entities/59b9573d67e4ebf340e1c014"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1961-08-01",
+        "addresses": [
+            {
+                "address": "The Granary, Chelsham Road, Warlingham, CR6 9PA"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC315843_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC315843_bods.json
@@ -1,1 +1,706 @@
-[{"statementID": "openownership-register-7651410578574933564", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WRIGHT HASSALL LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC315843"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC315843", "uri": "https://opencorporates.com/companies/gb/OC315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc3 15843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc315843"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc315843"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b936a767e4ebf3404e72ca", "uri": "http://register.openownership.org/entities/59b936a767e4ebf3404e72ca"}], "foundingDate": "2005-10-27", "addresses": [{"type": "registered", "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF", "country": "GB"}]}, {"statementID": "openownership-register-13962382526838419607", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16106591897737230311"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5007715911663710776", "statementType": "ownershipOrControlStatement", "statementDate": "2019-01-01", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10523247765593228188"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-01-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-06T08:35:11Z"}}, {"statementID": "openownership-register-4472592387288518574", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13368747952727850096"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2019-12-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-7324002290307708548", "statementType": "ownershipOrControlStatement", "statementDate": "2017-03-27", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7725358385510146867"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2017-03-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8483731793164105627", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18155010274767761461"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2018-12-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-08-16T09:24:39Z"}}, {"statementID": "openownership-register-6385832816127798064", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13239153905206747023"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6763506438618477727", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7517993889716308140"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2018-12-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-08-16T09:24:39Z"}}, {"statementID": "openownership-register-15102602937410762720", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10541273254140748717"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15007941518845500839", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-01", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8507452373901430598"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-01-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14836297394458463670", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7651410578574933564"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7442293034116067236"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-01-21T11:51:17Z"}}, {"statementID": "openownership-register-16106591897737230311", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Lindsay Ellis"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/2udlfRzAgt5sqfS_TH99Ov5e5Hk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596071", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596071"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1965-09-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-10523247765593228188", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Peter John Maguire"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/584_isHRlC5P8LqVAYE_BnCxyyY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5d7222449dfc3fae18eb02fd", "uri": "http://register.openownership.org/entities/5d7222449dfc3fae18eb02fd"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-10-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF", "country": "GB"}]}, {"statementID": "openownership-register-13368747952727850096", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Paul Mathison Rice"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/B8jc3v2dXptA7DborVF4dBoLOIo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596047", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596047"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-07-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-7725358385510146867", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip Albert Sutherland Formby Wilding"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/DchK8oYEmjHwFwMgruZVkY9hGog"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9d9bb67e4ebf340f918ac", "uri": "http://register.openownership.org/entities/59b9d9bb67e4ebf340f918ac"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-10-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-18155010274767761461", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip Julian Harris"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/G8p5SSPUpb2Di9hmLKF-STfMY9E"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700c67e4ebf34059607b", "uri": "http://register.openownership.org/entities/59b9700c67e4ebf34059607b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1958-06-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-13239153905206747023", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert James Lee"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/GmjvuAR1vPKee3jdwO146kMgeeY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596038", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596038"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-09-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF", "country": "GB"}]}, {"statementID": "openownership-register-7517993889716308140", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Richard Lane"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/HaTJ7d3U4pmhOz2SSsLq7S30_kc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596068", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596068"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-10-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-10541273254140748717", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Martin Stuart Oliver"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/I2X1U6Uo02CthSofGy657uUQ9LM"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596050", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596050"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1975-11-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-8507452373901430598", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Claire Waring"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/JxdN8hQeER2SsTkw6n2F3rns2-4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba73709dfc3fae18fbfabf", "uri": "http://register.openownership.org/entities/5aba73709dfc3fae18fbfabf"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-11-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}, {"statementID": "openownership-register-7442293034116067236", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Sarah Jane Perry"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC315843/persons-with-significant-control/individual/QVw3s8JGe4k0gS5-HjUTvxDK-20"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596032", "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596032"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1966-12-01", "addresses": [{"address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"}]}]
+[
+    {
+        "statementID": "openownership-register-7651410578574933564",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WRIGHT HASSALL LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC315843"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC315843",
+                "uri": "https://opencorporates.com/companies/gb/OC315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc3 15843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc315843"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b936a767e4ebf3404e72ca",
+                "uri": "http://register.openownership.org/entities/59b936a767e4ebf3404e72ca"
+            }
+        ],
+        "foundingDate": "2005-10-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13962382526838419607",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16106591897737230311"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5007715911663710776",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-01-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10523247765593228188"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-01-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-06T08:35:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4472592387288518574",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13368747952727850096"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2019-12-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7324002290307708548",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-03-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7725358385510146867"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2017-03-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8483731793164105627",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18155010274767761461"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2018-12-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-08-16T09:24:39Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6385832816127798064",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13239153905206747023"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6763506438618477727",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7517993889716308140"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2018-12-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-08-16T09:24:39Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15102602937410762720",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10541273254140748717"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15007941518845500839",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8507452373901430598"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-01-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14836297394458463670",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7651410578574933564"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7442293034116067236"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-01-21T11:51:17Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16106591897737230311",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Lindsay Ellis"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/2udlfRzAgt5sqfS_TH99Ov5e5Hk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596071",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596071"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1965-09-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10523247765593228188",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Peter John Maguire"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/584_isHRlC5P8LqVAYE_BnCxyyY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5d7222449dfc3fae18eb02fd",
+                "uri": "http://register.openownership.org/entities/5d7222449dfc3fae18eb02fd"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-10-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13368747952727850096",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Paul Mathison Rice"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/B8jc3v2dXptA7DborVF4dBoLOIo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596047",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596047"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-07-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7725358385510146867",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip Albert Sutherland Formby Wilding"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/DchK8oYEmjHwFwMgruZVkY9hGog"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9d9bb67e4ebf340f918ac",
+                "uri": "http://register.openownership.org/entities/59b9d9bb67e4ebf340f918ac"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-10-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18155010274767761461",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip Julian Harris"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/G8p5SSPUpb2Di9hmLKF-STfMY9E"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700c67e4ebf34059607b",
+                "uri": "http://register.openownership.org/entities/59b9700c67e4ebf34059607b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1958-06-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13239153905206747023",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert James Lee"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/GmjvuAR1vPKee3jdwO146kMgeeY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596038",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596038"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-09-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7517993889716308140",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Richard Lane"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/HaTJ7d3U4pmhOz2SSsLq7S30_kc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596068",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596068"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-10-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10541273254140748717",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Martin Stuart Oliver"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/I2X1U6Uo02CthSofGy657uUQ9LM"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596050",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596050"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1975-11-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8507452373901430598",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Claire Waring"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/JxdN8hQeER2SsTkw6n2F3rns2-4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba73709dfc3fae18fbfabf",
+                "uri": "http://register.openownership.org/entities/5aba73709dfc3fae18fbfabf"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-11-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7442293034116067236",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Sarah Jane Perry"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC315843/persons-with-significant-control/individual/QVw3s8JGe4k0gS5-HjUTvxDK-20"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9700b67e4ebf340596032",
+                "uri": "http://register.openownership.org/entities/59b9700b67e4ebf340596032"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1966-12-01",
+        "addresses": [
+            {
+                "address": "Olympus Avenue, Leamington Spa, Warwickshire, CV34 6BF"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC317852_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC317852_bods.json
@@ -1,1 +1,134 @@
-[{"statementID": "openownership-register-11362707020233081033", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DAC BEACHCROFT LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC317852"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC317852", "uri": "https://opencorporates.com/companies/gb/OC317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc317852"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94ca367e4ebf340b148b8", "uri": "http://register.openownership.org/entities/59b94ca367e4ebf340b148b8"}], "foundingDate": "2006-02-16", "addresses": [{"type": "registered", "address": "25 Walbrook, London, EC4N 8AF", "country": "GB"}]}, {"statementID": "openownership-register-3094841573998243750", "statementType": "ownershipOrControlStatement", "statementDate": "2017-02-16", "subject": {"describedByEntityStatement": "openownership-register-11362707020233081033"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-11362707020233081033",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DAC BEACHCROFT LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC317852"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC317852",
+                "uri": "https://opencorporates.com/companies/gb/OC317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc317852"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94ca367e4ebf340b148b8",
+                "uri": "http://register.openownership.org/entities/59b94ca367e4ebf340b148b8"
+            }
+        ],
+        "foundingDate": "2006-02-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "25 Walbrook, London, EC4N 8AF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-3094841573998243750",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-02-16",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-11362707020233081033"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC322962_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC322962_bods.json
@@ -1,1 +1,74 @@
-[{"statementID": "openownership-register-5525816457374190478", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "STEPHENSONS SOLICITORS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC322962"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC322962"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC322962", "uri": "https://opencorporates.com/companies/gb/OC322962"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc322962"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c2b967e4ebf340a4b370", "uri": "http://register.openownership.org/entities/59b9c2b967e4ebf340a4b370"}], "foundingDate": "2006-10-06", "addresses": [{"type": "registered", "address": "Wigan Investment Centre, Wigan Investment Centre, Waterside Drive, Wigan, WN3 5BA", "country": "GB"}]}, {"statementID": "openownership-register-12063858916696067411", "statementType": "ownershipOrControlStatement", "statementDate": "2016-10-06", "subject": {"describedByEntityStatement": "openownership-register-5525816457374190478"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-5525816457374190478",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "STEPHENSONS SOLICITORS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC322962"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC322962"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC322962",
+                "uri": "https://opencorporates.com/companies/gb/OC322962"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc322962"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c2b967e4ebf340a4b370",
+                "uri": "http://register.openownership.org/entities/59b9c2b967e4ebf340a4b370"
+            }
+        ],
+        "foundingDate": "2006-10-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Wigan Investment Centre, Wigan Investment Centre, Waterside Drive, Wigan, WN3 5BA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12063858916696067411",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-10-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5525816457374190478"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC326117_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC326117_bods.json
@@ -1,1 +1,314 @@
-[{"statementID": "openownership-register-8580774794750988473", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "WEIGHTMANS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC326117"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC326117", "uri": "https://opencorporates.com/companies/gb/OC326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc326117"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b934b567e4ebf34045357b", "uri": "http://register.openownership.org/entities/59b934b567e4ebf34045357b"}], "foundingDate": "2007-02-19", "addresses": [{"type": "registered", "address": "100 Old Hall Street, Liverpool, L3 9QJ", "country": "GB"}]}, {"statementID": "openownership-register-8202023377983507219", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8580774794750988473"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7435368254264604568"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2018-04-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11373710125996048941", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-8580774794750988473"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1394320131345474139"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2044792420327364534", "statementType": "ownershipOrControlStatement", "statementDate": "2018-04-30", "subject": {"describedByEntityStatement": "openownership-register-8580774794750988473"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8053696035948311858"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-04-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-7435368254264604568", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Daniel Stanley Cutts"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC326117/persons-with-significant-control/individual/8q9d_5T0v-QdX-5SKdCvbCgFMDA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8bd", "uri": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8bd"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-01-01", "addresses": [{"address": "100, Old Hall Street, Liverpool, L3 9QJ"}]}, {"statementID": "openownership-register-1394320131345474139", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "John Andrew Schorah"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC326117/persons-with-significant-control/individual/KWw3gQbDYoZqvBrCzocVVU_9EVU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8c8", "uri": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8c8"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-11-01", "addresses": [{"address": "100, Old Hall Street, Liverpool, L3 9QJ"}]}, {"statementID": "openownership-register-8053696035948311858", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Christopher David Lawday Lewis"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC326117/persons-with-significant-control/individual/TMEvKKRWePg7dpIomh6y-QFgxOk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5bbc474d9dfc3fae188d4f12", "uri": "http://register.openownership.org/entities/5bbc474d9dfc3fae188d4f12"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-12-01", "addresses": [{"address": "100, Old Hall Street, Liverpool, L3 9QJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-8580774794750988473",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "WEIGHTMANS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC326117"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC326117",
+                "uri": "https://opencorporates.com/companies/gb/OC326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc326117"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b934b567e4ebf34045357b",
+                "uri": "http://register.openownership.org/entities/59b934b567e4ebf34045357b"
+            }
+        ],
+        "foundingDate": "2007-02-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 Old Hall Street, Liverpool, L3 9QJ",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8202023377983507219",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8580774794750988473"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7435368254264604568"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2018-04-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11373710125996048941",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8580774794750988473"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1394320131345474139"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2044792420327364534",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-04-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-8580774794750988473"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8053696035948311858"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-04-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7435368254264604568",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Daniel Stanley Cutts"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC326117/persons-with-significant-control/individual/8q9d_5T0v-QdX-5SKdCvbCgFMDA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8bd",
+                "uri": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8bd"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-01-01",
+        "addresses": [
+            {
+                "address": "100, Old Hall Street, Liverpool, L3 9QJ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1394320131345474139",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "John Andrew Schorah"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC326117/persons-with-significant-control/individual/KWw3gQbDYoZqvBrCzocVVU_9EVU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8c8",
+                "uri": "http://register.openownership.org/entities/59b9bae567e4ebf34086e8c8"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-11-01",
+        "addresses": [
+            {
+                "address": "100, Old Hall Street, Liverpool, L3 9QJ"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8053696035948311858",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Christopher David Lawday Lewis"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC326117/persons-with-significant-control/individual/TMEvKKRWePg7dpIomh6y-QFgxOk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5bbc474d9dfc3fae188d4f12",
+                "uri": "http://register.openownership.org/entities/5bbc474d9dfc3fae188d4f12"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-12-01",
+        "addresses": [
+            {
+                "address": "100, Old Hall Street, Liverpool, L3 9QJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC333653_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC333653_bods.json
@@ -1,1 +1,364 @@
-[{"statementID": "openownership-register-14815585528706038768", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "PINSENT MASONS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC333653"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC333653", "uri": "https://opencorporates.com/companies/gb/OC333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc333653"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b933a267e4ebf340402764", "uri": "http://register.openownership.org/entities/59b933a267e4ebf340402764"}], "foundingDate": "2007-12-18", "addresses": [{"type": "registered", "address": "30 Crown Place, London, EC2A 4ES", "country": "GB"}]}, {"statementID": "openownership-register-11083589991999289268", "statementType": "ownershipOrControlStatement", "statementDate": "2016-12-18", "subject": {"describedByEntityStatement": "openownership-register-14815585528706038768"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-14815585528706038768",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "PINSENT MASONS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC333653"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC333653",
+                "uri": "https://opencorporates.com/companies/gb/OC333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc333653"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b933a267e4ebf340402764",
+                "uri": "http://register.openownership.org/entities/59b933a267e4ebf340402764"
+            }
+        ],
+        "foundingDate": "2007-12-18",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "30 Crown Place, London, EC2A 4ES",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11083589991999289268",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-12-18",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-14815585528706038768"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC339470_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC339470_bods.json
@@ -1,1 +1,115 @@
-[{"statementID": "openownership-register-10019017462640746210", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GERALD EVE LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC339470"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC339470", "uri": "https://opencorporates.com/companies/gb/OC339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc339470"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9475767e4ebf340991600", "uri": "http://register.openownership.org/entities/59b9475767e4ebf340991600"}], "foundingDate": "2008-08-19", "addresses": [{"type": "registered", "address": "72 Welbeck Street, London, W1G 0AY", "country": "GB"}]}, {"statementID": "openownership-register-13979267004856362211", "statementType": "ownershipOrControlStatement", "statementDate": "2016-08-19", "subject": {"describedByEntityStatement": "openownership-register-10019017462640746210"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-10019017462640746210",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GERALD EVE LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC339470"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC339470",
+                "uri": "https://opencorporates.com/companies/gb/OC339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc339470"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9475767e4ebf340991600",
+                "uri": "http://register.openownership.org/entities/59b9475767e4ebf340991600"
+            }
+        ],
+        "foundingDate": "2008-08-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "72 Welbeck Street, London, W1G 0AY",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13979267004856362211",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-08-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10019017462640746210"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC340360_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC340360_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-17763690257184401609", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CAPSTICKS SOLICITORS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC340360"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC340360", "uri": "https://opencorporates.com/companies/gb/OC340360"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4f6bc67e4ebf34048c891", "uri": "http://register.openownership.org/entities/59c4f6bc67e4ebf34048c891"}], "foundingDate": "2008-09-25", "addresses": [{"type": "registered", "address": "One St. Georges Road, Wimbldon, London, SW19 4DR", "country": "GB"}]}, {"statementID": "openownership-register-90944314896191053", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-25", "subject": {"describedByEntityStatement": "openownership-register-17763690257184401609"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-17763690257184401609",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CAPSTICKS SOLICITORS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC340360"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC340360",
+                "uri": "https://opencorporates.com/companies/gb/OC340360"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4f6bc67e4ebf34048c891",
+                "uri": "http://register.openownership.org/entities/59c4f6bc67e4ebf34048c891"
+            }
+        ],
+        "foundingDate": "2008-09-25",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "One St. Georges Road, Wimbldon, London, SW19 4DR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-90944314896191053",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-17763690257184401609"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC342432_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC342432_bods.json
@@ -1,1 +1,736 @@
-[{"statementID": "openownership-register-4442162229988002011", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ASHFORDS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342432"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC342432", "uri": "https://opencorporates.com/companies/gb/OC342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc342432"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b920a667e4ebf340ea5b08", "uri": "http://register.openownership.org/entities/59b920a667e4ebf340ea5b08"}], "foundingDate": "2009-01-07", "addresses": [{"type": "registered", "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH", "country": "GB"}]}, {"statementID": "openownership-register-2695368120306549604", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-3473572154848905592"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-17699754866767552592", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15230387729249208841"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6042355952223842474", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13682641575622083992"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13557013695673138406", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-9594672080618897631"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14228164358055924264", "statementType": "ownershipOrControlStatement", "statementDate": "2018-07-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8694325656096344587"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-07-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4837093494964446056", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15859045837999734916"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-01-12", "endDate": "2020-04-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-05-26T09:05:26Z"}}, {"statementID": "openownership-register-1822406331930248651", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-4396228279436516156"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14255502053085298004", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16133992242825407583"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-01-12", "endDate": "2018-04-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5689184067564264558", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-338605344135560537"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2020-04-21"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-04-24T09:24:16Z"}}, {"statementID": "openownership-register-16606177655401225975", "statementType": "ownershipOrControlStatement", "statementDate": "2018-01-12", "subject": {"describedByEntityStatement": "openownership-register-4442162229988002011"}, "interestedParty": {"describedByPersonStatement": "openownership-register-10041257467811247726"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-01-12"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-3473572154848905592", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Timothy Ralph Heal"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/0LkWxYWrPG3r5KmwQhpAPeZ5cX8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca8c", "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca8c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-11-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-15230387729249208841", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Judith Margaret Park"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/5E8ZnhfJ0BNXkXJsEQ-0IxU9REk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8867e4ebf340a6cac5", "uri": "http://register.openownership.org/entities/59b97f8867e4ebf340a6cac5"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1958-03-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-13682641575622083992", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Michael Alistair Alden"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/5mb768-cwQuauez_ft3ZyburZLU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6caa4", "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6caa4"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-12-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-9594672080618897631", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mark Mallyon Lomas"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/8KoPJXGsnA4429c7oMhI3XwFX-U"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca63", "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca63"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-11-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-8694325656096344587", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Louise Jane Workman"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/AsegU2a5fPtUF31UnzZsrEQAZPU"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5c3d3c669dfc3fae1817c229", "uri": "http://register.openownership.org/entities/5c3d3c669dfc3fae1817c229"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-05-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-15859045837999734916", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Ruth Kathryn Murray"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/N3gKYKS3fu0auWY3C96KnPuUA3E"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba68d49dfc3fae18f46d2b", "uri": "http://register.openownership.org/entities/5aba68d49dfc3fae18f46d2b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1978-02-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-4396228279436516156", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Andrew Collins Betteridge"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/YzAif2Bu8L1SZopHBwrzU-Vxnck"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca45", "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca45"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1975-07-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-16133992242825407583", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Samantha Miriam Irene Palmer"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/i_G1bGKkFO-2ngtkSPhngi1LnfI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba68cd9dfc3fae18f46760", "uri": "http://register.openownership.org/entities/5aba68cd9dfc3fae18f46760"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1968-01-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH", "country": "GB"}]}, {"statementID": "openownership-register-338605344135560537", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Garry Sutherland Mackay"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/lCY9mUKJYhQ50EF4WGMJKWx5jcs"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca79", "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca79"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-07-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}, {"statementID": "openownership-register-10041257467811247726", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Dirk Horsey"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC342432/persons-with-significant-control/individual/mhQKEHuVgg_5zfQ-013MkxIxEpo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5aba68d09dfc3fae18f469d6", "uri": "http://register.openownership.org/entities/5aba68d09dfc3fae18f469d6"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1963-06-01", "addresses": [{"address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"}]}]
+[
+    {
+        "statementID": "openownership-register-4442162229988002011",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ASHFORDS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342432"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC342432",
+                "uri": "https://opencorporates.com/companies/gb/OC342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc342432"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b920a667e4ebf340ea5b08",
+                "uri": "http://register.openownership.org/entities/59b920a667e4ebf340ea5b08"
+            }
+        ],
+        "foundingDate": "2009-01-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2695368120306549604",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-3473572154848905592"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17699754866767552592",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15230387729249208841"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6042355952223842474",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13682641575622083992"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13557013695673138406",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-9594672080618897631"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14228164358055924264",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-07-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8694325656096344587"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-07-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4837093494964446056",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15859045837999734916"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-01-12",
+                "endDate": "2020-04-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-05-26T09:05:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1822406331930248651",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-4396228279436516156"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14255502053085298004",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16133992242825407583"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-01-12",
+                "endDate": "2018-04-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5689184067564264558",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-338605344135560537"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2020-04-21"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-04-24T09:24:16Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16606177655401225975",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-01-12",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-4442162229988002011"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-10041257467811247726"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-01-12"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3473572154848905592",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Timothy Ralph Heal"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/0LkWxYWrPG3r5KmwQhpAPeZ5cX8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca8c",
+                "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca8c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-11-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15230387729249208841",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Judith Margaret Park"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/5E8ZnhfJ0BNXkXJsEQ-0IxU9REk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8867e4ebf340a6cac5",
+                "uri": "http://register.openownership.org/entities/59b97f8867e4ebf340a6cac5"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1958-03-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13682641575622083992",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Michael Alistair Alden"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/5mb768-cwQuauez_ft3ZyburZLU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6caa4",
+                "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6caa4"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-12-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-9594672080618897631",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mark Mallyon Lomas"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/8KoPJXGsnA4429c7oMhI3XwFX-U"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca63",
+                "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca63"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-11-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-8694325656096344587",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Louise Jane Workman"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/AsegU2a5fPtUF31UnzZsrEQAZPU"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5c3d3c669dfc3fae1817c229",
+                "uri": "http://register.openownership.org/entities/5c3d3c669dfc3fae1817c229"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-05-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15859045837999734916",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Ruth Kathryn Murray"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/N3gKYKS3fu0auWY3C96KnPuUA3E"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba68d49dfc3fae18f46d2b",
+                "uri": "http://register.openownership.org/entities/5aba68d49dfc3fae18f46d2b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1978-02-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4396228279436516156",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Andrew Collins Betteridge"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/YzAif2Bu8L1SZopHBwrzU-Vxnck"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca45",
+                "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca45"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1975-07-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16133992242825407583",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Samantha Miriam Irene Palmer"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/i_G1bGKkFO-2ngtkSPhngi1LnfI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba68cd9dfc3fae18f46760",
+                "uri": "http://register.openownership.org/entities/5aba68cd9dfc3fae18f46760"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1968-01-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-338605344135560537",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Garry Sutherland Mackay"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/lCY9mUKJYhQ50EF4WGMJKWx5jcs"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca79",
+                "uri": "http://register.openownership.org/entities/59b97f8767e4ebf340a6ca79"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-07-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10041257467811247726",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Dirk Horsey"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC342432/persons-with-significant-control/individual/mhQKEHuVgg_5zfQ-013MkxIxEpo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5aba68d09dfc3fae18f469d6",
+                "uri": "http://register.openownership.org/entities/5aba68d09dfc3fae18f469d6"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1963-06-01",
+        "addresses": [
+            {
+                "address": "Ashford House, Grenadier Road, Exeter, Devon, EX1 3LH"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC342692_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC342692_bods.json
@@ -1,1 +1,60 @@
-[{"statementID": "openownership-register-547557611669889435", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BARTON WILLMORE LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC342692"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC342692", "uri": "https://opencorporates.com/companies/gb/OC342692"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59c4ffe367e4ebf3405b5265", "uri": "http://register.openownership.org/entities/59c4ffe367e4ebf3405b5265"}], "foundingDate": "2009-01-19", "addresses": [{"type": "registered", "address": "The Blade, Abbey Square, Reading, RG1 3BE", "country": "GB"}]}, {"statementID": "openownership-register-12788701116959250203", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-19", "subject": {"describedByEntityStatement": "openownership-register-547557611669889435"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-547557611669889435",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BARTON WILLMORE LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC342692"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC342692",
+                "uri": "https://opencorporates.com/companies/gb/OC342692"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59c4ffe367e4ebf3405b5265",
+                "uri": "http://register.openownership.org/entities/59c4ffe367e4ebf3405b5265"
+            }
+        ],
+        "foundingDate": "2009-01-19",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "The Blade, Abbey Square, Reading, RG1 3BE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12788701116959250203",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-19",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-547557611669889435"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC343375_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC343375_bods.json
@@ -1,1 +1,468 @@
-[{"statementID": "openownership-register-5778976240577282133", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "CROFTONS SOLICITORS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC343375"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC343375", "uri": "https://opencorporates.com/companies/gb/OC343375"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc343375"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77725", "uri": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77725"}], "foundingDate": "2009-02-16", "addresses": [{"type": "registered", "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW", "country": "GB"}]}, {"statementID": "openownership-register-4650427658737328362", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2025260354267267442"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2020-01-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-10325627755928978974", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2733258794339827545"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2020-01-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-6000127455713541851", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2914615560105751953"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2020-01-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-02-24T11:31:42Z"}}, {"statementID": "openownership-register-11874165378303953401", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByEntityStatement": "openownership-register-5089843382367478694"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2245484790497248852", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByEntityStatement": "openownership-register-17370970087885959587"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9338726313436835145", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-5778976240577282133"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13211463439774639677"}, "interests": [{"type": "voting-rights", "details": "voting-rights-25-to-50-percent-limited-liability-partnership", "share": {"minimum": 25, "maximum": 50, "exclusiveMinimum": true, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2025260354267267442", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Bob Agnew"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC343375/persons-with-significant-control/individual/1B3LIx8VFm5CDQJm6r7ig1Bkm7c"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77739", "uri": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77739"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-03-01", "addresses": [{"address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"}]}, {"statementID": "openownership-register-2733258794339827545", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Simon Timothy Leighton"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC343375/persons-with-significant-control/individual/i6761n2eIviuaYa4tH0qbq__tAc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7797a", "uri": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7797a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1970-04-01", "addresses": [{"address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"}]}, {"statementID": "openownership-register-2914615560105751953", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Arthur Chapman"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC343375/persons-with-significant-control/individual/lA6rSaV2X-_oyUP8TcH4ntj_zbo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7799f", "uri": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7799f"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-05-01", "addresses": [{"address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"}]}, {"statementID": "openownership-register-5089843382367478694", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARTHUR CHAPMAN LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07720594"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07720594", "uri": "https://opencorporates.com/companies/gb/07720594"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b928d467e4ebf3400bcff1", "uri": "http://register.openownership.org/entities/59b928d467e4ebf3400bcff1"}], "foundingDate": "2011-07-27", "addresses": [{"type": "registered", "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW", "country": "GB"}]}, {"statementID": "openownership-register-17370970087885959587", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "BOB AGNEW LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07720661"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07720661", "uri": "https://opencorporates.com/companies/gb/07720661"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b928da67e4ebf3400be308", "uri": "http://register.openownership.org/entities/59b928da67e4ebf3400be308"}], "foundingDate": "2011-07-27", "addresses": [{"type": "registered", "address": "Knights Plc, The Brampton, Newcastle-Under-Lyme, Staffordshire, ST5 0QW", "country": "GB"}]}, {"statementID": "openownership-register-13211463439774639677", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SIMON LEIGHTON LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07720644"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07720644", "uri": "https://opencorporates.com/companies/gb/07720644"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b928dc67e4ebf3400bf10e", "uri": "http://register.openownership.org/entities/59b928dc67e4ebf3400bf10e"}], "foundingDate": "2011-07-27", "addresses": [{"type": "registered", "address": "Knights Plc, The Brampton, Newcastle-Under-Lyme, Staffordshire, ST5 0QW", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-5778976240577282133",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "CROFTONS SOLICITORS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC343375"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC343375",
+                "uri": "https://opencorporates.com/companies/gb/OC343375"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc343375"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77725",
+                "uri": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77725"
+            }
+        ],
+        "foundingDate": "2009-02-16",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4650427658737328362",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2025260354267267442"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2020-01-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10325627755928978974",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2733258794339827545"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2020-01-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6000127455713541851",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2914615560105751953"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2020-01-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-02-24T11:31:42Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11874165378303953401",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-5089843382367478694"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2245484790497248852",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-17370970087885959587"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9338726313436835145",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-5778976240577282133"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13211463439774639677"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-25-to-50-percent-limited-liability-partnership",
+                "share": {
+                    "minimum": 25,
+                    "maximum": 50,
+                    "exclusiveMinimum": true,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2025260354267267442",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Bob Agnew"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC343375/persons-with-significant-control/individual/1B3LIx8VFm5CDQJm6r7ig1Bkm7c"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77739",
+                "uri": "http://register.openownership.org/entities/59b98b5e67e4ebf340d77739"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-03-01",
+        "addresses": [
+            {
+                "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2733258794339827545",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Simon Timothy Leighton"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC343375/persons-with-significant-control/individual/i6761n2eIviuaYa4tH0qbq__tAc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7797a",
+                "uri": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7797a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1970-04-01",
+        "addresses": [
+            {
+                "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2914615560105751953",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Arthur Chapman"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC343375/persons-with-significant-control/individual/lA6rSaV2X-_oyUP8TcH4ntj_zbo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7799f",
+                "uri": "http://register.openownership.org/entities/59b98b5f67e4ebf340d7799f"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-05-01",
+        "addresses": [
+            {
+                "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-5089843382367478694",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARTHUR CHAPMAN LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07720594"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07720594",
+                "uri": "https://opencorporates.com/companies/gb/07720594"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b928d467e4ebf3400bcff1",
+                "uri": "http://register.openownership.org/entities/59b928d467e4ebf3400bcff1"
+            }
+        ],
+        "foundingDate": "2011-07-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Knights Plc, The Brampton, Newcastle Under Lyme, Staffordshire, ST5 0QW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-17370970087885959587",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "BOB AGNEW LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07720661"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07720661",
+                "uri": "https://opencorporates.com/companies/gb/07720661"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b928da67e4ebf3400be308",
+                "uri": "http://register.openownership.org/entities/59b928da67e4ebf3400be308"
+            }
+        ],
+        "foundingDate": "2011-07-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Knights Plc, The Brampton, Newcastle-Under-Lyme, Staffordshire, ST5 0QW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13211463439774639677",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SIMON LEIGHTON LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07720644"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07720644",
+                "uri": "https://opencorporates.com/companies/gb/07720644"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b928dc67e4ebf3400bf10e",
+                "uri": "http://register.openownership.org/entities/59b928dc67e4ebf3400bf10e"
+            }
+        ],
+        "foundingDate": "2011-07-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Knights Plc, The Brampton, Newcastle-Under-Lyme, Staffordshire, ST5 0QW",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC344770_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC344770_bods.json
@@ -1,1 +1,656 @@
-[{"statementID": "openownership-register-3095570885452774947", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SANDERSON WEATHERALL LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC344770"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC344770", "uri": "https://opencorporates.com/companies/gb/OC344770"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc344770"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9655d67e4ebf34024382b", "uri": "http://register.openownership.org/entities/59b9655d67e4ebf34024382b"}], "foundingDate": "2009-04-07", "addresses": [{"type": "registered", "address": "6th Floor Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-13818886577814001972", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-12276135248519039151"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2018-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-12-10T10:45:26Z"}}, {"statementID": "openownership-register-9436433136497870776", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15278934684241418494"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-15886764394515737524", "statementType": "ownershipOrControlStatement", "statementDate": "2017-04-10", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16487775237719957935"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2017-04-10"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-9579109869500439938", "statementType": "ownershipOrControlStatement", "statementDate": "2018-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-13995646828748330398"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2018-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1699223325152617504", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11006297771840872907"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-5914448458497858295", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-14016745425172113257"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2017-05-31"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14549262962119213094", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-7266201876784217447"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2332129167579050491", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-6876488956542971096"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-16042746883763585276", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2344834983264182546"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-12325759666066540513", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-3095570885452774947"}, "interestedParty": {"describedByPersonStatement": "openownership-register-745574459357274808"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14016745425172113257", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Graham Allan Brown"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC344770/persons-with-significant-control/individual/AtyEd3AN91E9ZEvQDNZowLyqMig"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9ad4567e4ebf34051abed", "uri": "http://register.openownership.org/entities/59b9ad4567e4ebf34051abed"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-06-01", "addresses": [{"address": "25, Wellington Street, Leeds, LS1 4WG", "country": "GB"}]}, {"statementID": "openownership-register-6876488956542971096", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Martin Walker Archer"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/25z_VFkZHva4J-8s0f5xMwgW7Es"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca20", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca20"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-03-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-15278934684241418494", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Richard Mcintosh Farr"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/4o-3dRumpunlZeWJSOA1Wf0KcuI"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dc9ff", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dc9ff"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-01-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-16487775237719957935", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Matthew John Lawrence"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/FxZ0n27mun77dD9RCuIHbVVzgj8"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9e39f67e4ebf3401eba7a", "uri": "http://register.openownership.org/entities/59b9e39f67e4ebf3401eba7a"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1976-04-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-12276135248519039151", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Robert Patterson"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/MGE-5r06oKvDIG10FOfPW0QlGAQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca7c", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca7c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1958-05-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-11006297771840872907", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "George Mclean Penrice"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/aOTqRCkGMPi6S5CTOlWpKZ2dhas"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca1b", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca1b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-02-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"}]}, {"statementID": "openownership-register-7266201876784217447", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Matthew Midwinter"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/b9K4ISq48zUeAMS34HvK0QZwAqY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca71", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca71"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1967-08-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"}]}, {"statementID": "openownership-register-13995646828748330398", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Kevin Michael Mcgorie"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/bzrYbyAxTMEeCr0sXkJjpCNB5W4"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5b16d2229dfc3fae1863bdef", "uri": "http://register.openownership.org/entities/5b16d2229dfc3fae1863bdef"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1983-02-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-745574459357274808", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "David Downing"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/hlNRpH37K-PuHVVs0iH-nr60aK0"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca3c", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca3c"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1971-09-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL", "country": "GB"}]}, {"statementID": "openownership-register-2344834983264182546", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Philip Bernard Kenny"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/04870380/persons-with-significant-control/individual/raYNrW7zaAdkcA38SvutAi3jUew"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca66", "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca66"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1956-01-01", "addresses": [{"address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"}]}]
+[
+    {
+        "statementID": "openownership-register-3095570885452774947",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SANDERSON WEATHERALL LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC344770"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC344770",
+                "uri": "https://opencorporates.com/companies/gb/OC344770"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc344770"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9655d67e4ebf34024382b",
+                "uri": "http://register.openownership.org/entities/59b9655d67e4ebf34024382b"
+            }
+        ],
+        "foundingDate": "2009-04-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "6th Floor Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13818886577814001972",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-12276135248519039151"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2018-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-12-10T10:45:26Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9436433136497870776",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15278934684241418494"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15886764394515737524",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-04-10",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16487775237719957935"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2017-04-10"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-9579109869500439938",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-13995646828748330398"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2018-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1699223325152617504",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11006297771840872907"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5914448458497858295",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-14016745425172113257"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2017-05-31"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14549262962119213094",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-7266201876784217447"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2332129167579050491",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-6876488956542971096"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16042746883763585276",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2344834983264182546"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-12325759666066540513",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-3095570885452774947"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-745574459357274808"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14016745425172113257",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Graham Allan Brown"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC344770/persons-with-significant-control/individual/AtyEd3AN91E9ZEvQDNZowLyqMig"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9ad4567e4ebf34051abed",
+                "uri": "http://register.openownership.org/entities/59b9ad4567e4ebf34051abed"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-06-01",
+        "addresses": [
+            {
+                "address": "25, Wellington Street, Leeds, LS1 4WG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6876488956542971096",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Martin Walker Archer"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/25z_VFkZHva4J-8s0f5xMwgW7Es"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca20",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca20"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-03-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15278934684241418494",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Richard Mcintosh Farr"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/4o-3dRumpunlZeWJSOA1Wf0KcuI"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dc9ff",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dc9ff"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-01-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16487775237719957935",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Matthew John Lawrence"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/FxZ0n27mun77dD9RCuIHbVVzgj8"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9e39f67e4ebf3401eba7a",
+                "uri": "http://register.openownership.org/entities/59b9e39f67e4ebf3401eba7a"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1976-04-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12276135248519039151",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Robert Patterson"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/MGE-5r06oKvDIG10FOfPW0QlGAQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca7c",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca7c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1958-05-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11006297771840872907",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "George Mclean Penrice"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/aOTqRCkGMPi6S5CTOlWpKZ2dhas"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca1b",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca1b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-02-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-7266201876784217447",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Matthew Midwinter"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/b9K4ISq48zUeAMS34HvK0QZwAqY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca71",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca71"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1967-08-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-13995646828748330398",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Kevin Michael Mcgorie"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/bzrYbyAxTMEeCr0sXkJjpCNB5W4"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5b16d2229dfc3fae1863bdef",
+                "uri": "http://register.openownership.org/entities/5b16d2229dfc3fae1863bdef"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1983-02-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-745574459357274808",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "David Downing"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/hlNRpH37K-PuHVVs0iH-nr60aK0"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca3c",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca3c"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1971-09-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2344834983264182546",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Philip Bernard Kenny"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/04870380/persons-with-significant-control/individual/raYNrW7zaAdkcA38SvutAi3jUew"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9368467e4ebf3404dca66",
+                "uri": "http://register.openownership.org/entities/59b9368467e4ebf3404dca66"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1956-01-01",
+        "addresses": [
+            {
+                "address": "6th Floor, Central Square, 29 Wellington Street, Leeds, LS1 4DL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC368843_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC368843_bods.json
@@ -1,1 +1,123 @@
-[{"statementID": "openownership-register-15281777671499216434", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARCADIS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC368843"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC368843", "uri": "https://opencorporates.com/companies/gb/OC368843"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9529267e4ebf340cbc578", "uri": "http://register.openownership.org/entities/59b9529267e4ebf340cbc578"}], "foundingDate": "2011-10-12", "addresses": [{"type": "registered", "address": "Arcadis House, 34 York Way, London, N1 9AB", "country": "GB"}]}, {"statementID": "openownership-register-2773108059449619984", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-15281777671499216434"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6979190602910927519"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent-limited-liability-partnership", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "rights-to-surplus-assets", "details": "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership", "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6979190602910927519", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Arcadis (Bac) Ltd", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07803869"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07803869"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07803869", "uri": "https://opencorporates.com/companies/gb/07803869"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95fb167e4ebf340095891", "uri": "http://register.openownership.org/entities/59b95fb167e4ebf340095891"}], "foundingDate": "2011-10-10", "addresses": [{"type": "registered", "address": "Arcadis House, 34, York Way, London, N1 9AB", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-15281777671499216434",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARCADIS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC368843"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC368843",
+                "uri": "https://opencorporates.com/companies/gb/OC368843"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9529267e4ebf340cbc578",
+                "uri": "http://register.openownership.org/entities/59b9529267e4ebf340cbc578"
+            }
+        ],
+        "foundingDate": "2011-10-12",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Arcadis House, 34 York Way, London, N1 9AB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2773108059449619984",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-15281777671499216434"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6979190602910927519"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent-limited-liability-partnership",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "rights-to-surplus-assets",
+                "details": "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6979190602910927519",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Arcadis (Bac) Ltd",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07803869"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07803869"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07803869",
+                "uri": "https://opencorporates.com/companies/gb/07803869"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95fb167e4ebf340095891",
+                "uri": "http://register.openownership.org/entities/59b95fb167e4ebf340095891"
+            }
+        ],
+        "foundingDate": "2011-10-10",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Arcadis House, 34, York Way, London, N1 9AB",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC374987_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC374987_bods.json
@@ -1,1 +1,225 @@
-[{"statementID": "openownership-register-13278964990746319555", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SHOOSMITHS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC374987"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC374987", "uri": "https://opencorporates.com/companies/gb/OC374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc374987"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b949a167e4ebf340a4b25d", "uri": "http://register.openownership.org/entities/59b949a167e4ebf340a4b25d"}], "foundingDate": "2012-05-04", "addresses": [{"type": "registered", "address": "100 Avebury Boulevard, Milton Keynes, MK9 1FH", "country": "GB"}]}, {"statementID": "openownership-register-12576264503538874619", "statementType": "ownershipOrControlStatement", "statementDate": "2016-09-27", "subject": {"describedByEntityStatement": "openownership-register-13278964990746319555"}, "interestedParty": {"describedByPersonStatement": "openownership-register-8211484472444372368"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2016-09-27", "endDate": "2019-01-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-8379851428253030038", "statementType": "ownershipOrControlStatement", "statementDate": "2019-01-01", "subject": {"describedByEntityStatement": "openownership-register-13278964990746319555"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18397622779679067049"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2019-01-01"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2020-03-24T16:58:02Z"}}, {"statementID": "openownership-register-8211484472444372368", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Claire Maurine Rowe"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC374987/persons-with-significant-control/individual/wGyeR48EyJ9aOEG3mvV6EqFWVzE"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b94a2867e4ebf340a72b5b", "uri": "http://register.openownership.org/entities/59b94a2867e4ebf340a72b5b"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1962-05-01", "addresses": [{"address": "Witan Gate House, 500-600 Witan Gate West, Milton Keynes, Buckinghamshire, MK9 1SH", "country": "GB"}]}, {"statementID": "openownership-register-18397622779679067049", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Simon Andrew Boss"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC374987/persons-with-significant-control/individual/xt_IZrDzSIr3duugGUR_NrH7kcc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5c5bbf169dfc3fae18f7acfa", "uri": "http://register.openownership.org/entities/5c5bbf169dfc3fae18f7acfa"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1964-08-01", "addresses": [{"address": "100, Avebury Boulevard, Milton Keynes, MK9 1FH", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-13278964990746319555",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SHOOSMITHS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC374987"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC374987",
+                "uri": "https://opencorporates.com/companies/gb/OC374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc374987"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b949a167e4ebf340a4b25d",
+                "uri": "http://register.openownership.org/entities/59b949a167e4ebf340a4b25d"
+            }
+        ],
+        "foundingDate": "2012-05-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "100 Avebury Boulevard, Milton Keynes, MK9 1FH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12576264503538874619",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13278964990746319555"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-8211484472444372368"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2016-09-27",
+                "endDate": "2019-01-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8379851428253030038",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-01-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13278964990746319555"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18397622779679067049"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2019-01-01"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2020-03-24T16:58:02Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-8211484472444372368",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Claire Maurine Rowe"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC374987/persons-with-significant-control/individual/wGyeR48EyJ9aOEG3mvV6EqFWVzE"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b94a2867e4ebf340a72b5b",
+                "uri": "http://register.openownership.org/entities/59b94a2867e4ebf340a72b5b"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1962-05-01",
+        "addresses": [
+            {
+                "address": "Witan Gate House, 500-600 Witan Gate West, Milton Keynes, Buckinghamshire, MK9 1SH",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18397622779679067049",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Simon Andrew Boss"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC374987/persons-with-significant-control/individual/xt_IZrDzSIr3duugGUR_NrH7kcc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5c5bbf169dfc3fae18f7acfa",
+                "uri": "http://register.openownership.org/entities/5c5bbf169dfc3fae18f7acfa"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1964-08-01",
+        "addresses": [
+            {
+                "address": "100, Avebury Boulevard, Milton Keynes, MK9 1FH",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC381717_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC381717_bods.json
@@ -1,1 +1,452 @@
-[{"statementID": "openownership-register-7711046534604848486", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "HTA DESIGN LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC381717"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC381717", "uri": "https://opencorporates.com/companies/gb/OC381717"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec40", "uri": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec40"}], "foundingDate": "2013-01-17", "addresses": [{"type": "registered", "address": "78 Chamber Street, London, E1 8BL", "country": "GB"}]}, {"statementID": "openownership-register-11696124239914724462", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15784053759802461833"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-17598144227349889189", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-11960585114011173447"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-6775475219512923441", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-16528350131437825739"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-16582888553196286332", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15056623865790699284"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-7473323342813479615", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-1150807148694273506"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-7985750478034913922", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-2935521605536033920"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06", "endDate": "2019-09-11"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-09-25T14:19:31Z"}}, {"statementID": "openownership-register-5251409142266200841", "statementType": "ownershipOrControlStatement", "statementDate": "2019-09-27", "subject": {"describedByEntityStatement": "openownership-register-7711046534604848486"}, "interestedParty": {"describedByPersonStatement": "openownership-register-18360852710859700675"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2019-09-27"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-10-16T16:17:08Z"}}, {"statementID": "openownership-register-15784053759802461833", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Benjamin Charles Edward Derbyshire"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/DTtSKgO6CfQ4r0gY7f8YZW1QKwc"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755b99dfc3fae182601a0", "uri": "http://register.openownership.org/entities/5da755b99dfc3fae182601a0"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-05-01", "addresses": [{"address": "Hta Design 78, Chamber Street, London, E1 8BL"}]}, {"statementID": "openownership-register-11960585114011173447", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Colin Ainger"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/XbPXShHySt3q6gRzU7NmwbVR5CA"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755c99dfc3fae18262a9e", "uri": "http://register.openownership.org/entities/5da755c99dfc3fae18262a9e"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1974-01-01", "addresses": [{"address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"}]}, {"statementID": "openownership-register-16528350131437825739", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Mike De'Ath"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/_AuEqjLAj0QLh5kfne81zPn2jcQ"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755bd9dfc3fae18260bef", "uri": "http://register.openownership.org/entities/5da755bd9dfc3fae18260bef"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1959-02-01", "addresses": [{"address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"}]}, {"statementID": "openownership-register-15056623865790699284", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Caroline Dove"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/c8cEPt8wJbfjkSW20uw9ttBrRwY"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755c69dfc3fae182620ac", "uri": "http://register.openownership.org/entities/5da755c69dfc3fae182620ac"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1957-03-01", "addresses": [{"address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"}]}, {"statementID": "openownership-register-1150807148694273506", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Simon Bayliss"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/kYA1xm_aQVo1lGssFUKfWhCK_vk"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755c19dfc3fae182615c3", "uri": "http://register.openownership.org/entities/5da755c19dfc3fae182615c3"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1972-09-01", "addresses": [{"address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"}]}, {"statementID": "openownership-register-2935521605536033920", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Benjamin Derbyshire"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/qjYD2PCu4ygFFHuTDxNFZ9eOQ0g"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec51", "uri": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec51"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1953-05-01", "addresses": [{"address": "106-110, Kentish Town Road, London, NW1 9PX"}]}, {"statementID": "openownership-register-18360852710859700675", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Alastair Morrison"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC381717/persons-with-significant-control/individual/w_ft3KFIbRj8JqKdNednJdBkRDo"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5da755ca9dfc3fae18262ca6", "uri": "http://register.openownership.org/entities/5da755ca9dfc3fae18262ca6"}], "birthDate": "1979-03-01", "addresses": [{"address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"}]}]
+[
+    {
+        "statementID": "openownership-register-7711046534604848486",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "HTA DESIGN LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC381717"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC381717",
+                "uri": "https://opencorporates.com/companies/gb/OC381717"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec40",
+                "uri": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec40"
+            }
+        ],
+        "foundingDate": "2013-01-17",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "78 Chamber Street, London, E1 8BL",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11696124239914724462",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15784053759802461833"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-17598144227349889189",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-11960585114011173447"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6775475219512923441",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-16528350131437825739"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-16582888553196286332",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15056623865790699284"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7473323342813479615",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-1150807148694273506"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-7985750478034913922",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-2935521605536033920"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06",
+                "endDate": "2019-09-11"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-09-25T14:19:31Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5251409142266200841",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-09-27",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-7711046534604848486"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-18360852710859700675"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2019-09-27"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-10-16T16:17:08Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-15784053759802461833",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Benjamin Charles Edward Derbyshire"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/DTtSKgO6CfQ4r0gY7f8YZW1QKwc"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755b99dfc3fae182601a0",
+                "uri": "http://register.openownership.org/entities/5da755b99dfc3fae182601a0"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-05-01",
+        "addresses": [
+            {
+                "address": "Hta Design 78, Chamber Street, London, E1 8BL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11960585114011173447",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Colin Ainger"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/XbPXShHySt3q6gRzU7NmwbVR5CA"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755c99dfc3fae18262a9e",
+                "uri": "http://register.openownership.org/entities/5da755c99dfc3fae18262a9e"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1974-01-01",
+        "addresses": [
+            {
+                "address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-16528350131437825739",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Mike De'Ath"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/_AuEqjLAj0QLh5kfne81zPn2jcQ"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755bd9dfc3fae18260bef",
+                "uri": "http://register.openownership.org/entities/5da755bd9dfc3fae18260bef"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1959-02-01",
+        "addresses": [
+            {
+                "address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15056623865790699284",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Caroline Dove"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/c8cEPt8wJbfjkSW20uw9ttBrRwY"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755c69dfc3fae182620ac",
+                "uri": "http://register.openownership.org/entities/5da755c69dfc3fae182620ac"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1957-03-01",
+        "addresses": [
+            {
+                "address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-1150807148694273506",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Simon Bayliss"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/kYA1xm_aQVo1lGssFUKfWhCK_vk"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755c19dfc3fae182615c3",
+                "uri": "http://register.openownership.org/entities/5da755c19dfc3fae182615c3"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1972-09-01",
+        "addresses": [
+            {
+                "address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2935521605536033920",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Benjamin Derbyshire"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/qjYD2PCu4ygFFHuTDxNFZ9eOQ0g"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec51",
+                "uri": "http://register.openownership.org/entities/59b97dab67e4ebf3409cec51"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1953-05-01",
+        "addresses": [
+            {
+                "address": "106-110, Kentish Town Road, London, NW1 9PX"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-18360852710859700675",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Alastair Morrison"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC381717/persons-with-significant-control/individual/w_ft3KFIbRj8JqKdNednJdBkRDo"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5da755ca9dfc3fae18262ca6",
+                "uri": "http://register.openownership.org/entities/5da755ca9dfc3fae18262ca6"
+            }
+        ],
+        "birthDate": "1979-03-01",
+        "addresses": [
+            {
+                "address": "78 Hta Design Llp, Chamber Street, London, E1 8BL"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC385143_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC385143_bods.json
@@ -1,1 +1,298 @@
-[{"statementID": "openownership-register-13156530670852249118", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "COLLIERS INTERNATIONAL PROPERTY ADVISERS UK LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC385143"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC385143", "uri": "https://opencorporates.com/companies/gb/OC385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc385143"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b99bb567e4ebf34010b011", "uri": "http://register.openownership.org/entities/59b99bb567e4ebf34010b011"}], "foundingDate": "2013-05-15", "addresses": [{"type": "registered", "address": "50 George Street, London, W1U 7GA", "country": "GB"}]}, {"statementID": "openownership-register-15757220343482060901", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13156530670852249118"}, "interestedParty": {"describedByEntityStatement": "openownership-register-13278473840519391700"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent-limited-liability-partnership", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "rights-to-surplus-assets", "details": "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership", "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-members-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-2995831973359097433", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-13156530670852249118"}, "interestedParty": {"describedByPersonStatement": "openownership-register-15454947930903358921"}, "interests": [{"type": "influence-or-control", "details": "significant-influence-or-control-limited-liability-partnership", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13278473840519391700", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "GLOBESTAR LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05159841"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05159841", "uri": "https://opencorporates.com/companies/gb/05159841"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b92c6f67e4ebf3401ccc2b", "uri": "http://register.openownership.org/entities/59b92c6f67e4ebf3401ccc2b"}], "foundingDate": "2004-06-22", "addresses": [{"type": "registered", "address": "50 George Street, London, W1U 7GA", "country": "GB"}]}, {"statementID": "openownership-register-15454947930903358921", "statementType": "personStatement", "personType": "knownPerson", "names": [{"type": "individual", "fullName": "Anthony Michael Horrell"}], "identifiers": [{"schemeName": "GB Persons Of Significant Control Register", "id": "/company/OC385143/persons-with-significant-control/individual/u6TgpwMtI6tHyaQGiALMpZbqesw"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9c46c67e4ebf340ab59b9", "uri": "http://register.openownership.org/entities/59b9c46c67e4ebf340ab59b9"}], "nationalities": [{"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}], "birthDate": "1960-11-01", "addresses": [{"address": "50, George Street, London, W1U 7GA"}]}]
+[
+    {
+        "statementID": "openownership-register-13156530670852249118",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "COLLIERS INTERNATIONAL PROPERTY ADVISERS UK LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC385143"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC385143",
+                "uri": "https://opencorporates.com/companies/gb/OC385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc385143"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b99bb567e4ebf34010b011",
+                "uri": "http://register.openownership.org/entities/59b99bb567e4ebf34010b011"
+            }
+        ],
+        "foundingDate": "2013-05-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "50 George Street, London, W1U 7GA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15757220343482060901",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13156530670852249118"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-13278473840519391700"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent-limited-liability-partnership",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "rights-to-surplus-assets",
+                "details": "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-members-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-2995831973359097433",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-13156530670852249118"
+        },
+        "interestedParty": {
+            "describedByPersonStatement": "openownership-register-15454947930903358921"
+        },
+        "interests": [
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-limited-liability-partnership",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13278473840519391700",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "GLOBESTAR LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05159841"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05159841",
+                "uri": "https://opencorporates.com/companies/gb/05159841"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b92c6f67e4ebf3401ccc2b",
+                "uri": "http://register.openownership.org/entities/59b92c6f67e4ebf3401ccc2b"
+            }
+        ],
+        "foundingDate": "2004-06-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "50 George Street, London, W1U 7GA",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-15454947930903358921",
+        "statementType": "personStatement",
+        "personType": "knownPerson",
+        "names": [
+            {
+                "type": "individual",
+                "fullName": "Anthony Michael Horrell"
+            }
+        ],
+        "identifiers": [
+            {
+                "schemeName": "GB Persons Of Significant Control Register",
+                "id": "/company/OC385143/persons-with-significant-control/individual/u6TgpwMtI6tHyaQGiALMpZbqesw"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9c46c67e4ebf340ab59b9",
+                "uri": "http://register.openownership.org/entities/59b9c46c67e4ebf340ab59b9"
+            }
+        ],
+        "nationalities": [
+            {
+                "name": "United Kingdom of Great Britain and Northern Ireland",
+                "code": "GB"
+            }
+        ],
+        "birthDate": "1960-11-01",
+        "addresses": [
+            {
+                "address": "50, George Street, London, W1U 7GA"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC397401_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_OC397401_bods.json
@@ -1,1 +1,90 @@
-[{"statementID": "openownership-register-10529995378911682754", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "DEVONSHIRES SOLICITORS LLP", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "OC397401"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/OC397401", "uri": "https://opencorporates.com/companies/gb/OC397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc397401"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Oc397401"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96fd167e4ebf34058324f", "uri": "http://register.openownership.org/entities/59b96fd167e4ebf34058324f"}], "foundingDate": "2015-01-07", "addresses": [{"type": "registered", "address": "30 Finsbury Circus, London, Greater London, EC2M 7DT", "country": "GB"}]}, {"statementID": "openownership-register-10217011032742468695", "statementType": "ownershipOrControlStatement", "statementDate": "2017-01-07", "subject": {"describedByEntityStatement": "openownership-register-10529995378911682754"}, "interestedParty": {"unspecified": {"reason": "no-beneficial-owners", "description": "No person"}}, "interests": [], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}]
+[
+    {
+        "statementID": "openownership-register-10529995378911682754",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "DEVONSHIRES SOLICITORS LLP",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "OC397401"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/OC397401",
+                "uri": "https://opencorporates.com/companies/gb/OC397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc397401"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Oc397401"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96fd167e4ebf34058324f",
+                "uri": "http://register.openownership.org/entities/59b96fd167e4ebf34058324f"
+            }
+        ],
+        "foundingDate": "2015-01-07",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "30 Finsbury Circus, London, Greater London, EC2M 7DT",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10217011032742468695",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2017-01-07",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-10529995378911682754"
+        },
+        "interestedParty": {
+            "unspecified": {
+                "reason": "no-beneficial-owners",
+                "description": "No person"
+            }
+        },
+        "interests": [],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC115530_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC115530_bods.json
@@ -1,1 +1,1269 @@
-[{"statementID": "openownership-register-2238142703985505137", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RSK ENVIRONMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC115530"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC115530", "uri": "https://opencorporates.com/companies/gb/SC115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc 115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc 115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc115530"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9236967e4ebf340f59c67", "uri": "http://register.openownership.org/entities/59b9236967e4ebf340f59c67"}], "foundingDate": "1989-01-11", "addresses": [{"type": "registered", "address": "65 Sussex Street, Glasgow, G41 1DX", "country": "GB"}]}, {"statementID": "openownership-register-6515993296950174906", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-01", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2299048395076470051"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-01", "endDate": "2018-11-02"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-01", "endDate": "2018-11-02"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-06-01", "endDate": "2018-11-02"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2016-06-01", "endDate": "2018-11-02"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-14991013107323706458", "statementType": "ownershipOrControlStatement", "statementDate": "2018-10-25", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-6328351276023210308"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-10-25"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-5854409131115882342", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-2299048395076470051"}, "interests": [{"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-3010109675599429805", "statementType": "ownershipOrControlStatement", "statementDate": "2018-11-02", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11045089261065343993"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2018-11-02", "endDate": "2018-11-03"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-13860668236294748644", "statementType": "ownershipOrControlStatement", "statementDate": "2019-01-04", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11594163747467247203"}, "interests": [{"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2019-01-04", "endDate": "2019-01-04"}, {"type": "influence-or-control", "details": "significant-influence-or-control-as-firm", "startDate": "2019-01-04", "endDate": "2019-01-04"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-25T09:59:00Z"}}, {"statementID": "openownership-register-10086484886008203045", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2238142703985505137"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4607927860998451369"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-11-02"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06", "endDate": "2018-11-02"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06", "endDate": "2018-11-02"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-6328351276023210308", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "ARES MANAGEMENT LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/05837428", "uri": "https://opencorporates.com/companies/gb/05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "5837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "05837428"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9845f67e4ebf340bd8b48", "uri": "http://register.openownership.org/entities/59b9845f67e4ebf340bd8b48"}], "foundingDate": "2006-06-05", "addresses": [{"type": "registered", "address": "C/O Tmf Group 8th Floor, 20 Farringdon Street, London, EC4A 4AB", "country": "GB"}]}, {"statementID": "openownership-register-2299048395076470051", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "RSK GROUP LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03761340"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03761340", "uri": "https://opencorporates.com/companies/gb/03761340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "3761340"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6", "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6"}], "foundingDate": "1999-04-28", "addresses": [{"type": "registered", "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR", "country": "GB"}]}, {"statementID": "openownership-register-11045089261065343993", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "POSITIVE CONNECTIONS INTERNATIONAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "03461340"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/03461340", "uri": "https://opencorporates.com/companies/gb/03461340"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "03461340"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9994967e4ebf34007fc68", "uri": "http://register.openownership.org/entities/59b9994967e4ebf34007fc68"}], "foundingDate": "1997-11-05", "dissolutionDate": "2005-03-22", "addresses": [{"type": "registered", "address": "54 LULWORTH GARDENS, SOUTH HARROW, MIDDLESEX, HA2 9NP", "country": "GB"}]}, {"statementID": "openownership-register-11594163747467247203", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "Ares Management Ltd", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "0178567"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/5c5bb51a9dfc3fae18e6863f", "uri": "http://register.openownership.org/entities/5c5bb51a9dfc3fae18e6863f"}], "addresses": [{"type": "registered", "address": "5th Floor, 6, St. Andrew Street, London, EC4A 3AE", "country": "GB"}]}, {"statementID": "openownership-register-4607927860998451369", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "U.S. BANK TRUSTEES LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/02379632", "uri": "https://opencorporates.com/companies/gb/02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "02379632"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9744c67e4ebf3406e95c0", "uri": "http://register.openownership.org/entities/59b9744c67e4ebf3406e95c0"}], "foundingDate": "1989-05-04", "addresses": [{"type": "registered", "address": "125 Old Broad Street, Fifth Floor, London, EC2N 1AR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2238142703985505137",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RSK ENVIRONMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC115530"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC115530",
+                "uri": "https://opencorporates.com/companies/gb/SC115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc 115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc 115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc115530"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9236967e4ebf340f59c67",
+                "uri": "http://register.openownership.org/entities/59b9236967e4ebf340f59c67"
+            }
+        ],
+        "foundingDate": "1989-01-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "65 Sussex Street, Glasgow, G41 1DX",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-6515993296950174906",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-01",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2299048395076470051"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01",
+                "endDate": "2018-11-02"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-01",
+                "endDate": "2018-11-02"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-06-01",
+                "endDate": "2018-11-02"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2016-06-01",
+                "endDate": "2018-11-02"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-14991013107323706458",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-10-25",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-6328351276023210308"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-10-25"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-5854409131115882342",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-2299048395076470051"
+        },
+        "interests": [
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-3010109675599429805",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2018-11-02",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11045089261065343993"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2018-11-02",
+                "endDate": "2018-11-03"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-13860668236294748644",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2019-01-04",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11594163747467247203"
+        },
+        "interests": [
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2019-01-04",
+                "endDate": "2019-01-04"
+            },
+            {
+                "type": "influence-or-control",
+                "details": "significant-influence-or-control-as-firm",
+                "startDate": "2019-01-04",
+                "endDate": "2019-01-04"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-25T09:59:00Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-10086484886008203045",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2238142703985505137"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4607927860998451369"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-11-02"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06",
+                "endDate": "2018-11-02"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06",
+                "endDate": "2018-11-02"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-6328351276023210308",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "ARES MANAGEMENT LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/05837428",
+                "uri": "https://opencorporates.com/companies/gb/05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "5837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "05837428"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9845f67e4ebf340bd8b48",
+                "uri": "http://register.openownership.org/entities/59b9845f67e4ebf340bd8b48"
+            }
+        ],
+        "foundingDate": "2006-06-05",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "C/O Tmf Group 8th Floor, 20 Farringdon Street, London, EC4A 4AB",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2299048395076470051",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "RSK GROUP LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03761340"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03761340",
+                "uri": "https://opencorporates.com/companies/gb/03761340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "3761340"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6",
+                "uri": "http://register.openownership.org/entities/59b95eed67e4ebf34005c6c6"
+            }
+        ],
+        "foundingDate": "1999-04-28",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Spring Lodge, 172 Chester Road, Helsby, Cheshire, WA6 0AR",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11045089261065343993",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "POSITIVE CONNECTIONS INTERNATIONAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03461340"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/03461340",
+                "uri": "https://opencorporates.com/companies/gb/03461340"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "03461340"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9994967e4ebf34007fc68",
+                "uri": "http://register.openownership.org/entities/59b9994967e4ebf34007fc68"
+            }
+        ],
+        "foundingDate": "1997-11-05",
+        "dissolutionDate": "2005-03-22",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "54 LULWORTH GARDENS, SOUTH HARROW, MIDDLESEX, HA2 9NP",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-11594163747467247203",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "Ares Management Ltd",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "0178567"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/5c5bb51a9dfc3fae18e6863f",
+                "uri": "http://register.openownership.org/entities/5c5bb51a9dfc3fae18e6863f"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "5th Floor, 6, St. Andrew Street, London, EC4A 3AE",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-4607927860998451369",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "U.S. BANK TRUSTEES LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/02379632",
+                "uri": "https://opencorporates.com/companies/gb/02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "02379632"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9744c67e4ebf3406e95c0",
+                "uri": "http://register.openownership.org/entities/59b9744c67e4ebf3406e95c0"
+            }
+        ],
+        "foundingDate": "1989-05-04",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "125 Old Broad Street, Fifth Floor, London, EC2N 1AR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC133446_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC133446_bods.json
@@ -1,1 +1,223 @@
-[{"statementID": "openownership-register-2306891488075229429", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SPIE SCOTSHIELD LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC133446"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC133446", "uri": "https://opencorporates.com/companies/gb/SC133446"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b9405b67e4ebf3407b43fb", "uri": "http://register.openownership.org/entities/59b9405b67e4ebf3407b43fb"}], "foundingDate": "1991-08-15", "addresses": [{"type": "registered", "address": "1 Rutherglen Links, Rutherglen, Glasgow, G73 1DF", "country": "GB"}]}, {"statementID": "openownership-register-10823646043074085788", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2306891488075229429"}, "interestedParty": {"describedByEntityStatement": "openownership-register-4172516027807446328"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "voting-rights", "details": "voting-rights-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}, {"type": "appointment-of-board", "details": "right-to-appoint-and-remove-directors", "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-4172516027807446328", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SPIE UK LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "07201157"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/07201157", "uri": "https://opencorporates.com/companies/gb/07201157"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"scheme": "GB-COH", "schemeName": "Companies House"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b938cd67e4ebf34058813d", "uri": "http://register.openownership.org/entities/59b938cd67e4ebf34058813d"}], "foundingDate": "2010-03-24", "addresses": [{"type": "registered", "address": "11th Floor Snow Hill, Birmingham, B4 6WR", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2306891488075229429",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SPIE SCOTSHIELD LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC133446"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC133446",
+                "uri": "https://opencorporates.com/companies/gb/SC133446"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b9405b67e4ebf3407b43fb",
+                "uri": "http://register.openownership.org/entities/59b9405b67e4ebf3407b43fb"
+            }
+        ],
+        "foundingDate": "1991-08-15",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "1 Rutherglen Links, Rutherglen, Glasgow, G73 1DF",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-10823646043074085788",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2306891488075229429"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-4172516027807446328"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "voting-rights",
+                "details": "voting-rights-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            },
+            {
+                "type": "appointment-of-board",
+                "details": "right-to-appoint-and-remove-directors",
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-4172516027807446328",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SPIE UK LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "07201157"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/07201157",
+                "uri": "https://opencorporates.com/companies/gb/07201157"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b938cd67e4ebf34058813d",
+                "uri": "http://register.openownership.org/entities/59b938cd67e4ebf34058813d"
+            }
+        ],
+        "foundingDate": "2010-03-24",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "11th Floor Snow Hill, Birmingham, B4 6WR",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC148684_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC148684_bods.json
@@ -1,1 +1,139 @@
-[{"statementID": "openownership-register-9901028970296525899", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SAC COMMERCIAL LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC148684"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC148684"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC148684"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC148684", "uri": "https://opencorporates.com/companies/gb/SC148684"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc148684"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc148684"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc148684"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b96d2467e4ebf3404b3ec9", "uri": "http://register.openownership.org/entities/59b96d2467e4ebf3404b3ec9"}], "foundingDate": "1994-01-27", "addresses": [{"type": "registered", "address": "Peter Wilson Building, King's Buildings, West Mains Road, Edinburgh, EH9 3JG", "country": "GB"}]}, {"statementID": "openownership-register-12645811604416291382", "statementType": "ownershipOrControlStatement", "statementDate": "2016-06-30", "subject": {"describedByEntityStatement": "openownership-register-9901028970296525899"}, "interestedParty": {"describedByEntityStatement": "openownership-register-11322447614075732303"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent-as-trust", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-06-30"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-11322447614075732303", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "SAC CORPORATE TRUSTEE LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC151249"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC151249"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC151249", "uri": "https://opencorporates.com/companies/gb/SC151249"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "Sc151249"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b985d967e4ebf340c41af6", "uri": "http://register.openownership.org/entities/59b985d967e4ebf340c41af6"}], "foundingDate": "1994-06-06", "addresses": [{"type": "registered", "address": "West Mains Road, Edinburgh, Midlothian, EH9 3JG", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-9901028970296525899",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SAC COMMERCIAL LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC148684"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC148684"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC148684"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC148684",
+                "uri": "https://opencorporates.com/companies/gb/SC148684"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc148684"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc148684"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc148684"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b96d2467e4ebf3404b3ec9",
+                "uri": "http://register.openownership.org/entities/59b96d2467e4ebf3404b3ec9"
+            }
+        ],
+        "foundingDate": "1994-01-27",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Peter Wilson Building, King's Buildings, West Mains Road, Edinburgh, EH9 3JG",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-12645811604416291382",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-06-30",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-9901028970296525899"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-11322447614075732303"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent-as-trust",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-06-30"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-11322447614075732303",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "SAC CORPORATE TRUSTEE LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC151249"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC151249"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC151249",
+                "uri": "https://opencorporates.com/companies/gb/SC151249"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "Sc151249"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b985d967e4ebf340c41af6",
+                "uri": "http://register.openownership.org/entities/59b985d967e4ebf340c41af6"
+            }
+        ],
+        "foundingDate": "1994-06-06",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "West Mains Road, Edinburgh, Midlothian, EH9 3JG",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC220049_bods.json
+++ b/data/contracts_finder/bods/ch_id_openownership_bods/GB-COH_SC220049_bods.json
@@ -1,1 +1,150 @@
-[{"statementID": "openownership-register-2545645952973756099", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "FES FM LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "SC220049"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/SC220049", "uri": "https://opencorporates.com/companies/gb/SC220049"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c54e", "uri": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c54e"}], "foundingDate": "2001-06-11", "addresses": [{"type": "registered", "address": "Forth House, Pirnhall Business Park, Stirling, FK7 8HW", "country": "GB"}]}, {"statementID": "openownership-register-2410630959760770390", "statementType": "ownershipOrControlStatement", "statementDate": "2016-04-06", "subject": {"describedByEntityStatement": "openownership-register-2545645952973756099"}, "interestedParty": {"describedByEntityStatement": "openownership-register-1510641779704190376"}, "interests": [{"type": "shareholding", "details": "ownership-of-shares-75-to-100-percent", "share": {"minimum": 75, "maximum": 100, "exclusiveMinimum": false, "exclusiveMaximum": false}, "startDate": "2016-04-06"}], "source": {"type": ["officialRegister"], "description": "GB Persons Of Significant Control Register", "url": "http://download.companieshouse.gov.uk/en_pscdata.html", "retrievedAt": "2019-07-08T10:37:11Z"}}, {"statementID": "openownership-register-1510641779704190376", "statementType": "entityStatement", "entityType": "registeredEntity", "name": "LAMB CONSTRUCTION LIMITED", "incorporatedInJurisdiction": {"name": "United Kingdom of Great Britain and Northern Ireland", "code": "GB"}, "identifiers": [{"scheme": "GB-COH", "schemeName": "Companies House", "id": "00401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "00401258"}, {"schemeName": "OpenCorporates", "id": "https://opencorporates.com/companies/gb/00401258", "uri": "https://opencorporates.com/companies/gb/00401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "401258"}, {"scheme": "GB-COH", "schemeName": "Companies House", "id": "401258"}, {"schemeName": "OpenOwnership Register", "id": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c6e2", "uri": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c6e2"}], "foundingDate": "1945-11-29", "dissolutionDate": "2006-09-26", "addresses": [{"type": "registered", "address": "ASTON SCIENCE PARK, LOVE LANE, BIRMINGHAM, B7 4BJ", "country": "GB"}]}]
+[
+    {
+        "statementID": "openownership-register-2545645952973756099",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "FES FM LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "SC220049"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/SC220049",
+                "uri": "https://opencorporates.com/companies/gb/SC220049"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c54e",
+                "uri": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c54e"
+            }
+        ],
+        "foundingDate": "2001-06-11",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "Forth House, Pirnhall Business Park, Stirling, FK7 8HW",
+                "country": "GB"
+            }
+        ]
+    },
+    {
+        "statementID": "openownership-register-2410630959760770390",
+        "statementType": "ownershipOrControlStatement",
+        "statementDate": "2016-04-06",
+        "subject": {
+            "describedByEntityStatement": "openownership-register-2545645952973756099"
+        },
+        "interestedParty": {
+            "describedByEntityStatement": "openownership-register-1510641779704190376"
+        },
+        "interests": [
+            {
+                "type": "shareholding",
+                "details": "ownership-of-shares-75-to-100-percent",
+                "share": {
+                    "minimum": 75,
+                    "maximum": 100,
+                    "exclusiveMinimum": false,
+                    "exclusiveMaximum": false
+                },
+                "startDate": "2016-04-06"
+            }
+        ],
+        "source": {
+            "type": [
+                "officialRegister"
+            ],
+            "description": "GB Persons Of Significant Control Register",
+            "url": "http://download.companieshouse.gov.uk/en_pscdata.html",
+            "retrievedAt": "2019-07-08T10:37:11Z"
+        }
+    },
+    {
+        "statementID": "openownership-register-1510641779704190376",
+        "statementType": "entityStatement",
+        "entityType": "registeredEntity",
+        "name": "LAMB CONSTRUCTION LIMITED",
+        "incorporatedInJurisdiction": {
+            "name": "United Kingdom of Great Britain and Northern Ireland",
+            "code": "GB"
+        },
+        "identifiers": [
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "00401258"
+            },
+            {
+                "schemeName": "OpenCorporates",
+                "id": "https://opencorporates.com/companies/gb/00401258",
+                "uri": "https://opencorporates.com/companies/gb/00401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "401258"
+            },
+            {
+                "scheme": "GB-COH",
+                "schemeName": "Companies House",
+                "id": "401258"
+            },
+            {
+                "schemeName": "OpenOwnership Register",
+                "id": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c6e2",
+                "uri": "http://register.openownership.org/entities/59b91a5367e4ebf340d5c6e2"
+            }
+        ],
+        "foundingDate": "1945-11-29",
+        "dissolutionDate": "2006-09-26",
+        "addresses": [
+            {
+                "type": "registered",
+                "address": "ASTON SCIENCE PARK, LOVE LANE, BIRMINGHAM, B7 4BJ",
+                "country": "GB"
+            }
+        ]
+    }
+]

--- a/data/contracts_finder/processing/scripts/get_fix_cf_notices.py
+++ b/data/contracts_finder/processing/scripts/get_fix_cf_notices.py
@@ -20,7 +20,7 @@ from elasticsearch_dsl import Search
 from ocdskit.upgrade import upgrade_10_11
 
 
-ELASTICSEARCH_7_TEST = os.getenv("ELASTICSEARCH_7_TEST")
+ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL")
 DATABASE_URL = os.environ.get('DATABASE_URL')
 OPENOPPS_DB_URL = os.environ.get('OPENOPPS_DB_URL')
 OCDS_OUTPUT_DIR = os.path.join(settings.BASE_DIR, "data", "contracts_finder", "processing")
@@ -29,7 +29,7 @@ OCDS_OUTPUT_DIR = os.path.join(settings.BASE_DIR, "data", "contracts_finder", "p
 def get_company_statements(
         company_id,
         scheme='GB-COH',
-        elastic_conn=Elasticsearch(ELASTICSEARCH_7_TEST, verify_certs=True),
+        elastic_conn=Elasticsearch(ELASTICSEARCH_URL, verify_certs=True),
 ):
     s = Search(using=elastic_conn, index="bods") \
         .filter("term", identifiers__scheme__keyword=scheme) \

--- a/data/contracts_finder/processing/sql/bods_views.sql
+++ b/data/contracts_finder/processing/sql/bods_views.sql
@@ -1,0 +1,54 @@
+-- SQL used to aid in debugging and fixing the duplicate and malformed Companies House IDs
+SELECT
+    b.statement_id,
+    b.statement_json -> 'identifiers'                          AS identifiers_json,
+                jsonb_agg(identifiers.value) identifiers_json
+FROM
+    bluetail_bods_statement_json b
+        LEFT JOIN LATERAL (
+            select distinct on (identifier)
+                identifier.value
+            from jsonb_array_elements(b.statement_json -> 'identifiers') identifier(value)
+            where
+                NOT (identifier ->> 'scheme' notnull AND identifier ->> 'scheme' = 'GB-COH' AND length(identifier ->> 'id') < 8)
+        ) identifiers ON TRUE
+WHERE TRUE
+--            AND b.statement_json ->> 'statementType' = 'entityStatement'
+  AND statement_id = 'openownership-register-5867724539491802071'
+--   AND statement_id = 'openownership-register-6008205498718995750'
+--     and ch_id notnull
+group by statement_id
+;
+
+
+-- Show BODS statements that have Companies House number less than 8 digits only and NOT one EQUAL to 8 digits
+SELECT
+    b.statement_id
+  , *
+FROM
+    bluetail_bods_entitystatement_view b
+    LEFT JOIN LATERAL jsonb_array_elements(b.statement_json -> 'identifiers') ch_id(value) ON (ch_id.value ->> 'scheme' = 'GB-COH')
+WHERE
+    b.statement_id in (
+        SELECT
+            b.statement_id
+        FROM
+            bluetail_bods_entitystatement_view b
+                LEFT JOIN LATERAL jsonb_array_elements(b.statement_json -> 'identifiers') ch_id(value) ON (ch_id.value ->> 'scheme' = 'GB-COH')
+        WHERE
+              TRUE
+          AND length(ch_id ->> 'id') < 8
+    )
+    AND NOT b.statement_id in (
+        SELECT
+            b.statement_id
+        FROM
+            bluetail_bods_entitystatement_view b
+                LEFT JOIN LATERAL jsonb_array_elements(b.statement_json -> 'identifiers') ch_id(value) ON (ch_id.value ->> 'scheme' = 'GB-COH')
+        WHERE
+              TRUE
+          AND length(ch_id ->> 'id') = 8
+    )
+--           AND b.statement_json ->> 'statementType' = 'entityStatement'
+--           AND statement_id = 'openownership-register-5867724539491802071'
+;


### PR DESCRIPTION
This PR adds 2 Django management commands for acquiring BODS data

- create_openownership_elasticsearch_index.py
    This is a script to build an Elasticsearch index for querying the Open Ownership register
- get_bods_statements_from_ocds.py
    This script will lookup any Companies House IDs present in the OCDS data to gather any related BODS data from the elasticsearch index created above and store in the Bluetail database.
