### PR TITLE
Readme updates and default db uri for simple local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,14 @@ You’ll need:
 
 As above, make sure you’ve cloned the repo.
 
-Open up a Postgres shell (eg: `psql`) and create a user and database matching the details in `conf/config.py`:
+The `SECRET_KEY` environment variable must be set locally before running the application.
+
+    SECRET_KEY="any-random-alphanumeric-string"
+
+Open up a Postgres shell (eg: `psql`) and create a user and database:
+
+> If you decide to use a different username and password here you must also set the `DATABASE_URL` environment variable to the relevant [Postgres connection URI](https://tableplus.com/blog/2018/08/connection-uri-syntax-in-postgresql.html) as demonstrated in the [Heroku deployment section](deployment-to-heroku) below
+
 
 ```
 CREATE USER bluetail SUPERUSER CREATEDB PASSWORD 'bluetail'
@@ -96,7 +103,6 @@ If you want to load example data, run:
 ```
 script/setup
 ```
-
 
 And run the development server:
 

--- a/script/setup
+++ b/script/setup
@@ -8,6 +8,7 @@ cd `dirname $0`/..
 find . -name '*.pyc' -delete
 
 # Recreate database contents.
+DATABASE_URL=${DATABASE_URL:-"postgres://bluetail:bluetail@localhost:5432/bluetail"}
 psql -d $DATABASE_URL -c "DROP SCHEMA IF EXISTS public CASCADE"
 psql -d $DATABASE_URL -c "CREATE SCHEMA public"
 


### PR DESCRIPTION
* Allow for DATABASE_URL environment variable to be not present by providing default
  * As per:
  * https://github.com/mysociety/bluetail/blob/ec93534af1e8eebceab50a5c1a83670061420024/conf/config_defaults.py#L18
  * provide a default value for DATABASE_URL when not specified in line with setup instructions.

* Update README.md local setup instructions
  * Include setting required SECRET_KEY environment varieable
  * Include note telling users to update DATABASE_URL if they change the default username and password.