### PR TITLE
Use contract start date, not tender start date in templates

### DIFF
--- a/bluetail/models/ocds_models.py
+++ b/bluetail/models/ocds_models.py
@@ -41,7 +41,7 @@ class OCDSPackageData(pgviews.View):
             package.package_data ->> 'license' as license,
             package.package_data ->> 'version' as version,
             package.package_data ->> 'publishedDate' as publishedDate,
-            package.package_data ->> 'publicationPolicy' as publicationPolicy,            
+            package.package_data ->> 'publicationPolicy' as publicationPolicy,
             package.package_data -> 'packages' as packages,
             package.package_data -> 'publisher' as publisher,
             package.package_data -> 'publisher' ->> 'uid' as publisher_uid,
@@ -115,6 +115,8 @@ class OCDSTender(pgviews.View):
     release_date = models.DateTimeField()
     tender_startdate = models.DateTimeField()
     tender_enddate = models.DateTimeField()
+    contract_startdate = models.DateTimeField()
+    contract_enddate = models.DateTimeField()
     buyer = models.TextField()
     buyer_id = models.TextField()
 
@@ -133,6 +135,8 @@ class OCDSTender(pgviews.View):
             cast(NULLIF(ocds.release_json ->> 'date', '') AS TIMESTAMPTZ) AS release_date,
             cast(NULLIF(ocds.release_json -> 'tender' -> 'tenderPeriod' ->> 'startDate', '') AS TIMESTAMPTZ) AS tender_startdate,
             cast(NULLIF(ocds.release_json -> 'tender' -> 'tenderPeriod' ->> 'endDate', '') AS TIMESTAMPTZ) AS tender_enddate,
+            cast(NULLIF(ocds.release_json -> 'tender' -> 'contractPeriod' ->> 'startDate', '') AS TIMESTAMPTZ) AS contract_startdate,
+            cast(NULLIF(ocds.release_json -> 'tender' -> 'contractPeriod' ->> 'endDate', '') AS TIMESTAMPTZ) AS contract_enddate,
             ocds.release_json -> 'buyer' ->> 'name' AS buyer,
             ocds.release_json -> 'buyer' ->> 'id' AS buyer_id
         FROM bluetail_ocds_release_json_view ocds

--- a/bluetail/templates/bluetail/ocds-tender.html
+++ b/bluetail/templates/bluetail/ocds-tender.html
@@ -22,7 +22,7 @@
         <dt class="col-sm-5">Closing date</dt>
         <dd class="col-sm-7">{{ object.tender_enddate }}</dd>
         <dt class="col-sm-5">Contract start date</dt>
-        <dd class="col-sm-7">{{ object.tender_startdate }}</dd>
+        <dd class="col-sm-7">{{ object.contract_startdate }}</dd>
         <dt class="col-sm-5">Value of contract</dt>
         <dd class="col-sm-7">{{ object.value }} {{ object.currency }} </dd>
     </dl>
@@ -59,4 +59,3 @@
 {#    </p>#}
 
 {% endblock %}
-


### PR DESCRIPTION
It's already labelled as such in the UI, but we weren't pulling the
right field  from the OCDS json to be able to show a contract start date,
instead showing the tender's start date, which can be confusing.
This adds a new field to the model to get the right data from the OCDS
JSON and then shows that instead. I've also added the corresponding
end date field for completeness.

Note that this changes the Postgres view, so we need to run
`python manage.py sync_pgviews --force` to regenerate them, but this is
contained within script/migrate, so I presume would be run on normal
deployment anyway.