### PR TITLE
Fix flag lookups with ocid

### DIFF
--- a/bluetail/helpers.py
+++ b/bluetail/helpers.py
@@ -66,24 +66,23 @@ class FlagHelperFunctions():
             )
         return flags
 
-
-    def get_flags_for_bods_entity_or_person(self, object):
+    def get_flags_for_bods_entity_or_person(self, object, ocid=None):
         flags = []
         for identifier in object.identifiers_json:
-            id_flags = self.get_flags_for_bods_identifier(identifier)
+            id_flags = self.get_flags_for_bods_identifier(identifier, ocid=ocid)
             flags.extend(id_flags)
-        return flags
+        return list(set(flags))
 
     def get_flags_for_ocds_party(self, object):
         flags = []
 
         primary_identifier = object.party_json.get("identifier")
-        flags.extend(self.get_flags_for_ocds_party_identifier(primary_identifier))
+        flags.extend(self.get_flags_for_ocds_party_identifier(primary_identifier, ocid=object.ocid))
 
         for identifier in object.party_json.get("additionalIdentifiers", []):
-            id_flags = self.get_flags_for_ocds_party_identifier(identifier)
+            id_flags = self.get_flags_for_ocds_party_identifier(identifier, ocid=object.ocid)
             flags.extend(id_flags)
-        return flags
+        return list(set(flags))
 
     def build_flags_context(self, flags):
         company_id_flags = [flag for flag in flags if flag.flag_field == "company_id"]
@@ -168,7 +167,7 @@ class ContextHelperFunctions():
 
         interested_parties = bods_helper.get_related_bods_data_for_tenderer(tenderer)
         for person in interested_parties["interested_persons"]:
-            person_flags = flags_helper.get_flags_for_bods_entity_or_person(person)
+            person_flags = flags_helper.get_flags_for_bods_entity_or_person(person, ocid=tenderer.ocid)
             if person_flags:
                 for flag in person_flags:
                     if flag.flag_type == "warning":
@@ -176,7 +175,7 @@ class ContextHelperFunctions():
                     elif flag.flag_type == "error":
                         errors.append(flag)
         for entity in interested_parties["interested_entities"]:
-            entity_flags = flags_helper.get_flags_for_bods_entity_or_person(entity)
+            entity_flags = flags_helper.get_flags_for_bods_entity_or_person(entity, ocid=tenderer.ocid)
             if entity_flags:
                 for flag in entity_flags:
                     if flag.flag_type == "warning":

--- a/bluetail/templatetags/flag_templatetags.py
+++ b/bluetail/templatetags/flag_templatetags.py
@@ -8,8 +8,8 @@ helper = FlagHelperFunctions()
 
 
 @register.simple_tag()
-def get_flags_for_bods_entity_or_person(object):
-    flags = helper.get_flags_for_bods_entity_or_person(object)
+def get_flags_for_bods_entity_or_person(object, ocid=None):
+    flags = helper.get_flags_for_bods_entity_or_person(object, ocid=ocid)
     flags_context = helper.build_flags_context(flags)
     return flags_context
 

--- a/bluetail/tests/test_helpers.py
+++ b/bluetail/tests/test_helpers.py
@@ -5,16 +5,24 @@ from django.conf import settings
 from django.test import TestCase
 
 from bluetail import models
-from bluetail.helpers import FlagHelperFunctions
+from bluetail.helpers import FlagHelperFunctions, UpsertDataHelpers
+from bluetail.models import BODSPersonStatement
 from bluetail.tests.fixtures import insert_flags, insert_flag_attachments
 
 
+PROTOTYPE_DATA_PATH = os.path.join(settings.BASE_DIR, "data", "prototype")
+TEST_DATA_PATH = os.path.join(settings.BASE_DIR, "bluetail", "tests", "data")
+
+
 class TestFlagHelperFunctions(TestCase):
-    helper = FlagHelperFunctions()
+    flag_helper = FlagHelperFunctions()
+    upsert_helper = UpsertDataHelpers()
 
     def setUp(self):
         insert_flags()
         insert_flag_attachments()
+        bods_test_file_path = os.path.join(PROTOTYPE_DATA_PATH, "bods", "PROC-20-0001", "d_ownership.json")
+        self.upsert_helper.upsert_bods_data(bods_test_file_path)
 
     def test_get_flags_for_ocds_party_identifier(self):
         identifier = {
@@ -22,12 +30,12 @@ class TestFlagHelperFunctions(TestCase):
             "id": "1602647563",
             "legalName": "Synomus Technology Services Ltd."
         }
