### PR TITLE
Adjusted Barnet to Toupee in example data

### DIFF
--- a/bluetail/data/prototype/ocds/ocds_tenderers_package.json
+++ b/bluetail/data/prototype/ocds/ocds_tenderers_package.json
@@ -14,30 +14,15 @@
         {
           "identifier": {
             "scheme": "GB-LAC",
-            "id": "E09000003",
-            "legalName": "London Borough of Toupee",
-            "uri": "http://www.barnet.gov.uk/"
+            "id": "E12345678",
+            "legalName": "London Borough of Toupee"
           },
           "name": "London Borough of Toupee",
-          "address": {
-            "streetAddress": "4, North London Business Park, Oakleigh Rd S",
-            "locality": "London",
-            "region": "London",
-            "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
-          },
-          "contactPoint": {
-            "name": "Procurement Team",
-            "email": "procurement-team@example.com",
-            "telephone": "01234 345 346",
-            "faxNumber": "01234 345 345",
-            "url": "http://example.com/contact/"
-          },
           "roles": [
             "procuringEntity",
             "buyer"
           ],
-          "id": "GB-LAC-E09000003"
+          "id": "GB-LAC-E12345678"
         },
         {
           "identifier": {
@@ -148,7 +133,7 @@
         }
       ],
       "buyer": {
-        "id": "GB-LAC-E09000003",
+        "id": "GB-LAC-E12345678",
         "name": "London Borough of Toupee"
       },
       "tender": {
@@ -178,7 +163,7 @@
           "endDate": "2021-06-01T23:59:59Z"
         },
         "procuringEntity": {
-          "id": "GB-LAC-E09000003",
+          "id": "GB-LAC-E12345678",
           "name": "London Borough of Toupee"
         },
         "numberOfTenderers": 5,

--- a/bluetail/data/prototype/ocds/ocds_tenderers_package.json
+++ b/bluetail/data/prototype/ocds/ocds_tenderers_package.json
@@ -15,10 +15,10 @@
           "identifier": {
             "scheme": "GB-LAC",
             "id": "E09000003",
-            "legalName": "London Borough of Barnet",
+            "legalName": "London Borough of Toupee",
             "uri": "http://www.barnet.gov.uk/"
           },
-          "name": "London Borough of Barnet",
+          "name": "London Borough of Toupee",
           "address": {
             "streetAddress": "4, North London Business Park, Oakleigh Rd S",
             "locality": "London",
@@ -149,7 +149,7 @@
       ],
       "buyer": {
         "id": "GB-LAC-E09000003",
-        "name": "London Borough of Barnet"
+        "name": "London Borough of Toupee"
       },
       "tender": {
         "id": "PROC-20-0001",
@@ -179,7 +179,7 @@
         },
         "procuringEntity": {
           "id": "GB-LAC-E09000003",
-          "name": "London Borough of Barnet"
+          "name": "London Borough of Toupee"
         },
         "numberOfTenderers": 5,
         "tenderers": [


### PR DESCRIPTION
For consistency with anonymised real data, replaced Barnet with Toupee in the example data. 

Tested locally, works ok. 