-        flags = self.helper.get_flags_for_ocds_party_identifier(identifier)
+        flags = self.flag_helper.get_flags_for_ocds_party_identifier(identifier)
         assert any(flag.flag_name == "company_id_invalid" for flag in flags)
 
     def test_get_flags_for_ocid(self):
         ocid = "ocds-123abc-PROC-20-0001"
-        flags = self.helper.get_flags_for_ocid(ocid)
+        flags = self.flag_helper.get_flags_for_ocid(ocid)
         assert any(flag.flag_name == "person_in_multiple_applications_to_tender" for flag in flags)
         assert any(flag.flag_name == "company_in_multiple_applications_to_tender" for flag in flags)
 
@@ -36,7 +44,7 @@ class TestFlagHelperFunctions(TestCase):
             "id": "HMCI17014140912423",
             "schemeName": "National ID"
         }
-        flags = self.helper.get_flags_for_bods_identifier(identifier)
+        flags = self.flag_helper.get_flags_for_bods_identifier(identifier)
         assert any(flag.flag_name == "person_id_matches_cabinet_minister" for flag in flags)
 
     def test_get_flags_for_bods_identifier_with_ocid(self):
@@ -47,11 +55,29 @@ class TestFlagHelperFunctions(TestCase):
         ocid = "ocds-123abc-PROC-20-0001"
 
         # Test we get back all flags for identifier with and without OCID
-        flags = self.helper.get_flags_for_bods_identifier(identifier, ocid)
+        flags = self.flag_helper.get_flags_for_bods_identifier(identifier, ocid)
         assert any(flag.flag_name == "person_in_multiple_applications_to_tender" for flag in flags)
         assert any(flag.flag_name == "person_id_matches_cabinet_minister" for flag in flags)
 
         # Test we do NOT get flags for identifier where the flag is only for a particular OCID
-        flags = self.helper.get_flags_for_bods_identifier(identifier)
+        flags = self.flag_helper.get_flags_for_bods_identifier(identifier)
+        assert not any(flag.flag_name == "person_in_multiple_applications_to_tender" for flag in flags)
+        assert any(flag.flag_name == "person_id_matches_cabinet_minister" for flag in flags)
+
+    def test_get_flags_for_bods_entity_or_person(self):
+        identifier = {
+            "id": "HMCI17014140912423",
+            "schemeName": "National ID"
+        }
+        ocid = "ocds-123abc-PROC-20-0001"
+        person = BODSPersonStatement.objects.get(statement_id="019a93f1-e470-42e9-957b-03554681b2e3")
+
+        # Test we get back all flags for identifier with and without OCID
+        flags = self.flag_helper.get_flags_for_bods_entity_or_person(person, ocid)
+        assert any(flag.flag_name == "person_in_multiple_applications_to_tender" for flag in flags)
+        assert any(flag.flag_name == "person_id_matches_cabinet_minister" for flag in flags)
+
+        # Test we do NOT get flags for identifier where the flag is only for a particular OCID
+        flags = self.flag_helper.get_flags_for_bods_identifier(identifier)
         assert not any(flag.flag_name == "person_in_multiple_applications_to_tender" for flag in flags)
         assert any(flag.flag_name == "person_id_matches_cabinet_minister" for flag in flags)

--- a/templates/partials/bods-entity.html
+++ b/templates/partials/bods-entity.html
@@ -1,5 +1,5 @@
 {% load flag_templatetags %}
-{% get_flags_for_bods_entity_or_person company as flags %}
+{% get_flags_for_bods_entity_or_person company tenderer.ocid as flags %}
 
 <div class="card bods-scorecard">
     <h5 class="card-header d-flex align-items-center">

--- a/templates/partials/bods-person.html
+++ b/templates/partials/bods-person.html
@@ -1,5 +1,5 @@
 {% load flag_templatetags %}
-{% get_flags_for_bods_entity_or_person person as flags %}
+{% get_flags_for_bods_entity_or_person person tenderer.ocid as flags %}
 
 <div class="card bods-scorecard">
     <h5 class="card-header d-flex align-items-center">


### PR DESCRIPTION
This PR updates the flag lookups in views and templates 
- Include the OCID so the lookup works with the output from the scan contracts command
- Only return unique flags to allow for multiple identifiers in Flag attachments to the same person/entity